### PR TITLE
[STORY-201] 인박스 목록 및 상세보기 화면 구현

### DIFF
--- a/.github/ISSUE_TEMPLATE/fe_task.md
+++ b/.github/ISSUE_TEMPLATE/fe_task.md
@@ -4,6 +4,7 @@ about: "FE 파트의 Task를 작성합니다"
 title: "[TASK-101] "
 type: "Task-FE"
 ---
+
 ## 🛠️ 목적
 
 무엇을 위한 작업인지 설명

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.eslintcache
 
 node_modules
 dist

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,8 @@ node_modules/
 dist/
 coverage/
 .pnpm-store/
+.claude
+.agents
 pnpm-lock.yaml
 package-lock.json
 yarn.lock

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,9 +36,11 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^16.5.0",
+        "lint-staged": "^16.4.0",
         "portless": "^0.9.6",
         "prettier": "^3.8.1",
         "prettier-plugin-tailwindcss": "^0.7.2",
+        "simple-git-hooks": "^2.13.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.1",
         "vite": "^7.3.1"
@@ -1332,9 +1334,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.12",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
-      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -3173,6 +3175,22 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -3556,6 +3574,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -3668,6 +3720,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -4029,6 +4088,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -4342,6 +4414,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -4955,9 +5034,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5690,6 +5769,79 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/lint-staged": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5751,6 +5903,90 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/lru-cache": {
@@ -6842,6 +7078,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
@@ -7199,11 +7442,68 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-git-hooks": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.13.1.tgz",
+      "integrity": "sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "simple-git-hooks": "cli.js"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -7249,6 +7549,16 @@
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "license": "MIT"
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -7398,6 +7708,16 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -7959,6 +8279,22 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,24 @@
   "scripts": {
     "dev": "portless mail vite dev",
     "build": "tsc -b && vite build",
-    "lint": "eslint .",
-    "format": "prettier --write \"**/*.{json,js,jsx,ts,tsx}\"",
+    "lint": "eslint . --cache",
+    "format": "prettier --write .",
     "typecheck": "tsc -b --noEmit",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "prepare": "simple-git-hooks"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --cache --fix",
+      "prettier --write"
+    ],
+    "*.{json,css,md}": [
+      "prettier --write"
+    ]
+  },
+  "simple-git-hooks": {
+    "pre-commit": "npx lint-staged",
+    "pre-push": "npm run typecheck"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
@@ -40,9 +54,11 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^16.5.0",
+    "lint-staged": "^16.4.0",
     "portless": "^0.9.6",
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
+    "simple-git-hooks": "^2.13.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.1",
     "vite": "^7.3.1"

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,11 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "",
+  "short_name": "",
+  "icons": [
+    { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/src/api/emails.ts
+++ b/src/api/emails.ts
@@ -1,0 +1,33 @@
+// import { apiClient } from "@/lib/api-client"
+import { getMockMailboxThreads, mockThreadDetails } from "@/mock-data/emails"
+import type {
+  InboxThreadDetail,
+  InboxThreadSummary,
+  ListThreadsParams,
+  MarkerSliceResponse,
+  SupportedMailboxId,
+} from "@/types/email"
+
+export async function getMailboxThreads(
+  mailbox: SupportedMailboxId,
+  params: ListThreadsParams = {}
+): Promise<MarkerSliceResponse<InboxThreadSummary>> {
+  return getMockMailboxThreads(mailbox, params)
+
+  // const path = mailbox === "INBOX" ? "/api/v1/threads/inbox" : "/api/v1/threads/sent"
+  // return apiClient.get<MarkerSliceResponse<InboxThreadSummary>>(path, {
+  //   params: params as Record<string, string | number | boolean | null | undefined>,
+  // })
+}
+
+export async function getThreadDetail(threadId: string): Promise<InboxThreadDetail> {
+  const detail = mockThreadDetails[threadId]
+
+  if (!detail) {
+    throw new Error(`Mock thread not found: ${threadId}`)
+  }
+
+  return detail
+
+  // return apiClient.get<InboxThreadDetail>(`/api/v1/threads/${threadId}`)
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,0 +1,56 @@
+import { Link } from "@tanstack/react-router"
+import { Mail } from "lucide-react"
+
+import { NavAccounts } from "@/components/nav-accounts"
+import { NavFolders } from "@/components/nav-folders"
+import { NavUser } from "@/components/nav-user"
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar"
+import type { PrimaryMailboxId } from "@/types/email"
+
+interface AppSidebarProps {
+  activeMailbox: PrimaryMailboxId
+  onMailboxChange: (mailbox: PrimaryMailboxId) => void
+}
+
+export function AppSidebar({
+  activeMailbox,
+  onMailboxChange,
+  ...props
+}: AppSidebarProps & React.ComponentProps<typeof Sidebar>) {
+  return (
+    <Sidebar variant="inset" {...props}>
+      <SidebarHeader className="md:hidden">
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="lg" render={<Link to="/inbox" />}>
+              <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
+                <Mail className="size-4" />
+              </div>
+              <div className="grid flex-1 text-left text-sm leading-tight">
+                <span className="truncate font-semibold">메일상자</span>
+                <span className="truncate text-xs">AI 메일 통합 인박스</span>
+              </div>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+
+      <SidebarContent>
+        <NavFolders activeMailbox={activeMailbox} onMailboxChange={onMailboxChange} />
+        <NavAccounts className="mt-auto" />
+      </SidebarContent>
+
+      <SidebarFooter>
+        <NavUser />
+      </SidebarFooter>
+    </Sidebar>
+  )
+}

--- a/src/components/inbox/email-detail.tsx
+++ b/src/components/inbox/email-detail.tsx
@@ -1,0 +1,195 @@
+import { Archive, Forward, MailOpen, Paperclip, Reply, Trash2, X } from "lucide-react"
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useThread } from "@/queries/emails"
+import type { InboxMessage } from "@/types/email"
+
+function formatDate(value: string) {
+  const date = new Date(value)
+
+  return date.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  })
+}
+
+function getInitials(value: string) {
+  const localPart = value.split("@")[0]?.trim() ?? ""
+
+  return localPart.slice(0, 2).toUpperCase() || "?"
+}
+
+function getMessageParticipants(message: InboxMessage) {
+  const seen = new Set<string>()
+
+  return [message.fromAddress, ...message.toAddresses, ...message.ccAddresses].filter((address) => {
+    const normalized = address.trim()
+
+    if (!normalized || seen.has(normalized)) {
+      return false
+    }
+
+    seen.add(normalized)
+    return true
+  })
+}
+
+function EmptyState() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3">
+      <div className="flex size-16 items-center justify-center rounded-full bg-muted">
+        <MailOpen className="size-8 text-muted-foreground" />
+      </div>
+      <div className="text-center">
+        <p className="font-medium text-muted-foreground">스레드를 선택해주세요</p>
+        <p className="mt-1 text-sm text-muted-foreground/70">목록에서 대화를 클릭하면 여기에 내용이 표시됩니다</p>
+      </div>
+    </div>
+  )
+}
+
+function LoadingState() {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-11 shrink-0 items-center justify-between gap-2 border-b px-4">
+        <Skeleton className="h-4 w-24" />
+        <div className="flex items-center gap-1">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Skeleton key={index} className="size-7 rounded-md" />
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col gap-4 p-6">
+        <Skeleton className="h-7 w-3/4" />
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-10 rounded-full" />
+          <div className="space-y-1.5">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-48" />
+          </div>
+        </div>
+        <Separator />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    </div>
+  )
+}
+
+interface EmailDetailProps {
+  threadId: string | null
+  onClose?: () => void
+}
+
+export function EmailDetail({ threadId, onClose }: EmailDetailProps) {
+  const { data: thread, isLoading } = useThread(threadId)
+
+  if (!threadId) return <EmptyState />
+  if (isLoading) return <LoadingState />
+  if (!thread) return <EmptyState />
+
+  const messages = thread.messages
+  const lastMessage = messages.at(-1)
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-11 shrink-0 items-center gap-2 border-b px-4">
+        {/*<span className="min-w-0 truncate text-sm font-medium">대화 상세</span>*/}
+        <div className="ml-auto flex items-center gap-1">
+          <Button variant="ghost" size="icon-sm" disabled title="답장 기능은 아직 지원되지 않습니다.">
+            <Reply className="size-4" />
+          </Button>
+          <Button variant="ghost" size="icon-sm" disabled title="전달 기능은 아직 지원되지 않습니다.">
+            <Forward className="size-4" />
+          </Button>
+          <Button variant="ghost" size="icon-sm" disabled title="보관 기능은 아직 지원되지 않습니다.">
+            <Archive className="size-4" />
+          </Button>
+          <Button variant="ghost" size="icon-sm" disabled title="삭제 기능은 아직 지원되지 않습니다.">
+            <Trash2 className="size-4" />
+          </Button>
+          {onClose ? (
+            <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="상세보기 닫기" className="-mr-2">
+              <X className="size-4" />
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="shrink-0 border-b p-6">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-semibold">{thread.latestSubject}</h2>
+            <p className="mt-1 text-sm text-muted-foreground">{messages.length}개 메시지</p>
+          </div>
+        </div>
+
+        {lastMessage ? (
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            {getMessageParticipants(lastMessage).map((participant) => (
+              <Badge key={participant} variant="secondary" className="font-normal">
+                {participant}
+              </Badge>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        <div className="flex flex-col gap-4 p-4">
+          {messages.map((message) => (
+            <section key={message.id} className="rounded-2xl border bg-card p-5 shadow-sm">
+              <div className="flex items-start gap-3">
+                <Avatar>
+                  <AvatarFallback>{getInitials(message.fromAddress)}</AvatarFallback>
+                </Avatar>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm font-medium">{message.fromAddress || "알 수 없음"}</p>
+                        <Badge variant="outline">{message.direction === "INBOUND" ? "수신" : "발신"}</Badge>
+                      </div>
+                      <p className="truncate text-xs text-muted-foreground">{message.subject}</p>
+                    </div>
+                    <span className="shrink-0 text-xs text-muted-foreground">{formatDate(message.sentAt)}</span>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    받는 사람: {message.toAddresses.length > 0 ? message.toAddresses.join(", ") : "-"}
+                  </p>
+                  {message.ccAddresses.length > 0 ? (
+                    <p className="mt-1 text-xs text-muted-foreground">참조: {message.ccAddresses.join(", ")}</p>
+                  ) : null}
+                </div>
+              </div>
+
+              <Separator className="my-4" />
+
+              {message.bodyHtml ? (
+                <div className="prose prose-sm max-w-none" dangerouslySetInnerHTML={{ __html: message.bodyHtml }} />
+              ) : (
+                <div className="prose prose-sm max-w-none text-sm whitespace-pre-wrap">
+                  {message.bodyText || message.snippet}
+                </div>
+              )}
+
+              {message.attachments.length > 0 ? (
+                <div className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
+                  <Paperclip className="size-3.5" />
+                  첨부파일 {message.attachments.length}개
+                </div>
+              ) : null}
+            </section>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/inbox/email-list-header.tsx
+++ b/src/components/inbox/email-list-header.tsx
@@ -1,0 +1,44 @@
+import { Toggle } from "@/components/ui/toggle"
+import { cn } from "@/lib/utils"
+
+export type EmailFilter = "all" | "unread"
+
+const filterOptions: Array<{ value: EmailFilter; label: string }> = [
+  { value: "all", label: "전체" },
+  { value: "unread", label: "안읽음" },
+]
+
+interface EmailListHeaderProps {
+  mailboxName: string
+  threadCount: number
+  filter: EmailFilter
+  onFilterChange: (filter: EmailFilter) => void
+}
+
+export function EmailListHeader({ mailboxName, threadCount, filter, onFilterChange }: EmailListHeaderProps) {
+  return (
+    <div className="flex h-11 shrink-0 items-center gap-3 border-b px-4">
+      <h2 className="min-w-0 truncate text-sm font-medium">{mailboxName}</h2>
+      <span className="hidden rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground sm:inline-flex">
+        {threadCount.toLocaleString()}개
+      </span>
+      <div className="ml-auto flex shrink-0 items-center gap-1">
+        {filterOptions.map((option) => (
+          <Toggle
+            key={option.value}
+            pressed={filter === option.value}
+            onPressedChange={(pressed) => {
+              if (pressed) {
+                onFilterChange(option.value)
+              }
+            }}
+            size="sm"
+            className={cn("text-xs", filter === option.value && "bg-muted font-medium")}
+          >
+            {option.label}
+          </Toggle>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/inbox/email-list.tsx
+++ b/src/components/inbox/email-list.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useRef } from "react"
+import { InboxIcon, Paperclip } from "lucide-react"
+
+import { EmailListHeader } from "@/components/inbox/email-list-header"
+import type { EmailFilter } from "@/components/inbox/email-list-header"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { cn } from "@/lib/utils"
+import type { InboxThreadSummary } from "@/types/email"
+
+interface EmailListProps {
+  mailboxName: string
+  threads: InboxThreadSummary[] | undefined
+  isLoading: boolean
+  isFetchingNextPage: boolean
+  hasNextPage: boolean
+  selectedThreadId: string | null
+  filter: EmailFilter
+  onFilterChange: (filter: EmailFilter) => void
+  onSelectThread: (id: string) => void
+  onLoadMore: () => void
+  getAccountColor: (accountId: string) => string | undefined
+  emptyTitle?: string
+  emptyDescription?: string
+}
+
+function formatRelativeDate(dateStr: string): string {
+  const date = new Date(dateStr)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+
+  if (diffDays === 0) {
+    return date.toLocaleTimeString("ko-KR", { hour: "numeric", minute: "2-digit", hour12: true })
+  }
+  if (diffDays === 1) return "어제"
+  if (diffDays < 7) return `${diffDays}일 전`
+  return date.toLocaleDateString("ko-KR", { month: "short", day: "numeric" })
+}
+
+function LoadingRows() {
+  return Array.from({ length: 10 }).map((_, index) => (
+    <TableRow key={index}>
+      <TableCell className="w-10">
+        <Skeleton className="size-2.5 rounded-full" />
+      </TableCell>
+      <TableCell className="w-[22%]">
+        <Skeleton className="h-4 w-28" />
+      </TableCell>
+      <TableCell className="w-[58%]">
+        <Skeleton className="h-4 w-full" />
+      </TableCell>
+      <TableCell className="hidden w-14 text-center md:table-cell">
+        <Skeleton className="mx-auto size-4 rounded-full" />
+      </TableCell>
+      <TableCell className="w-24 text-right">
+        <Skeleton className="ml-auto h-4 w-16" />
+      </TableCell>
+    </TableRow>
+  ))
+}
+
+export function EmailList({
+  mailboxName,
+  threads,
+  isLoading,
+  isFetchingNextPage,
+  hasNextPage,
+  selectedThreadId,
+  filter,
+  onFilterChange,
+  onSelectThread,
+  onLoadMore,
+  getAccountColor,
+  emptyTitle = "메일이 없습니다",
+  emptyDescription,
+}: EmailListProps) {
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const node = loadMoreRef.current
+
+    if (!node || !hasNextPage) {
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && !isFetchingNextPage) {
+          onLoadMore()
+        }
+      },
+      { rootMargin: "200px 0px" }
+    )
+
+    observer.observe(node)
+
+    return () => observer.disconnect()
+  }, [hasNextPage, isFetchingNextPage, onLoadMore])
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-[inherit]">
+      <EmailListHeader
+        mailboxName={mailboxName}
+        threadCount={threads?.length ?? 0}
+        filter={filter}
+        onFilterChange={onFilterChange}
+      />
+
+      <ScrollArea className="min-h-0 flex-1">
+        {isLoading ? (
+          <Table className="table-fixed">
+            <TableHeader className="sticky top-0 z-10 bg-background">
+              <TableRow>
+                <TableHead className="w-10">상태</TableHead>
+                <TableHead className="w-[22%]">보낸 사람</TableHead>
+                <TableHead className="w-[58%]">제목</TableHead>
+                <TableHead className="hidden w-14 text-center md:table-cell">첨부</TableHead>
+                <TableHead className="w-24 text-right">시간</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <LoadingRows />
+            </TableBody>
+          </Table>
+        ) : threads && threads.length > 0 ? (
+          <>
+            <Table className="table-fixed">
+              <TableHeader className="sticky top-0 z-10 bg-background">
+                <TableRow>
+                  <TableHead className="w-10">상태</TableHead>
+                  <TableHead className="w-[28%] md:w-[22%]">보낸 사람</TableHead>
+                  <TableHead className="w-[52%] md:w-[58%]">제목</TableHead>
+                  <TableHead className="hidden w-14 text-center md:table-cell">첨부</TableHead>
+                  <TableHead className="w-24 text-right">시간</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {threads.map((thread) => {
+                  const isSelected = selectedThreadId === thread.threadId
+                  const isUnread = !thread.isRead
+                  const accountColor = getAccountColor(thread.accountId)
+                  const hasAttachments = thread.attachments.length > 0
+
+                  return (
+                    <TableRow
+                      key={thread.threadId}
+                      data-state={isSelected ? "selected" : undefined}
+                      onClick={() => onSelectThread(thread.threadId)}
+                      className={cn(
+                        "cursor-pointer",
+                        isUnread && "bg-accent/20 font-medium",
+                        isSelected && "bg-accent hover:bg-accent"
+                      )}
+                    >
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <span className={cn("size-2.5 rounded-full", isUnread ? "bg-primary" : "bg-transparent")} />
+                          {accountColor ? (
+                            <span
+                              className="hidden size-2 rounded-full md:inline-flex"
+                              style={{ backgroundColor: accountColor }}
+                            />
+                          ) : null}
+                        </div>
+                      </TableCell>
+                      <TableCell className="truncate">
+                        <span className={cn("truncate", isUnread ? "text-foreground" : "text-muted-foreground")}>
+                          {thread.participantAddress || "알 수 없음"}
+                        </span>
+                      </TableCell>
+                      <TableCell className="min-w-0">
+                        <div className="flex min-w-0 items-center gap-2">
+                          <span className={cn("truncate", isUnread ? "text-foreground" : "text-muted-foreground")}>
+                            {thread.latestSubject || "(제목 없음)"}
+                          </span>
+                          <span className="truncate text-muted-foreground">- {thread.snippet}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="hidden text-center md:table-cell">
+                        {hasAttachments ? <Paperclip className="mx-auto size-4 text-muted-foreground" /> : null}
+                      </TableCell>
+                      <TableCell className="text-right text-xs text-muted-foreground">
+                        {formatRelativeDate(thread.lastMessageAt)}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+                {isFetchingNextPage ? <LoadingRows /> : null}
+              </TableBody>
+            </Table>
+            <div ref={loadMoreRef} className="h-1" />
+          </>
+        ) : (
+          <div className="flex min-h-full flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+            <div className="flex size-14 items-center justify-center rounded-full bg-muted">
+              <InboxIcon className="size-7 text-muted-foreground/60" />
+            </div>
+            <div>
+              <p className="font-medium text-muted-foreground">{emptyTitle}</p>
+              {emptyDescription ? <p className="mt-1 text-sm text-muted-foreground">{emptyDescription}</p> : null}
+            </div>
+          </div>
+        )}
+      </ScrollArea>
+    </div>
+  )
+}

--- a/src/components/layout/main-content.tsx
+++ b/src/components/layout/main-content.tsx
@@ -1,7 +1,0 @@
-export function MainContent({ children }: { children: React.ReactNode }) {
-  return (
-    <main className="flex min-w-0 flex-1 flex-col overflow-hidden bg-background p-4">
-      <div className="flex-1 overflow-auto rounded-[30px] bg-card">{children}</div>
-    </main>
-  )
-}

--- a/src/components/nav-accounts.tsx
+++ b/src/components/nav-accounts.tsx
@@ -1,0 +1,43 @@
+import { Link } from "@tanstack/react-router"
+
+import {
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar"
+import { cn } from "@/lib/utils"
+import { useMailAccounts } from "@/queries/mail-accounts"
+
+export function NavAccounts({ className }: { className?: string }) {
+  const { data: accounts } = useMailAccounts()
+
+  if (!accounts?.length) return null
+
+  return (
+    <SidebarGroup className={cn("group-data-[collapsible=icon]:hidden", className)}>
+      <SidebarGroupLabel
+        render={<Link to="/settings/account" />}
+        className="transition-colors hover:text-sidebar-foreground"
+      >
+        계정
+      </SidebarGroupLabel>
+      <SidebarMenu>
+        {accounts.map((account) => (
+          <SidebarMenuItem key={account.id}>
+            <SidebarMenuButton>
+              <span
+                className="flex size-4 shrink-0 items-center justify-center rounded-full"
+                style={{ backgroundColor: account.color }}
+              >
+                <span className="text-[10px] font-bold text-white">{account.alias.charAt(0).toUpperCase()}</span>
+              </span>
+              <span className="truncate text-xs">{account.emailAddress}</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        ))}
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}

--- a/src/components/nav-folders.tsx
+++ b/src/components/nav-folders.tsx
@@ -1,0 +1,46 @@
+import { Inbox, Send, FileText, AlertTriangle, Trash2 } from "lucide-react"
+
+import {
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar"
+import { MAILBOX_LABELS, PRIMARY_MAILBOX_IDS } from "@/types/email"
+import type { PrimaryMailboxId } from "@/types/email"
+
+const folderIcons: Record<PrimaryMailboxId, React.ReactNode> = {
+  INBOX: <Inbox />,
+  SENT: <Send />,
+  DRAFT: <FileText />,
+  SPAM: <AlertTriangle />,
+  TRASH: <Trash2 />,
+}
+
+interface NavFoldersProps {
+  activeMailbox: PrimaryMailboxId
+  onMailboxChange: (mailbox: PrimaryMailboxId) => void
+}
+
+export function NavFolders({ activeMailbox, onMailboxChange }: NavFoldersProps) {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>메일함</SidebarGroupLabel>
+      <SidebarMenu>
+        {PRIMARY_MAILBOX_IDS.map((mailboxId) => (
+          <SidebarMenuItem key={mailboxId}>
+            <SidebarMenuButton
+              tooltip={MAILBOX_LABELS[mailboxId]}
+              isActive={activeMailbox === mailboxId}
+              onClick={() => onMailboxChange(mailboxId)}
+            >
+              {folderIcons[mailboxId]}
+              <span>{MAILBOX_LABELS[mailboxId]}</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        ))}
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -1,0 +1,84 @@
+import { Link } from "@tanstack/react-router"
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar } from "@/components/ui/sidebar"
+import { useLogout } from "@/mutations/auth"
+import { useUser } from "@/queries/user"
+import { ChevronsUpDown, LogOut, Settings, UserIcon } from "lucide-react"
+
+export function NavUser() {
+  const { data: user } = useUser()
+  const logout = useLogout()
+  const { isMobile } = useSidebar()
+
+  if (!user) return null
+
+  const initials = user.name
+    .split("")
+    .filter((_, i) => i < 2)
+    .join("")
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger render={<SidebarMenuButton size="lg" className="aria-expanded:bg-muted" />}>
+            <Avatar size="sm">
+              <AvatarFallback>{initials}</AvatarFallback>
+            </Avatar>
+            <div className="grid flex-1 text-left text-sm leading-tight">
+              <span className="truncate font-medium">{user.name}</span>
+              <span className="truncate text-xs text-muted-foreground">{user.username}</span>
+            </div>
+            <ChevronsUpDown className="ml-auto size-4" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="min-w-56 rounded-lg"
+            side={isMobile ? "bottom" : "right"}
+            align="end"
+            sideOffset={4}
+          >
+            <DropdownMenuGroup>
+              <DropdownMenuLabel className="p-0 font-normal">
+                <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+                  <Avatar size="sm">
+                    <AvatarFallback>{initials}</AvatarFallback>
+                  </Avatar>
+                  <div className="grid flex-1 text-left text-sm leading-tight">
+                    <span className="truncate font-medium">{user.name}</span>
+                    <span className="truncate text-xs text-muted-foreground">{user.username}</span>
+                  </div>
+                </div>
+              </DropdownMenuLabel>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuItem render={<Link to="/settings/account" />}>
+                <UserIcon />
+                <span>내 계정</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem render={<Link to="/settings" />}>
+                <Settings />
+                <span>설정</span>
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={logout}>
+              <LogOut />
+              <span>로그아웃</span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,91 @@
+import * as React from "react"
+import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: AvatarPrimitive.Root.Props & {
+  size?: "default" | "sm" | "lg"
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border after:border-border after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({ className, ...props }: AvatarPrimitive.Image.Props) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn("aspect-square size-full rounded-full object-cover", className)}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({ className, ...props }: AvatarPrimitive.Fallback.Props) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground bg-blend-color ring-2 ring-background select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroupCount({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Avatar, AvatarImage, AvatarFallback, AvatarGroup, AvatarGroupCount, AvatarBadge }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,50 @@
+/* eslint-disable react-refresh/only-export-components */
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  })
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,9 +1,9 @@
 import * as React from "react"
 import { mergeProps } from "@base-ui/react/merge-props"
 import { useRender } from "@base-ui/react/use-render"
-import { ChevronRight, MoreHorizontal } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { ChevronRightIcon, MoreHorizontalIcon } from "lucide-react"
 
 function Breadcrumb({ className, ...props }: React.ComponentProps<"nav">) {
   return <nav aria-label="breadcrumb" data-slot="breadcrumb" className={cn(className)} {...props} />
@@ -13,7 +13,7 @@ function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
   return (
     <ol
       data-slot="breadcrumb-list"
-      className={cn("flex flex-wrap items-center gap-1.5 text-sm break-words text-muted-foreground", className)}
+      className={cn("flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground", className)}
       {...props}
     />
   )
@@ -61,7 +61,7 @@ function BreadcrumbSeparator({ children, className, ...props }: React.ComponentP
       className={cn("[&>svg]:size-3.5", className)}
       {...props}
     >
-      {children ?? <ChevronRight />}
+      {children ?? <ChevronRightIcon />}
     </li>
   )
 }
@@ -75,7 +75,7 @@ function BreadcrumbEllipsis({ className, ...props }: React.ComponentProps<"span"
       className={cn("flex size-5 items-center justify-center [&>svg]:size-4", className)}
       {...props}
     >
-      <MoreHorizontal />
+      <MoreHorizontalIcon />
       <span className="sr-only">More</span>
     </span>
   )

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,15 @@
+import { Collapsible as CollapsiblePrimitive } from "@base-ui/react/collapsible"
+
+function Collapsible({ ...props }: CollapsiblePrimitive.Root.Props) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({ ...props }: CollapsiblePrimitive.Trigger.Props) {
+  return <CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />
+}
+
+function CollapsibleContent({ ...props }: CollapsiblePrimitive.Panel.Props) {
+  return <CollapsiblePrimitive.Panel data-slot="collapsible-content" {...props} />
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,254 @@
+"use client"
+
+import * as React from "react"
+import { Menu as MenuPrimitive } from "@base-ui/react/menu"
+
+import { cn } from "@/lib/utils"
+import { ChevronRightIcon, CheckIcon } from "lucide-react"
+
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
+  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+}
+
+function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+}
+
+function DropdownMenuContent({
+  align = "start",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  className,
+  ...props
+}: MenuPrimitive.Popup.Props & Pick<MenuPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset">) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn(
+            "z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props) {
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: MenuPrimitive.GroupLabel.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.GroupLabel
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn("px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: MenuPrimitive.Item.Props & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
+  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: MenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.SubmenuTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-popup-open:bg-accent data-popup-open:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </MenuPrimitive.SubmenuTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  align = "start",
+  alignOffset = -3,
+  side = "right",
+  sideOffset = 0,
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuContent>) {
+  return (
+    <DropdownMenuContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "w-auto min-w-[96px] rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+        className
+      )}
+      align={align}
+      alignOffset={alignOffset}
+      side={side}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: MenuPrimitive.CheckboxItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <MenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon />
+        </MenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+  return <MenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: MenuPrimitive.RadioItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <MenuPrimitive.RadioItemIndicator>
+          <CheckIcon />
+        </MenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuSeparator({ className, ...props }: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,37 @@
+import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area"
+
+import { cn } from "@/lib/utils"
+
+function ScrollArea({ className, children, ...props }: ScrollAreaPrimitive.Root.Props) {
+  return (
+    <ScrollAreaPrimitive.Root data-slot="scroll-area" className={cn("relative", className)} {...props}>
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+function ScrollBar({ className, orientation = "vertical", ...props }: ScrollAreaPrimitive.Scrollbar.Props) {
+  return (
+    <ScrollAreaPrimitive.Scrollbar
+      data-slot="scroll-area-scrollbar"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Thumb data-slot="scroll-area-thumb" className="relative flex-1 rounded-full bg-border" />
+    </ScrollAreaPrimitive.Scrollbar>
+  )
+}
+
+export { ScrollArea, ScrollBar }

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,19 @@
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({ className, orientation = "horizontal", ...props }: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as SheetPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Sheet({ ...props }: SheetPrimitive.Root.Props) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({ ...props }: SheetPrimitive.Trigger.Props) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({ ...props }: SheetPrimitive.Close.Props) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({ ...props }: SheetPrimitive.Portal.Props) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
+  return (
+    <SheetPrimitive.Backdrop
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/10 transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: SheetPrimitive.Popup.Props & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Popup
+        data-slot="sheet-content"
+        data-side={side}
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-ending-style:opacity-0 data-starting-style:opacity-0 data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=bottom]:data-ending-style:translate-y-[2.5rem] data-[side=bottom]:data-starting-style:translate-y-[2.5rem] data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=left]:data-ending-style:translate-x-[-2.5rem] data-[side=left]:data-starting-style:translate-x-[-2.5rem] data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=right]:data-ending-style:translate-x-[2.5rem] data-[side=right]:data-starting-style:translate-x-[2.5rem] data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=top]:data-ending-style:translate-y-[-2.5rem] data-[side=top]:data-starting-style:translate-y-[-2.5rem] data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close
+            data-slot="sheet-close"
+            render={<Button variant="ghost" className="absolute top-3 right-3" size="icon-sm" />}
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Popup>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="sheet-header" className={cn("flex flex-col gap-0.5 p-4", className)} {...props} />
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="sheet-footer" className={cn("mt-auto flex flex-col gap-2 p-4", className)} {...props} />
+}
+
+function SheetTitle({ className, ...props }: SheetPrimitive.Title.Props) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-base font-medium text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({ className, ...props }: SheetPrimitive.Description.Props) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export { Sheet, SheetTrigger, SheetClose, SheetContent, SheetHeader, SheetFooter, SheetTitle, SheetDescription }

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,0 +1,674 @@
+/* eslint-disable react-refresh/only-export-components */
+import * as React from "react"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { useIsMobile } from "@/hooks/use-mobile"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Separator } from "@/components/ui/separator"
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { Menu } from "lucide-react"
+
+const SIDEBAR_COOKIE_NAME = "sidebar_state"
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
+const SIDEBAR_WIDTH = "16rem"
+const SIDEBAR_WIDTH_MOBILE = "18rem"
+const SIDEBAR_WIDTH_ICON = "3rem"
+const SIDEBAR_KEYBOARD_SHORTCUT = "b"
+
+type SidebarContextProps = {
+  state: "expanded" | "collapsed"
+  open: boolean
+  setOpen: (open: boolean) => void
+  openMobile: boolean
+  setOpenMobile: (open: boolean) => void
+  isMobile: boolean
+  toggleSidebar: () => void
+}
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null)
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext)
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.")
+  }
+
+  return context
+}
+
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: setOpenProp,
+  className,
+  style,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  defaultOpen?: boolean
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}) {
+  const isMobile = useIsMobile()
+  const [openMobile, setOpenMobile] = React.useState(false)
+
+  // This is the internal state of the sidebar.
+  // We use openProp and setOpenProp for control from outside the component.
+  const [_open, _setOpen] = React.useState(defaultOpen)
+  const open = openProp ?? _open
+  const setOpen = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === "function" ? value(open) : value
+      if (setOpenProp) {
+        setOpenProp(openState)
+      } else {
+        _setOpen(openState)
+      }
+
+      // This sets the cookie to keep the sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+    },
+    [setOpenProp, open]
+  )
+
+  // Helper to toggle the sidebar.
+  const toggleSidebar = React.useCallback(() => {
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
+  }, [isMobile, setOpen, setOpenMobile])
+
+  // Adds a keyboard shortcut to toggle the sidebar.
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === SIDEBAR_KEYBOARD_SHORTCUT && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault()
+        toggleSidebar()
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [toggleSidebar])
+
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes.
+  const state = open ? "expanded" : "collapsed"
+
+  const contextValue = React.useMemo<SidebarContextProps>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+    }),
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+  )
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <div
+        data-slot="sidebar-wrapper"
+        style={
+          {
+            "--sidebar-width": SIDEBAR_WIDTH,
+            "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+            ...style,
+          } as React.CSSProperties
+        }
+        className={cn("group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar", className)}
+        {...props}
+      >
+        {children}
+      </div>
+    </SidebarContext.Provider>
+  )
+}
+
+function Sidebar({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  children,
+  dir,
+  ...props
+}: React.ComponentProps<"div"> & {
+  side?: "left" | "right"
+  variant?: "sidebar" | "floating" | "inset"
+  collapsible?: "offcanvas" | "icon" | "none"
+}) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+
+  if (collapsible === "none") {
+    return (
+      <div
+        data-slot="sidebar"
+        className={cn("flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground", className)}
+        {...props}
+      >
+        {children}
+      </div>
+    )
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          dir={dir}
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <div
+      className="group peer hidden text-sidebar-foreground md:block"
+      data-state={state}
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-variant={variant}
+      data-side={side}
+      data-slot="sidebar"
+    >
+      {/* This is what handles the sidebar gap on desktop */}
+      <div
+        data-slot="sidebar-gap"
+        className={cn(
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "group-data-[collapsible=offcanvas]:w-0",
+          "group-data-[side=right]:rotate-180",
+          variant === "floating" || variant === "inset"
+            ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)"
+        )}
+      />
+      <div
+        data-slot="sidebar-container"
+        data-side={side}
+        className={cn(
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          // Adjust the padding for floating and inset variants.
+          variant === "floating" || variant === "inset"
+            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          className
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar"
+          data-slot="sidebar-inner"
+          className="flex size-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1 group-data-[variant=floating]:ring-sidebar-border"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<typeof Button>) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <Button
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="icon-sm"
+      className={cn(className)}
+      onClick={(event) => {
+        onClick?.(event)
+        toggleSidebar()
+      }}
+      {...props}
+    >
+      <Menu />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  )
+}
+
+function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
+        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        "relative flex w-full flex-1 flex-col bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarInput({ className, ...props }: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      data-sidebar="input"
+      className={cn("h-8 w-full bg-background shadow-none", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      data-sidebar="header"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      data-sidebar="footer"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarSeparator({ className, ...props }: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      data-sidebar="separator"
+      className={cn("mx-2 w-auto bg-sidebar-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      data-sidebar="content"
+      className={cn(
+        "no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      data-sidebar="group"
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupLabel({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"div"> & React.ComponentProps<"div">) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(
+          "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "sidebar-group-label",
+      sidebar: "group-label",
+    },
+  })
+}
+
+function SidebarGroupAction({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"button"> & React.ComponentProps<"button">) {
+  return useRender({
+    defaultTagName: "button",
+    props: mergeProps<"button">(
+      {
+        className: cn(
+          "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "sidebar-group-action",
+      sidebar: "group-action",
+    },
+  })
+}
+
+function SidebarGroupContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      data-sidebar="group-content"
+      className={cn("w-full text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      data-sidebar="menu"
+      className={cn("flex w-full min-w-0 flex-col gap-0", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      data-sidebar="menu-item"
+      className={cn("group/menu-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+const sidebarMenuButtonVariants = cva(
+  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        outline:
+          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+      },
+      size: {
+        default: "h-8 text-sm",
+        sm: "h-7 text-xs",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function SidebarMenuButton({
+  render,
+  isActive = false,
+  variant = "default",
+  size = "default",
+  tooltip,
+  className,
+  ...props
+}: useRender.ComponentProps<"button"> &
+  React.ComponentProps<"button"> & {
+    isActive?: boolean
+    tooltip?: string | React.ComponentProps<typeof TooltipContent>
+  } & VariantProps<typeof sidebarMenuButtonVariants>) {
+  const { isMobile, state } = useSidebar()
+  const comp = useRender({
+    defaultTagName: "button",
+    props: mergeProps<"button">(
+      {
+        className: cn(sidebarMenuButtonVariants({ variant, size }), className),
+      },
+      props
+    ),
+    render: !tooltip ? render : <TooltipTrigger render={render} />,
+    state: {
+      slot: "sidebar-menu-button",
+      sidebar: "menu-button",
+      size,
+      active: isActive,
+    },
+  })
+
+  if (!tooltip) {
+    return comp
+  }
+
+  if (typeof tooltip === "string") {
+    tooltip = {
+      children: tooltip,
+    }
+  }
+
+  return (
+    <Tooltip>
+      {comp}
+      <TooltipContent side="right" align="center" hidden={state !== "collapsed" || isMobile} {...tooltip} />
+    </Tooltip>
+  )
+}
+
+function SidebarMenuAction({
+  className,
+  render,
+  showOnHover = false,
+  ...props
+}: useRender.ComponentProps<"button"> &
+  React.ComponentProps<"button"> & {
+    showOnHover?: boolean
+  }) {
+  return useRender({
+    defaultTagName: "button",
+    props: mergeProps<"button">(
+      {
+        className: cn(
+          "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+          showOnHover &&
+            "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-active/menu-button:text-sidebar-accent-foreground aria-expanded:opacity-100 md:opacity-0",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "sidebar-menu-action",
+      sidebar: "menu-action",
+    },
+  })
+}
+
+function SidebarMenuBadge({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-menu-badge"
+      data-sidebar="menu-badge"
+      className={cn(
+        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 peer-data-active/menu-button:text-sidebar-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSkeleton({
+  className,
+  showIcon = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showIcon?: boolean
+}) {
+  // Random width between 50 to 90%.
+  const [width] = React.useState(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`
+  })
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      data-sidebar="menu-skeleton"
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      {...props}
+    >
+      {showIcon && <Skeleton className="size-4 rounded-md" data-sidebar="menu-skeleton-icon" />}
+      <Skeleton
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            "--skeleton-width": width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  )
+}
+
+function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      data-sidebar="menu-sub"
+      className={cn(
+        "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5 group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      data-sidebar="menu-sub-item"
+      className={cn("group/menu-sub-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubButton({
+  render,
+  size = "md",
+  isActive = false,
+  className,
+  ...props
+}: useRender.ComponentProps<"a"> &
+  React.ComponentProps<"a"> & {
+    size?: "sm" | "md"
+    isActive?: boolean
+  }) {
+  return useRender({
+    defaultTagName: "a",
+    props: mergeProps<"a">(
+      {
+        className: cn(
+          "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "sidebar-menu-sub-button",
+      sidebar: "menu-sub-button",
+      size,
+      active: isActive,
+    },
+  })
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,7 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="skeleton" className={cn("animate-pulse rounded-md bg-muted", className)} {...props} />
+}
+
+export { Skeleton }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,70 @@
+/* eslint-disable react-refresh/only-export-components */
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({ className, orientation = "horizontal", ...props }: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn("group/tabs flex gap-2 data-horizontal:flex-col", className)}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel data-slot="tabs-content" className={cn("flex-1 text-sm outline-none", className)} {...props} />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import * as React from "react"
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle"
+import { ToggleGroup as ToggleGroupPrimitive } from "@base-ui/react/toggle-group"
+import { type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 0,
+  orientation: "horizontal",
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  orientation = "horizontal",
+  children,
+  ...props
+}: ToggleGroupPrimitive.Props &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }) {
+  return (
+    <ToggleGroupPrimitive
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      data-orientation={orientation}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] rounded-lg data-[size=sm]:rounded-[min(var(--radius-md),10px)] data-vertical:flex-col data-vertical:items-stretch",
+        className
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size, spacing, orientation }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant = "default",
+  size = "default",
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <TogglePrimitive
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        "shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-2 focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-lg group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-lg group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-lg group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-lg group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </TogglePrimitive>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable react-refresh/only-export-components */
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-lg text-sm font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: "border border-input bg-transparent hover:bg-muted",
+      },
+      size: {
+        default: "h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        sm: "h-7 min-w-7 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 min-w-9 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Toggle({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  return <TogglePrimitive data-slot="toggle" className={cn(toggleVariants({ variant, size, className }))} {...props} />
+}
+
+export { Toggle, toggleVariants }

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({ delay = 0, ...props }: TooltipPrimitive.Provider.Props) {
+  return <TooltipPrimitive.Provider data-slot="tooltip-provider" delay={delay} {...props} />
+}
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  side = "top",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<TooltipPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset">) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/contexts/inbox-context.tsx
+++ b/src/contexts/inbox-context.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext } from "react"
+
+import type { PrimaryMailboxId } from "@/types/email"
+
+interface InboxContextValue {
+  activeMailbox: PrimaryMailboxId
+  setActiveMailbox: (mailbox: PrimaryMailboxId) => void
+  searchQuery: string
+  setSearchQuery: (query: string) => void
+}
+
+export const InboxContext = createContext<InboxContextValue | null>(null)
+
+export function useInboxContext() {
+  const context = useContext(InboxContext)
+  if (!context) {
+    throw new Error("useInboxContext must be used within AuthenticatedRouteLayout")
+  }
+  return context
+}

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+const MOBILE_BREAKPOINT = 768
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    }
+    mql.addEventListener("change", onChange)
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    return () => mql.removeEventListener("change", onChange)
+  }, [])
+
+  return !!isMobile
+}

--- a/src/index.css
+++ b/src/index.css
@@ -6,72 +6,63 @@
 
 @font-face {
   font-family: "Pretendard";
-  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-Thin.woff2")
-    format("woff2");
+  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-Thin.woff2") format("woff2");
   font-weight: 100;
   font-display: swap;
 }
 
 @font-face {
   font-family: "Pretendard";
-  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-ExtraLight.woff2")
-    format("woff2");
+  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-ExtraLight.woff2") format("woff2");
   font-weight: 200;
   font-display: swap;
 }
 
 @font-face {
   font-family: "Pretendard";
-  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-Light.woff2")
-    format("woff2");
+  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-Light.woff2") format("woff2");
   font-weight: 300;
   font-display: swap;
 }
 
 @font-face {
   font-family: "Pretendard";
-  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-Regular.woff2")
-    format("woff2");
+  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-Regular.woff2") format("woff2");
   font-weight: 400;
   font-display: swap;
 }
 
 @font-face {
   font-family: "Pretendard";
-  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-Medium.woff2")
-    format("woff2");
+  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-Medium.woff2") format("woff2");
   font-weight: 500;
   font-display: swap;
 }
 
 @font-face {
   font-family: "Pretendard";
-  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-SemiBold.woff2")
-    format("woff2");
+  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-SemiBold.woff2") format("woff2");
   font-weight: 600;
   font-display: swap;
 }
 
 @font-face {
   font-family: "Pretendard";
-  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-Bold.woff2")
-    format("woff2");
+  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-Bold.woff2") format("woff2");
   font-weight: 700;
   font-display: swap;
 }
 
 @font-face {
   font-family: "Pretendard";
-  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-ExtraBold.woff2")
-    format("woff2");
+  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-ExtraBold.woff2") format("woff2");
   font-weight: 800;
   font-display: swap;
 }
 
 @font-face {
   font-family: "Pretendard";
-  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-Black.woff2")
-    format("woff2");
+  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/pretendard@1.0/Pretendard-Black.woff2") format("woff2");
   font-weight: 900;
   font-display: swap;
 }
@@ -121,15 +112,11 @@
   --shadow-color: oklch(0 0 0);
   --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
   --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
-  --shadow-sm:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
+  --shadow-sm: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
   --shadow: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
-  --shadow-md:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 2px 4px -1px hsl(0 0% 0% / 0.1);
-  --shadow-lg:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 4px 6px -1px hsl(0 0% 0% / 0.1);
-  --shadow-xl:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
+  --shadow-md: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 2px 4px -1px hsl(0 0% 0% / 0.1);
+  --shadow-lg: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 4px 6px -1px hsl(0 0% 0% / 0.1);
+  --shadow-xl: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
   --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
   --tracking-normal: 0em;
   --spacing: 0.25rem;
@@ -180,15 +167,11 @@
   --shadow-color: oklch(0 0 0);
   --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
   --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
-  --shadow-sm:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
+  --shadow-sm: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
   --shadow: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
-  --shadow-md:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 2px 4px -1px hsl(0 0% 0% / 0.1);
-  --shadow-lg:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 4px 6px -1px hsl(0 0% 0% / 0.1);
-  --shadow-xl:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
+  --shadow-md: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 2px 4px -1px hsl(0 0% 0% / 0.1);
+  --shadow-lg: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 4px 6px -1px hsl(0 0% 0% / 0.1);
+  --shadow-xl: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
   --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
 }
 
@@ -251,5 +234,8 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+  html {
+    scrollbar-gutter: stable;
   }
 }

--- a/src/mock-data/accounts.ts
+++ b/src/mock-data/accounts.ts
@@ -1,0 +1,22 @@
+import type { MailAccount } from "@/types/mail-account"
+
+export const mockMailAccounts: MailAccount[] = [
+  {
+    id: "550e8400-e29b-41d4-a716-446655440001",
+    isActive: true,
+    provider: "GMAIL",
+    emailAddress: "mailsangja@gmail.com",
+    alias: "업무 메일",
+    color: "#EA4335",
+    icon: "gmail",
+  },
+  {
+    id: "550e8400-e29b-41d4-a716-446655440002",
+    isActive: true,
+    provider: "NAVER",
+    emailAddress: "mailsangja@naver.com",
+    alias: "개인 메일",
+    color: "#03C75A",
+    icon: "naver",
+  },
+]

--- a/src/mock-data/emails.ts
+++ b/src/mock-data/emails.ts
@@ -1,0 +1,269 @@
+import type {
+  Attachment,
+  InboxMessage,
+  InboxThreadDetail,
+  InboxThreadSummary,
+  MarkerSliceResponse,
+  SupportedMailboxId,
+} from "@/types/email"
+
+const accountIds = {
+  gmail: "550e8400-e29b-41d4-a716-446655440001",
+  naver: "550e8400-e29b-41d4-a716-446655440002",
+} as const
+
+function attachment(id: string, filename: string, mimeType: string, size: number): Attachment {
+  return {
+    id,
+    gmailAttachmentId: `gmail-${id}`,
+    filename,
+    mimeType,
+    size,
+  }
+}
+
+function message(data: InboxMessage): InboxMessage {
+  return data
+}
+
+function thread(data: InboxThreadDetail): InboxThreadDetail {
+  return data
+}
+
+const inboxDetails: InboxThreadDetail[] = [
+  thread({
+    threadId: "0d5a0c9e-9d26-49d4-b5ff-100000000001",
+    gmailThreadId: "gmail-thread-001",
+    accountId: accountIds.gmail,
+    latestSubject: "프로젝트 킥오프 일정 확정",
+    isRead: false,
+    lastMessageAt: "2026-04-10T08:40:00+09:00",
+    messages: [
+      message({
+        id: "5f4a0c9e-9d26-49d4-b5ff-200000000001",
+        gmailMessageId: "gmail-message-001-1",
+        subject: "프로젝트 킥오프 일정 확정",
+        direction: "INBOUND",
+        fromAddress: "pm@company.com",
+        toAddresses: ["mailsangja@gmail.com"],
+        ccAddresses: ["design@company.com"],
+        snippet: "다음 주 월요일 오전 10시로 킥오프 미팅을 확정했습니다.",
+        isRead: false,
+        sentAt: "2026-04-10T08:40:00+09:00",
+        bodyText: "다음 주 월요일 오전 10시로 킥오프 미팅을 확정했습니다.\n회의 링크는 별도 공유드리겠습니다.",
+        bodyHtml:
+          "<p>다음 주 월요일 오전 10시로 킥오프 미팅을 확정했습니다.</p><p>회의 링크는 별도 공유드리겠습니다.</p>",
+        attachments: [],
+      }),
+    ],
+  }),
+  thread({
+    threadId: "0d5a0c9e-9d26-49d4-b5ff-100000000002",
+    gmailThreadId: "gmail-thread-002",
+    accountId: accountIds.naver,
+    latestSubject: "견적서 검토 부탁드립니다",
+    isRead: true,
+    lastMessageAt: "2026-04-09T17:15:00+09:00",
+    messages: [
+      message({
+        id: "5f4a0c9e-9d26-49d4-b5ff-200000000002",
+        gmailMessageId: "gmail-message-002-1",
+        subject: "견적서 검토 부탁드립니다",
+        direction: "INBOUND",
+        fromAddress: "sales@vendor.io",
+        toAddresses: ["mailsangja@naver.com"],
+        ccAddresses: [],
+        snippet: "첨부드린 2분기 제안 견적서를 확인 부탁드립니다.",
+        isRead: true,
+        sentAt: "2026-04-09T17:15:00+09:00",
+        bodyText: "첨부드린 2분기 제안 견적서를 확인 부탁드립니다.",
+        bodyHtml: "<p>첨부드린 2분기 제안 견적서를 확인 부탁드립니다.</p>",
+        attachments: [attachment("30000000-0000-0000-0000-000000000001", "quote-q2.pdf", "application/pdf", 240512)],
+      }),
+    ],
+  }),
+  thread({
+    threadId: "0d5a0c9e-9d26-49d4-b5ff-100000000003",
+    gmailThreadId: "gmail-thread-003",
+    accountId: accountIds.gmail,
+    latestSubject: "디자인 시안 피드백 요청",
+    isRead: true,
+    lastMessageAt: "2026-04-09T10:05:00+09:00",
+    messages: [
+      message({
+        id: "5f4a0c9e-9d26-49d4-b5ff-200000000003",
+        gmailMessageId: "gmail-message-003-1",
+        subject: "디자인 시안 피드백 요청",
+        direction: "INBOUND",
+        fromAddress: "designer@studio.kr",
+        toAddresses: ["mailsangja@gmail.com"],
+        ccAddresses: [],
+        snippet: "랜딩 페이지 시안을 공유드립니다. 확인 후 코멘트 부탁드립니다.",
+        isRead: true,
+        sentAt: "2026-04-09T10:05:00+09:00",
+        bodyText: "랜딩 페이지 시안을 공유드립니다. 확인 후 코멘트 부탁드립니다.",
+        bodyHtml: "<p>랜딩 페이지 시안을 공유드립니다. 확인 후 코멘트 부탁드립니다.</p>",
+        attachments: [attachment("30000000-0000-0000-0000-000000000002", "landing-v3.png", "image/png", 180422)],
+      }),
+    ],
+  }),
+  thread({
+    threadId: "0d5a0c9e-9d26-49d4-b5ff-100000000004",
+    gmailThreadId: "gmail-thread-004",
+    accountId: accountIds.naver,
+    latestSubject: "주간 리포트 공유",
+    isRead: false,
+    lastMessageAt: "2026-04-08T18:20:00+09:00",
+    messages: [
+      message({
+        id: "5f4a0c9e-9d26-49d4-b5ff-200000000004",
+        gmailMessageId: "gmail-message-004-1",
+        subject: "주간 리포트 공유",
+        direction: "INBOUND",
+        fromAddress: "ops@company.com",
+        toAddresses: ["mailsangja@naver.com"],
+        ccAddresses: ["team@company.com"],
+        snippet: "이번 주 운영 지표와 주요 이슈를 정리했습니다.",
+        isRead: false,
+        sentAt: "2026-04-08T18:20:00+09:00",
+        bodyText: "이번 주 운영 지표와 주요 이슈를 정리했습니다.",
+        bodyHtml: "<p>이번 주 운영 지표와 주요 이슈를 정리했습니다.</p>",
+        attachments: [],
+      }),
+    ],
+  }),
+]
+
+const sentDetails: InboxThreadDetail[] = [
+  thread({
+    threadId: "0d5a0c9e-9d26-49d4-b5ff-100000000101",
+    gmailThreadId: "gmail-thread-101",
+    accountId: accountIds.gmail,
+    latestSubject: "Re: 프로젝트 킥오프 일정 확정",
+    isRead: true,
+    lastMessageAt: "2026-04-10T09:05:00+09:00",
+    messages: [
+      message({
+        id: "5f4a0c9e-9d26-49d4-b5ff-200000000101",
+        gmailMessageId: "gmail-message-101-1",
+        subject: "Re: 프로젝트 킥오프 일정 확정",
+        direction: "OUTBOUND",
+        fromAddress: "mailsangja@gmail.com",
+        toAddresses: ["pm@company.com"],
+        ccAddresses: ["design@company.com"],
+        snippet: "월요일 오전 10시 확인했습니다. 자료 준비해서 참석하겠습니다.",
+        isRead: true,
+        sentAt: "2026-04-10T09:05:00+09:00",
+        bodyText: "월요일 오전 10시 확인했습니다. 자료 준비해서 참석하겠습니다.",
+        bodyHtml: "<p>월요일 오전 10시 확인했습니다. 자료 준비해서 참석하겠습니다.</p>",
+        attachments: [],
+      }),
+    ],
+  }),
+  thread({
+    threadId: "0d5a0c9e-9d26-49d4-b5ff-100000000102",
+    gmailThreadId: "gmail-thread-102",
+    accountId: accountIds.naver,
+    latestSubject: "회의록 전달드립니다",
+    isRead: true,
+    lastMessageAt: "2026-04-09T19:45:00+09:00",
+    messages: [
+      message({
+        id: "5f4a0c9e-9d26-49d4-b5ff-200000000102",
+        gmailMessageId: "gmail-message-102-1",
+        subject: "회의록 전달드립니다",
+        direction: "OUTBOUND",
+        fromAddress: "mailsangja@naver.com",
+        toAddresses: ["lead@company.com", "team@company.com"],
+        ccAddresses: [],
+        snippet: "오늘 회의에서 논의한 사항을 정리해 공유드립니다.",
+        isRead: true,
+        sentAt: "2026-04-09T19:45:00+09:00",
+        bodyText: "오늘 회의에서 논의한 사항을 정리해 공유드립니다.",
+        bodyHtml: "<p>오늘 회의에서 논의한 사항을 정리해 공유드립니다.</p>",
+        attachments: [
+          attachment(
+            "30000000-0000-0000-0000-000000000003",
+            "meeting-notes.docx",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            90112
+          ),
+        ],
+      }),
+    ],
+  }),
+  thread({
+    threadId: "0d5a0c9e-9d26-49d4-b5ff-100000000103",
+    gmailThreadId: "gmail-thread-103",
+    accountId: accountIds.gmail,
+    latestSubject: "계약서 초안 전달",
+    isRead: true,
+    lastMessageAt: "2026-04-08T11:10:00+09:00",
+    messages: [
+      message({
+        id: "5f4a0c9e-9d26-49d4-b5ff-200000000103",
+        gmailMessageId: "gmail-message-103-1",
+        subject: "계약서 초안 전달",
+        direction: "OUTBOUND",
+        fromAddress: "mailsangja@gmail.com",
+        toAddresses: ["legal@partner.com"],
+        ccAddresses: ["ceo@partner.com"],
+        snippet: "검토 부탁드리며 수정 의견 주시면 반영하겠습니다.",
+        isRead: true,
+        sentAt: "2026-04-08T11:10:00+09:00",
+        bodyText: "검토 부탁드리며 수정 의견 주시면 반영하겠습니다.",
+        bodyHtml: "<p>검토 부탁드리며 수정 의견 주시면 반영하겠습니다.</p>",
+        attachments: [
+          attachment("30000000-0000-0000-0000-000000000004", "contract-draft.pdf", "application/pdf", 512334),
+        ],
+      }),
+    ],
+  }),
+]
+
+const allDetails = [...inboxDetails, ...sentDetails]
+
+function toSummary(detail: InboxThreadDetail): InboxThreadSummary {
+  const lastMessage = detail.messages.at(-1)
+
+  return {
+    threadId: detail.threadId,
+    gmailThreadId: detail.gmailThreadId,
+    accountId: detail.accountId,
+    latestSubject: detail.latestSubject,
+    participantAddress:
+      lastMessage?.direction === "OUTBOUND" ? (lastMessage.toAddresses[0] ?? "") : (lastMessage?.fromAddress ?? ""),
+    snippet: lastMessage?.snippet ?? "",
+    isRead: detail.isRead,
+    lastMessageAt: detail.lastMessageAt,
+    attachments: detail.messages.flatMap((message) => message.attachments),
+  }
+}
+
+export const mockThreadDetails = Object.fromEntries(allDetails.map((detail) => [detail.threadId, detail])) as Record<
+  string,
+  InboxThreadDetail
+>
+
+export const mockThreadSummaries: Record<SupportedMailboxId, InboxThreadSummary[]> = {
+  INBOX: inboxDetails.map(toSummary),
+  SENT: sentDetails.map(toSummary),
+}
+
+export function getMockMailboxThreads(
+  mailbox: SupportedMailboxId,
+  params: { marker?: string; size?: number } = {}
+): MarkerSliceResponse<InboxThreadSummary> {
+  const items = mockThreadSummaries[mailbox]
+  const size = params.size ?? 50
+  const startIndex = params.marker ? items.findIndex((item) => item.threadId === params.marker) + 1 : 0
+  const content = items.slice(startIndex, startIndex + size)
+  const lastItem = content.at(-1)
+  const hasNext = startIndex + size < items.length
+
+  return {
+    content,
+    nextMarker: hasNext ? (lastItem?.threadId ?? null) : null,
+    hasNext,
+  }
+}

--- a/src/queries/emails.ts
+++ b/src/queries/emails.ts
@@ -1,0 +1,37 @@
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
+
+import { getMailboxThreads, getThreadDetail } from "@/api/emails"
+import type { SupportedMailboxId } from "@/types/email"
+
+export const emailKeys = {
+  all: () => ["emails"] as const,
+  mailbox: (mailbox: SupportedMailboxId | null, size: number) =>
+    [...emailKeys.all(), "mailbox", mailbox, size] as const,
+  thread: (id: string) => [...emailKeys.all(), "thread", id] as const,
+}
+
+export function useMailboxThreads(mailbox: SupportedMailboxId | null, options: { size?: number } = {}) {
+  const size = options.size ?? 50
+
+  return useInfiniteQuery({
+    queryKey: emailKeys.mailbox(mailbox, size),
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam }) => {
+      if (!mailbox) {
+        throw new Error("Mailbox is required")
+      }
+
+      return getMailboxThreads(mailbox, { marker: pageParam, size })
+    },
+    getNextPageParam: (lastPage) => lastPage.nextMarker ?? undefined,
+    enabled: mailbox != null,
+  })
+}
+
+export function useThread(id: string | null) {
+  return useQuery({
+    queryKey: emailKeys.thread(id ?? ""),
+    queryFn: () => getThreadDetail(id!),
+    enabled: id != null,
+  })
+}

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -1,10 +1,16 @@
+import { useState } from "react"
 import { Link, createFileRoute, Outlet, redirect } from "@tanstack/react-router"
-import { Bell, Loader2, Mail, Search, Settings } from "lucide-react"
+import { Bell, Mail, Search } from "lucide-react"
 
+import { AppSidebar } from "@/components/app-sidebar"
 import { LoadingLayout } from "@/components/layout/loading-layout"
-import { Button, buttonVariants } from "@/components/ui/button"
-import { cn } from "@/lib/utils"
-import { useUser, userQueries } from "@/queries/user"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar"
+import { InboxContext } from "@/contexts/inbox-context"
+import { useIsMobile } from "@/hooks/use-mobile"
+import { userQueries } from "@/queries/user"
+import type { PrimaryMailboxId } from "@/types/email"
 
 export const Route = createFileRoute("/_authenticated")({
   beforeLoad: async ({ context }) => {
@@ -19,47 +25,54 @@ export const Route = createFileRoute("/_authenticated")({
 })
 
 function AuthenticatedRouteLayout() {
-  const { data: user } = useUser()
-
-  if (!user) {
-    return (
-      <div className="flex min-h-svh items-center justify-center">
-        <Loader2 className="animate-spin" />
-      </div>
-    )
-  }
+  const [activeMailbox, setActiveMailbox] = useState<PrimaryMailboxId>("INBOX")
+  const [searchQuery, setSearchQuery] = useState("")
+  const isMobile = useIsMobile()
 
   return (
-    <div className="flex h-svh flex-col bg-background">
-      <header className="flex items-center gap-4 px-4 pt-3 pb-2">
-        <div className="flex shrink-0 items-center gap-2">
-          <Mail className="size-5" />
-          <span className="font-bold">메일상자</span>
-        </div>
+    <InboxContext.Provider value={{ activeMailbox, setActiveMailbox, searchQuery, setSearchQuery }}>
+      <SidebarProvider className="flex-col bg-background">
+        <header className="flex h-14 shrink-0 items-center gap-4 px-4">
+          {isMobile ? (
+            <SidebarTrigger className="shrink-0" />
+          ) : (
+            <Link to="/inbox" className="flex shrink-0 items-center gap-2">
+              <Mail className="size-5" />
+              <span className="font-bold">메일상자</span>
+            </Link>
+          )}
 
-        <div className="relative mx-auto w-full max-w-xl">
-          <Search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
-          <input
-            type="text"
-            aria-label="메일 검색"
-            placeholder="메일 검색"
-            className="h-9 w-full rounded-md bg-muted/50 pr-3 pl-9 text-sm outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-ring"
+          <div className="relative mx-auto w-full max-w-xl">
+            <Search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              aria-label="메일 검색"
+              placeholder="메일 검색"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="h-9 rounded-md bg-muted/50 pl-9 shadow-none"
+            />
+          </div>
+
+          <div className="flex shrink-0 items-center gap-1">
+            <Button variant="ghost" size="icon" aria-label="알림">
+              <Bell className="size-5" />
+            </Button>
+          </div>
+        </header>
+
+        <div className="flex min-h-0 flex-1 bg-sidebar">
+          <AppSidebar
+            activeMailbox={activeMailbox}
+            onMailboxChange={setActiveMailbox}
+            className="top-14 h-[calc(100svh-3.5rem)]"
           />
+          <div className="flex min-w-0 flex-1 flex-col">
+            <div className="relative m-2 mt-0 flex min-w-0 flex-1 flex-col rounded-xl bg-background shadow-sm md:ml-0">
+              <Outlet />
+            </div>
+          </div>
         </div>
-
-        <div className="flex shrink-0 items-center gap-1">
-          <Button variant="ghost" size="icon">
-            <Bell className="size-5" />
-          </Button>
-          <Link to="/settings" className={cn(buttonVariants({ variant: "ghost", size: "icon" }), "ml-1")}>
-            <Settings className="size-5" />
-          </Link>
-        </div>
-      </header>
-
-      <div className="flex min-h-0 flex-1 overflow-hidden">
-        <Outlet />
-      </div>
-    </div>
+      </SidebarProvider>
+    </InboxContext.Provider>
   )
 }

--- a/src/routes/_authenticated/inbox.tsx
+++ b/src/routes/_authenticated/inbox.tsx
@@ -1,46 +1,128 @@
-import { createFileRoute, Link } from "@tanstack/react-router"
-import { LogOut } from "lucide-react"
+import { useState } from "react"
+import { createFileRoute } from "@tanstack/react-router"
 
-import { MainContent } from "@/components/layout/main-content"
-import { Button } from "@/components/ui/button"
-import { useLogout } from "@/mutations/auth"
-import { useUser } from "@/queries/user"
+import { EmailDetail } from "@/components/inbox/email-detail"
+import type { EmailFilter } from "@/components/inbox/email-list-header"
+import { EmailList } from "@/components/inbox/email-list"
+import { Separator } from "@/components/ui/separator"
+import { useInboxContext } from "@/contexts/inbox-context"
+import { useIsMobile } from "@/hooks/use-mobile"
+import { cn } from "@/lib/utils"
+import { useMailAccounts } from "@/queries/mail-accounts"
+import { useMailboxThreads } from "@/queries/emails"
+import { isSupportedMailboxId, MAILBOX_LABELS } from "@/types/email"
 
 export const Route = createFileRoute("/_authenticated/inbox")({
   component: InboxPage,
 })
 
+function matchesSearch(value: string, terms: string[]) {
+  const normalized = value.toLowerCase()
+
+  return terms.every((term) => normalized.includes(term))
+}
+
 function InboxPage() {
-  const { data: user } = useUser()
-  const logout = useLogout()
+  const { activeMailbox, searchQuery } = useInboxContext()
+  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null)
+  const [filter, setFilter] = useState<EmailFilter>("all")
+  const isMobile = useIsMobile()
+  const { data: accounts } = useMailAccounts()
+  const supportedMailbox = isSupportedMailboxId(activeMailbox) ? activeMailbox : null
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useMailboxThreads(supportedMailbox)
+
+  const loadedThreads = data?.pages.flatMap((page) => page.content) ?? []
+  const searchTerms = searchQuery.trim().toLowerCase().split(/\s+/).filter(Boolean)
+
+  const threads = supportedMailbox
+    ? loadedThreads.filter((thread) => {
+        if (filter === "unread" && thread.isRead) {
+          return false
+        }
+
+        if (searchTerms.length === 0) {
+          return true
+        }
+
+        return matchesSearch([thread.latestSubject, thread.participantAddress, thread.snippet].join(" "), searchTerms)
+      })
+    : []
+
+  const getAccountColor = (accountId: string) => {
+    return accounts?.find((account) => account.id === accountId)?.color
+  }
+
+  const visibleSelectedThreadId = threads.some((thread) => thread.threadId === selectedThreadId)
+    ? selectedThreadId
+    : null
+  const mailboxName = MAILBOX_LABELS[activeMailbox]
+  const hasSelection = visibleSelectedThreadId != null
+
+  let emptyTitle = "메일이 없습니다"
+  let emptyDescription: string | undefined
+
+  if (!supportedMailbox) {
+    emptyTitle = "아직 지원되지 않는 메일함입니다"
+    emptyDescription = "현재 백엔드 API는 받은편지함과 보낸편지함만 지원합니다."
+  } else if (searchTerms.length > 0) {
+    emptyTitle = "검색 결과가 없습니다"
+    emptyDescription = "현재까지 불러온 메일에서 검색 결과를 찾지 못했습니다."
+  } else if (filter === "unread") {
+    emptyTitle = "안 읽은 메일이 없습니다"
+  }
+
+  const emailList = (
+    <EmailList
+      mailboxName={mailboxName}
+      threads={threads}
+      isLoading={supportedMailbox != null && isLoading}
+      isFetchingNextPage={isFetchingNextPage}
+      hasNextPage={!!hasNextPage}
+      selectedThreadId={visibleSelectedThreadId}
+      filter={filter}
+      onFilterChange={setFilter}
+      onSelectThread={setSelectedThreadId}
+      onLoadMore={() => {
+        if (supportedMailbox && hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage()
+        }
+      }}
+      getAccountColor={getAccountColor}
+      emptyTitle={emptyTitle}
+      emptyDescription={emptyDescription}
+    />
+  )
+
+  if (isMobile) {
+    return (
+      <div className="flex-1 overflow-hidden">
+        {hasSelection ? (
+          <EmailDetail threadId={visibleSelectedThreadId} onClose={() => setSelectedThreadId(null)} />
+        ) : (
+          emailList
+        )}
+      </div>
+    )
+  }
 
   return (
-    <div className="flex min-h-0 flex-1">
-      <aside className="flex w-64 shrink-0 flex-col overflow-y-auto">
-        <nav className="flex flex-1 flex-col gap-1 p-2">
-          <Link to="/inbox" className="flex items-center gap-2 rounded-md bg-accent px-3 py-2 text-sm">
-            인박스
-          </Link>
-        </nav>
-
-        <div className="border-t p-4">
-          <div className="mb-2 text-sm">
-            <p className="font-medium">{user?.name}</p>
-            <p className="text-muted-foreground">{user?.username}</p>
+    <div className="flex flex-1 overflow-hidden">
+      <div
+        className={cn(
+          "min-w-0 border-r-0 transition-[flex-basis,width] duration-300 ease-out",
+          hasSelection ? "basis-1/2" : "basis-full"
+        )}
+      >
+        {emailList}
+      </div>
+      {hasSelection ? (
+        <>
+          <Separator orientation="vertical" />
+          <div className="min-w-0 basis-1/2">
+            <EmailDetail threadId={visibleSelectedThreadId} onClose={() => setSelectedThreadId(null)} />
           </div>
-          <Button variant="ghost" size="sm" className="w-full justify-start" onClick={logout}>
-            <LogOut className="size-4" />
-            로그아웃
-          </Button>
-        </div>
-      </aside>
-
-      <MainContent>
-        <div className="p-8">
-          <h1 className="text-2xl font-bold">인박스</h1>
-          <p className="mt-2 text-muted-foreground">메일상자에 오신 것을 환영합니다.</p>
-        </div>
-      </MainContent>
+        </>
+      ) : null}
     </div>
   )
 }

--- a/src/routes/_authenticated/settings.tsx
+++ b/src/routes/_authenticated/settings.tsx
@@ -1,57 +1,56 @@
-import { createFileRoute, Link, Outlet } from "@tanstack/react-router"
-import { LogOut, Settings, User } from "lucide-react"
+import { createFileRoute, Outlet, useLocation, useNavigate } from "@tanstack/react-router"
+import { Settings, User } from "lucide-react"
 
-import { MainContent } from "@/components/layout/main-content"
-import { Button } from "@/components/ui/button"
-import { useLogout } from "@/mutations/auth"
-import { useUser } from "@/queries/user"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 export const Route = createFileRoute("/_authenticated/settings")({
   component: SettingsLayout,
 })
 
+const settingsTabRoutes = {
+  general: "/settings",
+  account: "/settings/account",
+} as const
+
 function SettingsLayout() {
-  const { data: user } = useUser()
-  const logout = useLogout()
+  const pathname = useLocation({ select: (location) => location.pathname })
+  const navigate = useNavigate()
+  const activeTab = pathname.startsWith(settingsTabRoutes.account) ? "account" : "general"
 
   return (
-    <div className="flex min-h-0 flex-1">
-      <aside className="flex w-64 shrink-0 flex-col overflow-y-auto">
-        <nav className="flex flex-1 flex-col gap-1 p-2">
-          <Link
-            to="/settings"
-            activeOptions={{ exact: true }}
-            className="flex items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-accent"
-            activeProps={{ className: "flex items-center gap-2 rounded-md bg-accent px-3 py-2 text-sm" }}
-          >
-            <Settings className="size-4" />
-            설정
-          </Link>
-          <Link
-            to="/settings/account"
-            className="flex items-center gap-2 rounded-md px-3 py-2 pl-7 text-sm hover:bg-accent"
-            activeProps={{ className: "flex items-center gap-2 rounded-md bg-accent px-3 py-2 text-sm pl-7" }}
-          >
-            <User className="size-4" />
-            계정
-          </Link>
-        </nav>
-
-        <div className="border-t p-4">
-          <div className="mb-2 text-sm">
-            <p className="font-medium">{user?.name}</p>
-            <p className="text-muted-foreground">{user?.username}</p>
-          </div>
-          <Button variant="ghost" size="sm" className="w-full justify-start" onClick={logout}>
-            <LogOut className="size-4" />
-            로그아웃
-          </Button>
+    <div className="flex min-h-0 flex-1 overflow-y-auto p-6">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-2xl font-semibold">설정</h1>
+          <p className="text-sm text-muted-foreground">메일상자 계정 및 메일 환경을 한 곳에서 관리합니다.</p>
         </div>
-      </aside>
 
-      <MainContent>
-        <Outlet />
-      </MainContent>
+        <Tabs
+          value={activeTab}
+          onValueChange={(value) => {
+            if (value === activeTab) {
+              return
+            }
+
+            void navigate({ to: settingsTabRoutes[value as keyof typeof settingsTabRoutes] })
+          }}
+          className="gap-6"
+        >
+          <TabsList variant="line" className="w-full justify-start border-b">
+            <TabsTrigger value="general" className="min-w-24 rounded-none px-4">
+              <Settings data-icon="inline-start" />
+              일반
+            </TabsTrigger>
+            <TabsTrigger value="account" className="min-w-24 rounded-none px-4">
+              <User data-icon="inline-start" />
+              계정
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value={activeTab}>
+            <Outlet />
+          </TabsContent>
+        </Tabs>
+      </div>
     </div>
   )
 }

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -1,17 +1,10 @@
 import { useMemo, useState } from "react"
-import { createFileRoute, Link } from "@tanstack/react-router"
-import { Home, Trash2, Plus } from "lucide-react"
+import { createFileRoute } from "@tanstack/react-router"
+import { Plus, Trash2 } from "lucide-react"
 
 import { AddAccountDialog } from "@/components/add-account-dialog"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb"
 import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
@@ -68,174 +61,158 @@ function SettingsAccountPage() {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto p-8">
-      <div className="mx-auto max-w-5xl space-y-8">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink render={<Link to="/inbox" />}>
-                <Home className="size-4" />
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbLink render={<Link to="/settings" />}>설정</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>계정</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-
-        {/* 계정 정보 */}
-        <section className="space-y-3">
-          <h2 className="text-lg font-semibold">계정 정보</h2>
-          <div className="flex items-center justify-between rounded-lg border border-border bg-background p-5">
-            <div className="space-y-1">
-              <p className="font-medium">{isUserPending ? "불러오는 중..." : (user?.name ?? "-")}</p>
-              <p className="text-sm text-muted-foreground">아이디: {user?.username ?? "-"}</p>
-              <p className="text-sm text-muted-foreground">플랜: {user?.plan ?? "-"}</p>
-            </div>
-            {/* TODO: 회원 탈퇴 API 연동 */}
-            <Button variant="outline" className="ml-2 px-8" disabled>
-              회원 탈퇴
-            </Button>
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>계정 정보</CardTitle>
+          <CardDescription>현재 로그인한 사용자와 구독 플랜 정보를 확인합니다.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex items-center justify-between gap-4">
+          <div className="flex flex-col gap-1">
+            <p className="font-medium">{isUserPending ? "불러오는 중..." : (user?.name ?? "-")}</p>
+            <p className="text-sm text-muted-foreground">아이디: {user?.username ?? "-"}</p>
+            <p className="text-sm text-muted-foreground">플랜: {user?.plan ?? "-"}</p>
           </div>
-        </section>
+          <Button variant="outline" disabled>
+            회원 탈퇴
+          </Button>
+        </CardContent>
+      </Card>
 
-        {/* Default 계정 */}
-        <section className="space-y-3">
-          <h2 className="text-lg font-semibold">기본 메일 계정</h2>
-          <p className="text-sm text-muted-foreground">계정 중 하나를 기본 발신 계정으로 선택할 수 있습니다.</p>
-          <div className="flex items-center gap-3">
-            <Select
-              value={selectedDefaultAccount}
-              onValueChange={setDefaultAccount}
-              items={defaultAccountItems}
-              disabled={isAccountsPending || accounts.length === 0}
-            >
-              <SelectTrigger className="w-72" aria-label="기본 발신 계정 선택">
-                <SelectValue
-                  placeholder={isAccountsPending ? "계정 목록을 불러오는 중..." : "기본 메일 계정을 선택하세요"}
-                />
-              </SelectTrigger>
-              <SelectContent align="start" alignItemWithTrigger={false}>
-                {defaultAccountItems.map((item) => (
-                  <SelectItem key={item.value} value={item.value} className="px-3 py-2">
-                    {item.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Button
-              variant="outline"
-              className="px-4"
-              onClick={handleSaveDefaultAccount}
-              disabled={
-                !selectedDefaultAccount ||
-                selectedDefaultAccount === user?.defaultMailAccountId ||
-                updateDefaultAccountMutation.isPending
-              }
-            >
-              {updateDefaultAccountMutation.isPending ? "저장 중..." : "저장"}
-            </Button>
-          </div>
-        </section>
+      <Card>
+        <CardHeader>
+          <CardTitle>기본 메일 계정</CardTitle>
+          <CardDescription>계정 중 하나를 기본 발신 계정으로 선택할 수 있습니다.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-wrap items-center gap-3">
+          <Select
+            value={selectedDefaultAccount}
+            onValueChange={setDefaultAccount}
+            items={defaultAccountItems}
+            disabled={isAccountsPending || accounts.length === 0}
+          >
+            <SelectTrigger className="w-72" aria-label="기본 발신 계정 선택">
+              <SelectValue
+                placeholder={isAccountsPending ? "계정 목록을 불러오는 중..." : "기본 메일 계정을 선택하세요"}
+              />
+            </SelectTrigger>
+            <SelectContent align="start" alignItemWithTrigger={false}>
+              {defaultAccountItems.map((item) => (
+                <SelectItem key={item.value} value={item.value} className="px-3 py-2">
+                  {item.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            variant="outline"
+            onClick={handleSaveDefaultAccount}
+            disabled={
+              !selectedDefaultAccount ||
+              selectedDefaultAccount === user?.defaultMailAccountId ||
+              updateDefaultAccountMutation.isPending
+            }
+          >
+            {updateDefaultAccountMutation.isPending ? "저장 중..." : "저장"}
+          </Button>
+        </CardContent>
+      </Card>
 
-        {/* 계정 관리 */}
-        <section className="space-y-3">
-          <h2 className="text-lg font-semibold">계정 관리</h2>
-          <div className="rounded-lg border border-border bg-background">
-            <Table>
-              <TableHeader>
+      <Card>
+        <CardHeader>
+          <CardTitle>계정 관리</CardTitle>
+          <CardDescription>연결된 메일 계정의 활성화 상태와 별칭을 확인합니다.</CardDescription>
+        </CardHeader>
+        <CardContent className="px-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-12 text-center">아이콘</TableHead>
+                <TableHead className="w-full">메일주소</TableHead>
+                <TableHead className="text-center">활성화</TableHead>
+                <TableHead className="text-center">삭제</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isAccountsPending && (
                 <TableRow>
-                  <TableHead className="w-12 text-center">아이콘</TableHead>
-                  <TableHead className="w-full">메일주소</TableHead>
-                  <TableHead className="text-center">활성화</TableHead>
-                  <TableHead className="text-center">삭제</TableHead>
+                  <TableCell colSpan={4} className="text-center text-sm text-muted-foreground">
+                    계정 목록을 불러오는 중입니다.
+                  </TableCell>
                 </TableRow>
-              </TableHeader>
-              <TableBody>
-                {isAccountsPending && (
-                  <TableRow>
-                    <TableCell colSpan={4} className="text-center text-sm text-muted-foreground">
-                      계정 목록을 불러오는 중입니다.
-                    </TableCell>
-                  </TableRow>
-                )}
-                {isAccountsError && (
-                  <TableRow>
-                    <TableCell colSpan={4} className="text-center text-sm text-destructive">
-                      계정 목록을 불러오지 못했습니다.
-                    </TableCell>
-                  </TableRow>
-                )}
-                {!isAccountsPending && !isAccountsError && accounts.length === 0 && (
-                  <TableRow>
-                    <TableCell colSpan={4} className="text-center text-sm text-muted-foreground">
-                      등록된 계정이 없습니다.
-                    </TableCell>
-                  </TableRow>
-                )}
-                {accounts.map((mailAccount) => (
-                  <TableRow key={mailAccount.id}>
-                    <TableCell className="text-center">
-                      {mailAccount.icon ? (
-                        <div
-                          className="mx-auto flex size-8 items-center justify-center rounded-full"
-                          style={{ backgroundColor: mailAccount.color || "#6B7280" }}
-                        >
-                          <AccountIcon name={mailAccount.icon} className="size-4 text-white" />
-                        </div>
-                      ) : (
-                        "-"
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex flex-col">
-                        <span className="text-sm">{mailAccount.emailAddress}</span>
-                        <span className="text-xs text-muted-foreground">{mailAccount.alias}</span>
+              )}
+              {isAccountsError && (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center text-sm text-destructive">
+                    계정 목록을 불러오지 못했습니다.
+                  </TableCell>
+                </TableRow>
+              )}
+              {!isAccountsPending && !isAccountsError && accounts.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center text-sm text-muted-foreground">
+                    등록된 계정이 없습니다.
+                  </TableCell>
+                </TableRow>
+              )}
+              {accounts.map((mailAccount) => (
+                <TableRow key={mailAccount.id}>
+                  <TableCell className="text-center">
+                    {mailAccount.icon ? (
+                      <div
+                        className="mx-auto flex size-8 items-center justify-center rounded-full"
+                        style={{ backgroundColor: mailAccount.color || "#6B7280" }}
+                      >
+                        <AccountIcon name={mailAccount.icon} className="size-4 text-white" />
                       </div>
-                    </TableCell>
-                    <TableCell className="text-center">
-                      <div className="flex justify-center">
-                        <Switch
-                          checked={mailAccount.isActive}
-                          onCheckedChange={() => handleToggleActive(mailAccount.id)}
-                        />
-                      </div>
-                    </TableCell>
-                    <TableCell className="text-center">
-                      <div className="flex justify-center">
-                        <Button variant="ghost" size="icon-sm" disabled>
-                          <Trash2 className="size-4 text-muted-foreground" />
-                        </Button>
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-        </section>
+                    ) : (
+                      "-"
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex flex-col">
+                      <span className="text-sm">{mailAccount.emailAddress}</span>
+                      <span className="text-xs text-muted-foreground">{mailAccount.alias}</span>
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <div className="flex justify-center">
+                      <Switch
+                        checked={mailAccount.isActive}
+                        onCheckedChange={() => handleToggleActive(mailAccount.id)}
+                      />
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <div className="flex justify-center">
+                      <Button variant="ghost" size="icon-sm" disabled>
+                        <Trash2 data-icon="inline-start" className="text-muted-foreground" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
 
-        {/* 계정 추가하기 */}
-        <section className="space-y-3">
-          <h2 className="text-lg font-semibold">계정 추가하기</h2>
-          <p className="text-sm text-muted-foreground">
-            아래 버튼을 눌러 계정의 별칭, 아이콘, 색상을 선택한 후 계정에 로그인하여 계정을 추가해보세요.
-          </p>
-          <div>
-            <AddAccountDialog>
-              <Button variant="outline" className="px-8">
-                <Plus className="size-4" />
-                계정 추가
-              </Button>
-            </AddAccountDialog>
-          </div>
-        </section>
-      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>계정 추가하기</CardTitle>
+          <CardDescription>
+            계정의 별칭, 아이콘, 색상을 선택한 뒤 로그인 절차를 거쳐 메일 계정을 연결할 수 있습니다.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <AddAccountDialog>
+            <Button variant="outline">
+              <Plus data-icon="inline-start" />
+              계정 추가
+            </Button>
+          </AddAccountDialog>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -1,4 +1,7 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { Link, createFileRoute } from "@tanstack/react-router"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
 
 export const Route = createFileRoute("/_authenticated/settings/")({
   component: SettingsPage,
@@ -6,9 +9,27 @@ export const Route = createFileRoute("/_authenticated/settings/")({
 
 function SettingsPage() {
   return (
-    <div className="p-8">
-      <h1 className="text-2xl font-bold">설정</h1>
-      <p className="mt-2 text-muted-foreground">계정 및 메일 설정을 관리합니다.</p>
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>설정 홈</CardTitle>
+          <CardDescription>메일상자 환경과 연결된 계정을 여기서 관리할 수 있습니다.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div>
+            <Button variant="outline" render={<Link to="/settings/account" />}>
+              계정 설정으로 이동
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>준비 중인 항목</CardTitle>
+          <CardDescription>알림 설정, 라벨 관리 같은 일반 설정은 이후 단계에서 추가될 예정입니다.</CardDescription>
+        </CardHeader>
+      </Card>
     </div>
   )
 }

--- a/src/types/email.ts
+++ b/src/types/email.ts
@@ -1,0 +1,74 @@
+export const PRIMARY_MAILBOX_IDS = ["INBOX", "SENT", "DRAFT", "SPAM", "TRASH"] as const
+export const SUPPORTED_MAILBOX_IDS = ["INBOX", "SENT"] as const
+
+export type PrimaryMailboxId = (typeof PRIMARY_MAILBOX_IDS)[number]
+export type SupportedMailboxId = (typeof SUPPORTED_MAILBOX_IDS)[number]
+
+export const MAILBOX_LABELS: Record<PrimaryMailboxId, string> = {
+  INBOX: "받은편지함",
+  SENT: "보낸편지함",
+  DRAFT: "임시보관함",
+  SPAM: "스팸함",
+  TRASH: "휴지통",
+}
+
+export function isSupportedMailboxId(mailboxId: PrimaryMailboxId): mailboxId is SupportedMailboxId {
+  return mailboxId === "INBOX" || mailboxId === "SENT"
+}
+
+export interface Attachment {
+  id: string
+  gmailAttachmentId: string
+  filename: string
+  mimeType: string
+  size: number
+}
+
+export interface InboxMessage {
+  id: string
+  gmailMessageId: string
+  subject: string
+  direction: "INBOUND" | "OUTBOUND"
+  fromAddress: string
+  toAddresses: string[]
+  ccAddresses: string[]
+  snippet: string
+  isRead: boolean
+  sentAt: string
+  bodyText: string
+  bodyHtml: string
+  attachments: Attachment[]
+}
+
+export interface InboxThreadSummary {
+  threadId: string
+  gmailThreadId: string
+  accountId: string
+  latestSubject: string
+  participantAddress: string
+  snippet: string
+  isRead: boolean
+  lastMessageAt: string
+  attachments: Attachment[]
+}
+
+export interface InboxThreadDetail {
+  threadId: string
+  gmailThreadId: string
+  accountId: string
+  latestSubject: string
+  isRead: boolean
+  lastMessageAt: string
+  messages: InboxMessage[]
+}
+
+export interface MarkerSliceResponse<T> {
+  content: T[]
+  nextMarker: string | null
+  hasNext: boolean
+}
+
+export interface ListThreadsParams {
+  marker?: string
+  size?: number
+}


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#4

### 📌 Task

- Closes #6
- #10 
- #11

## 💡 작업 내용

- `_authenticated` 레이아웃에 전역 사이드바를 도입하였습니다.
- 설정 페이지 내부 네비게이션을 탭 구조로 마이그레이션하였습니다.
- 인박스 목록 화면 및 상세보기 화면을 구현하였습니다.
- 이메일 관련 타입, 쿼리, mock API 및 mock 데이터를 추가해 인박스 UI 개발 기반을 구성했습니다.
- 린트 및 포매터 커밋 훅 구성을 추가하였습니다.

## 📝 추가 설명

- 현재 인박스 및 계정 데이터는 mock 데이터 기반으로 연결되어 있으며, 추후 실제 API 스펙 최종 확정 이후 교체 예정입니다.
- 데스크톱, 모바일 환경에서 헤더 및 사이드바 동작을 서로 다르게 정리하였습니다.
  - 데스크톱 화면에서는 상단 헤더 영역에 서비스명이 표시됩니다.
  - 모바일 화면에서는 상단 헤더 영역에 메뉴 버튼이 표시되며, 사이드바 패널을 열 수 있도록 구성하였습니다. 서비스명은 패널 내부에 표시됩니다.
- 인박스 화면을 표 기반 목록으로 구현하였습니다.
  - 데스크톱에서는 스레드 선택 시 우측 상세 패널이 열리는 UX를 적용했습니다.
  - 모바일 인박스에서는 목록과 상세가 전체 영역을 전환하는 방식으로 동작하도록 정리했습니다.
- 인박스 목록 및 메일 화면 상세 보기의 뷰 같은 경우에는 전반적인 레이아웃만 구조화하고, 임시로 구현해두었습니다. 세부적인 구성 요소나 디테일한 부분은 추후 수정이 필요합니다.

## 🖼️ 스크린샷

<img width="1265" height="735" alt="image" src="https://github.com/user-attachments/assets/793ea697-84ef-42c4-ba85-46a841b4aa16" />

데스크톱 인박스 목록 화면

<img width="1265" height="735" alt="image" src="https://github.com/user-attachments/assets/7fd51ed2-553a-4600-ab7c-b8c8e09ec153" />

데스크톱 메일 상세보기 화면

<img width="1265" height="914" alt="image" src="https://github.com/user-attachments/assets/f9d268c4-a017-46d7-b382-b83c639fd514" />

데스크톱 설정 화면

<img width="414" height="748" alt="image" src="https://github.com/user-attachments/assets/6b4d1968-5853-4d86-b04c-d7013318a475" />

모바일 인박스 목록 화면

<img width="414" height="748" alt="image" src="https://github.com/user-attachments/assets/32c3f961-0cba-4234-8bca-8b6f4b92d97d" />

모바일 패널 화면