### PR TITLE
[STORY-103] 기본 발신 계정 지정 구현

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,165 @@
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return <SelectPrimitive.Group data-slot="select-group" className={cn("scroll-my-1 p-1", className)} {...props} />
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value data-slot="select-value" className={cn("flex flex-1 text-left", className)} {...props} />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon render={<ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />} />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<SelectPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger">) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn(
+            "relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({ className, ...props }: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({ className, children, ...props }: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={<span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />}
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({ className, ...props }: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -39,7 +39,16 @@ function SettingsAccountPage() {
     )
   }, [mailAccounts, toggledIds])
 
-  const selectedDefaultAccount = defaultAccount ?? user?.defaultMailAccountId ?? accounts[0]?.id ?? null
+  const defaultAccountItems = useMemo(
+    () =>
+      accounts.map((mailAccount) => ({
+        value: mailAccount.id,
+        label: mailAccount.emailAddress,
+      })),
+    [accounts]
+  )
+
+  const selectedDefaultAccount = defaultAccount ?? user?.defaultMailAccountId ?? null
 
   const handleSaveDefaultAccount = () => {
     if (!selectedDefaultAccount) return
@@ -97,24 +106,24 @@ function SettingsAccountPage() {
 
         {/* Default 계정 */}
         <section className="space-y-3">
-          <h2 className="text-lg font-semibold">Default 계정</h2>
+          <h2 className="text-lg font-semibold">기본 메일 계정</h2>
           <p className="text-sm text-muted-foreground">계정 중 하나를 기본 발신 계정으로 선택할 수 있습니다.</p>
           <div className="flex items-center gap-3">
             <Select
-              value={selectedDefaultAccount ?? ""}
-              onValueChange={(id) => setDefaultAccount(id)}
+              value={selectedDefaultAccount}
+              onValueChange={setDefaultAccount}
+              items={defaultAccountItems}
+              disabled={isAccountsPending || accounts.length === 0}
             >
-              <SelectTrigger className="w-72">
-                <SelectValue>
-                  {(value: string) =>
-                    accounts.find((mailAccount) => mailAccount.id === value)?.emailAddress ?? ""
-                  }
-                </SelectValue>
+              <SelectTrigger className="w-72" aria-label="기본 발신 계정 선택">
+                <SelectValue
+                  placeholder={isAccountsPending ? "계정 목록을 불러오는 중..." : "기본 메일 계정을 선택하세요"}
+                />
               </SelectTrigger>
               <SelectContent align="start" alignItemWithTrigger={false}>
-                {accounts.map((mailAccount) => (
-                  <SelectItem key={mailAccount.id} value={mailAccount.id} className="px-3 py-2">
-                    {mailAccount.emailAddress}
+                {defaultAccountItems.map((item) => (
+                  <SelectItem key={item.value} value={item.value} className="px-3 py-2">
+                    {item.label}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -1,10 +1,8 @@
 import { useMemo, useState } from "react"
 import { createFileRoute, Link } from "@tanstack/react-router"
-import { Home, Trash2, LogOut, Plus } from "lucide-react"
+import { Home, Trash2, Plus } from "lucide-react"
 
 import { AddAccountDialog } from "@/components/add-account-dialog"
-import { Button, buttonVariants } from "@/components/ui/button"
-import { AccountIcon } from "@/lib/icon-entries"
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -13,12 +11,14 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb"
+import { Button } from "@/components/ui/button"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import { cn } from "@/lib/utils"
+import { AccountIcon } from "@/lib/icon-entries"
 import { useMailAccounts } from "@/queries/mail-accounts"
 import { useUser } from "@/queries/user"
-import { useLogout } from "@/mutations/auth"
+import { useUpdateDefaultAccount } from "@/mutations/user"
 
 export const Route = createFileRoute("/_authenticated/settings/account")({
   component: SettingsAccountPage,
@@ -26,15 +26,25 @@ export const Route = createFileRoute("/_authenticated/settings/account")({
 
 function SettingsAccountPage() {
   const { data: user, isPending: isUserPending } = useUser()
-  const { data: fetchedAccounts, isPending: isAccountsPending, isError: isAccountsError } = useMailAccounts()
+  const { data: mailAccounts, isPending: isAccountsPending, isError: isAccountsError } = useMailAccounts()
   const [toggledIds, setToggledIds] = useState<Set<string>>(new Set())
-  const logout = useLogout()
+  const [defaultAccount, setDefaultAccount] = useState<string | null>(null)
+  const updateDefaultAccountMutation = useUpdateDefaultAccount()
 
   // 추후 API 구현 후, 연동 예정
   const accounts = useMemo(() => {
-    if (!fetchedAccounts) return []
-    return fetchedAccounts.map((acc) => (toggledIds.has(acc.id) ? { ...acc, isActive: !acc.isActive } : acc))
-  }, [fetchedAccounts, toggledIds])
+    if (!mailAccounts) return []
+    return mailAccounts.map((mailAccount) =>
+      toggledIds.has(mailAccount.id) ? { ...mailAccount, isActive: !mailAccount.isActive } : mailAccount
+    )
+  }, [mailAccounts, toggledIds])
+
+  const selectedDefaultAccount = defaultAccount ?? user?.defaultMailAccountId ?? accounts[0]?.id ?? null
+
+  const handleSaveDefaultAccount = () => {
+    if (!selectedDefaultAccount) return
+    updateDefaultAccountMutation.mutate({ mailAccountId: selectedDefaultAccount })
+  }
 
   const handleToggleActive = (id: string) => {
     setToggledIds((prev) => {
@@ -79,9 +89,48 @@ function SettingsAccountPage() {
               <p className="text-sm text-muted-foreground">플랜: {user?.plan ?? "-"}</p>
             </div>
             {/* TODO: 회원 탈퇴 API 연동 */}
-            <Link to="/" className={cn(buttonVariants({ variant: "outline", size: "default" }), "ml-2 px-8")}>
+            <Button variant="outline" className="ml-2 px-8" disabled>
               회원 탈퇴
-            </Link>
+            </Button>
+          </div>
+        </section>
+
+        {/* Default 계정 */}
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold">Default 계정</h2>
+          <p className="text-sm text-muted-foreground">계정 중 하나를 기본 발신 계정으로 선택할 수 있습니다.</p>
+          <div className="flex items-center gap-3">
+            <Select
+              value={selectedDefaultAccount ?? ""}
+              onValueChange={(id) => setDefaultAccount(id)}
+            >
+              <SelectTrigger className="w-72">
+                <SelectValue>
+                  {(value: string) =>
+                    accounts.find((mailAccount) => mailAccount.id === value)?.emailAddress ?? ""
+                  }
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent align="start" alignItemWithTrigger={false}>
+                {accounts.map((mailAccount) => (
+                  <SelectItem key={mailAccount.id} value={mailAccount.id} className="px-3 py-2">
+                    {mailAccount.emailAddress}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              variant="outline"
+              className="px-4"
+              onClick={handleSaveDefaultAccount}
+              disabled={
+                !selectedDefaultAccount ||
+                selectedDefaultAccount === user?.defaultMailAccountId ||
+                updateDefaultAccountMutation.isPending
+              }
+            >
+              {updateDefaultAccountMutation.isPending ? "저장 중..." : "저장"}
+            </Button>
           </div>
         </section>
 
@@ -106,7 +155,7 @@ function SettingsAccountPage() {
                     </TableCell>
                   </TableRow>
                 )}
-                {isAccountsError && !isAccountsPending && (
+                {isAccountsError && (
                   <TableRow>
                     <TableCell colSpan={4} className="text-center text-sm text-destructive">
                       계정 목록을 불러오지 못했습니다.
@@ -177,13 +226,6 @@ function SettingsAccountPage() {
             </AddAccountDialog>
           </div>
         </section>
-
-        <div className="flex justify-end pt-8">
-          <Button className="ml-2" onClick={logout}>
-            로그아웃
-            <LogOut className="size-4" />
-          </Button>
-        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#3

### 📌 Task

- Closes #6 

## 💡 작업 내용

- `@/components/ui/select.tsx` 파일 생성
- 기본 계정 지정 UI구현
- 기본 계정 지정 API 연동 후 테스트 완료 

## 📝 추가 설명

- 회원 탈퇴 `<Link to="/">` → `<Button disabled>` 미구현 상태에서 홈으로 이동하던 오해 소지를 제거
- 페이지 하단의 로그아웃 버튼 제거(useLogout import 함께 제거)
- `isAccountsError` && `!isAccountsPending` → `isAccountsError`로 단순화 (isPending이 true면 isError는 false이므로 중복 조건)
- import 그룹 알파벳 순 정렬, 사용하지 않게 된 `cn/buttonVariants/LogOut` 제거
- 변수명 `fetchedAccounts` → `mailAccounts`, 콜백 인자 `acc` → `mailAccount`로 가독성 정리

## 🖼️ 스크린샷

| UI | Network |
| -- | -- |
| <img width="601" height="265" alt="image" src="https://github.com/user-attachments/assets/0b7a297b-a857-4de5-ad9b-3e51e838d3a9" /> | <img width="585" height="172" alt="image" src="https://github.com/user-attachments/assets/562631ec-1a62-42e7-a5ff-dd6c2d82d2c5" /> |
