### PR TITLE
[STORY-204] 메시지 및 스레드 삭제 구현

### DIFF
--- a/src/api/trash.ts
+++ b/src/api/trash.ts
@@ -1,0 +1,31 @@
+import { apiClient } from "@/lib/api-client"
+import type { MarkerSliceResponse, ListThreadsParams } from "@/types/email"
+import type { TrashThreadDetail, TrashThreadSummary } from "@/types/trash"
+
+export async function getTrashThreads(
+  params: ListThreadsParams = {}
+): Promise<MarkerSliceResponse<TrashThreadSummary>> {
+  return apiClient.get<MarkerSliceResponse<TrashThreadSummary>>("/api/v1/trash/threads", {
+    params: params as Record<string, string | number | boolean | null | undefined>,
+  })
+}
+
+export async function getTrashThreadDetail(threadId: string): Promise<TrashThreadDetail> {
+  return apiClient.get<TrashThreadDetail>(`/api/v1/trash/threads/${threadId}`)
+}
+
+export async function deleteThread(threadId: string): Promise<void> {
+  return apiClient.delete<void>(`/api/v1/threads/${threadId}`)
+}
+
+export async function deleteMessage(messageId: string): Promise<void> {
+  return apiClient.delete<void>(`/api/v1/messages/${messageId}`)
+}
+
+export async function restoreTrashThread(threadId: string): Promise<void> {
+  return apiClient.post<void>(`/api/v1/trash/threads/${threadId}/restore`)
+}
+
+export async function restoreTrashMessage(messageId: string): Promise<void> {
+  return apiClient.post<void>(`/api/v1/trash/messages/${messageId}/restore`)
+}

--- a/src/components/inbox/email-detail.tsx
+++ b/src/components/inbox/email-detail.tsx
@@ -91,7 +91,7 @@ function EmptyState() {
 function LoadingState() {
   return (
     <div className="flex h-full flex-col">
-      <div className="flex h-11 shrink-0 items-center justify-between gap-2 border-b px-4">
+      <div className="flex h-11 shrink-0 items-center justify-between gap-2 px-4">
         <Skeleton className="h-4 w-24" />
         <div className="flex items-center gap-1">
           {Array.from({ length: 4 }).map((_, index) => (
@@ -139,7 +139,7 @@ export function EmailDetail({ threadId, onClose }: EmailDetailProps) {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex h-11 shrink-0 items-center gap-2 border-b px-4">
+      <div className="flex h-11 shrink-0 items-center gap-2 px-4">
         {/*<span className="min-w-0 truncate text-sm font-medium">대화 상세</span>*/}
         <div className="flex w-full justify-between">
           {onClose ? (

--- a/src/components/inbox/email-detail.tsx
+++ b/src/components/inbox/email-detail.tsx
@@ -1,15 +1,16 @@
-import { Archive, ArrowLeft, Forward, MailOpen, Paperclip, Reply, Trash2 } from "lucide-react"
+import { Archive, ArrowLeft, Forward, MailOpen, MoreVertical, Paperclip, Reply, Trash2 } from "lucide-react"
 import { toast } from "sonner"
 
 import { EmailErrorState } from "@/components/inbox/email-error-state"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { getErrorMessage, getHttpStatus } from "@/lib/http-error"
 import { formatMailAddressList, getMailAddressFullLabel, getMailAddressLabel } from "@/lib/mail-address"
-import { useDeleteThread, useRestoreTrashThread } from "@/mutations/trash"
+import { useDeleteMessage, useDeleteThread, useRestoreTrashMessage, useRestoreTrashThread } from "@/mutations/trash"
 import { useThread } from "@/queries/emails"
 import type { InboxMessage, MailAddress } from "@/types/email"
 
@@ -126,6 +127,38 @@ export function EmailDetail({ threadId, onClose }: EmailDetailProps) {
   const { data: thread, isLoading, isError, error, refetch } = useThread(threadId)
   const { mutate: deleteThread, isPending: isDeleting } = useDeleteThread()
   const { mutate: restoreThread } = useRestoreTrashThread()
+  const { mutate: deleteMessage } = useDeleteMessage()
+  const { mutate: restoreMessage } = useRestoreTrashMessage()
+
+  const handleDeleteMessage = (messageId: string, isLast: boolean) => {
+    deleteMessage(messageId, {
+      onSuccess: () => {
+        if (isLast) onClose?.()
+        toast("메시지를 휴지통으로 옮겼습니다", {
+          action: {
+            label: "실행 취소",
+            onClick: () => {
+              restoreMessage(messageId, {
+                onSuccess: () => {
+                  toast.success("삭제가 취소되었습니다")
+                },
+                onError: (err) => {
+                  toast.error("삭제 취소에 실패했습니다", {
+                    description: getErrorMessage(err, "잠시 후 다시 시도해주세요."),
+                  })
+                },
+              })
+            },
+          },
+        })
+      },
+      onError: (err) => {
+        toast.error("메시지 삭제에 실패했습니다", {
+          description: getErrorMessage(err, "잠시 후 다시 시도해주세요."),
+        })
+      },
+    })
+  }
 
   const handleDelete = () => {
     if (!threadId) return
@@ -136,8 +169,16 @@ export function EmailDetail({ threadId, onClose }: EmailDetailProps) {
           action: {
             label: "실행 취소",
             onClick: () => {
-              restoreThread(threadId)
-              toast.success("삭제가 취소되었습니다")
+              restoreThread(threadId, {
+                onSuccess: () => {
+                  toast.success("삭제가 취소되었습니다")
+                },
+                onError: (err) => {
+                  toast.error("삭제 취소에 실패했습니다", {
+                    description: getErrorMessage(err, "잠시 후 다시 시도해주세요."),
+                  })
+                },
+              })
             },
           },
         })
@@ -226,19 +267,34 @@ export function EmailDetail({ threadId, onClose }: EmailDetailProps) {
                   <AvatarFallback>{getInitials(getMailAddressLabel(message.from))}</AvatarFallback>
                 </Avatar>
                 <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center justify-between gap-2">
-                    <div>
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
                         <p className="text-sm font-medium">{getMailAddressFullLabel(message.from)}</p>
                         <Badge variant="outline">{message.direction === "INBOUND" ? "수신" : "발신"}</Badge>
                       </div>
                       <p className="truncate text-xs text-muted-foreground">{message.subject}</p>
                     </div>
-                    <span className="shrink-0 text-xs text-muted-foreground">{formatDate(message.sentAt)}</span>
+                    <div className="flex shrink-0 items-start">
+                      <DropdownMenu>
+                        <DropdownMenuTrigger
+                          render={<Button variant="ghost" size="icon-sm" aria-label="메시지 더보기" />}
+                        >
+                          <MoreVertical className="size-4" />
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onClick={() => handleDeleteMessage(message.id, messages.length === 1)}>
+                            <Trash2 className="size-4" />
+                            삭제
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
                   </div>
                   <p className="mt-1 text-xs text-muted-foreground">
                     받는 사람: {message.to.length > 0 ? formatMailAddressList(message.to) : "-"}
                   </p>
+                  <p className="mt-1 text-xs text-muted-foreground">{formatDate(message.sentAt)}</p>
                   {message.cc.length > 0 ? (
                     <p className="mt-1 text-xs text-muted-foreground">참조: {formatMailAddressList(message.cc)}</p>
                   ) : null}

--- a/src/components/inbox/email-detail.tsx
+++ b/src/components/inbox/email-detail.tsx
@@ -1,4 +1,4 @@
-import { Archive, Forward, MailOpen, Paperclip, Reply, Trash2, X } from "lucide-react"
+import { Archive, ArrowLeft, Forward, MailOpen, Paperclip, Reply, Trash2} from "lucide-react"
 
 import { EmailErrorState } from "@/components/inbox/email-error-state"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
@@ -141,24 +141,26 @@ export function EmailDetail({ threadId, onClose }: EmailDetailProps) {
     <div className="flex h-full flex-col">
       <div className="flex h-11 shrink-0 items-center gap-2 border-b px-4">
         {/*<span className="min-w-0 truncate text-sm font-medium">대화 상세</span>*/}
-        <div className="ml-auto flex items-center gap-1">
-          <Button variant="ghost" size="icon-sm" disabled title="답장 기능은 아직 지원되지 않습니다.">
-            <Reply className="size-4" />
-          </Button>
-          <Button variant="ghost" size="icon-sm" disabled title="전달 기능은 아직 지원되지 않습니다.">
-            <Forward className="size-4" />
-          </Button>
-          <Button variant="ghost" size="icon-sm" disabled title="보관 기능은 아직 지원되지 않습니다.">
-            <Archive className="size-4" />
-          </Button>
-          <Button variant="ghost" size="icon-sm" disabled title="삭제 기능은 아직 지원되지 않습니다.">
-            <Trash2 className="size-4" />
-          </Button>
+        <div className="flex w-full justify-between">
           {onClose ? (
             <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="상세보기 닫기" className="-mr-2">
-              <X className="size-4" />
+              <ArrowLeft className="size-4" />
             </Button>
           ) : null}
+          <div className="ml-auto flex items-center gap-1">
+            <Button variant="ghost" size="icon-sm" disabled title="답장 기능은 아직 지원되지 않습니다.">
+              <Reply className="size-4" />
+            </Button>
+            <Button variant="ghost" size="icon-sm" disabled title="전달 기능은 아직 지원되지 않습니다.">
+              <Forward className="size-4" />
+            </Button>
+            <Button variant="ghost" size="icon-sm" disabled title="보관 기능은 아직 지원되지 않습니다.">
+              <Archive className="size-4" />
+            </Button>
+            <Button variant="ghost" size="icon-sm" disabled title="삭제 기능은 아직 지원되지 않습니다.">
+              <Trash2 className="size-4" />
+            </Button>
+          </div>
         </div>
       </div>
 

--- a/src/components/inbox/email-detail.tsx
+++ b/src/components/inbox/email-detail.tsx
@@ -1,4 +1,5 @@
-import { Archive, ArrowLeft, Forward, MailOpen, Paperclip, Reply, Trash2} from "lucide-react"
+import { Archive, ArrowLeft, Forward, MailOpen, Paperclip, Reply, Trash2 } from "lucide-react"
+import { toast } from "sonner"
 
 import { EmailErrorState } from "@/components/inbox/email-error-state"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
@@ -8,6 +9,7 @@ import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { getErrorMessage, getHttpStatus } from "@/lib/http-error"
 import { formatMailAddressList, getMailAddressFullLabel, getMailAddressLabel } from "@/lib/mail-address"
+import { useDeleteThread, useRestoreTrashThread } from "@/mutations/trash"
 import { useThread } from "@/queries/emails"
 import type { InboxMessage, MailAddress } from "@/types/email"
 
@@ -122,6 +124,31 @@ interface EmailDetailProps {
 
 export function EmailDetail({ threadId, onClose }: EmailDetailProps) {
   const { data: thread, isLoading, isError, error, refetch } = useThread(threadId)
+  const { mutate: deleteThread, isPending: isDeleting } = useDeleteThread()
+  const { mutate: restoreThread } = useRestoreTrashThread()
+
+  const handleDelete = () => {
+    if (!threadId) return
+    deleteThread(threadId, {
+      onSuccess: () => {
+        onClose?.()
+        toast("메일을 휴지통으로 옮겼습니다", {
+          action: {
+            label: "실행 취소",
+            onClick: () => {
+              restoreThread(threadId)
+              toast.success("삭제가 취소되었습니다")
+            },
+          },
+        })
+      },
+      onError: (err) => {
+        toast.error("메일 삭제에 실패했습니다", {
+          description: getErrorMessage(err, "잠시 후 다시 시도해주세요."),
+        })
+      },
+    })
+  }
 
   if (!threadId) return <EmptyState />
   if (isLoading) return <LoadingState />
@@ -157,7 +184,14 @@ export function EmailDetail({ threadId, onClose }: EmailDetailProps) {
             <Button variant="ghost" size="icon-sm" disabled title="보관 기능은 아직 지원되지 않습니다.">
               <Archive className="size-4" />
             </Button>
-            <Button variant="ghost" size="icon-sm" disabled title="삭제 기능은 아직 지원되지 않습니다.">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={handleDelete}
+              disabled={isDeleting}
+              title="삭제"
+              aria-label="메일 삭제"
+            >
               <Trash2 className="size-4" />
             </Button>
           </div>

--- a/src/components/inbox/email-list-header.tsx
+++ b/src/components/inbox/email-list-header.tsx
@@ -1,3 +1,6 @@
+import { Tag, Trash2, SquareMinus } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
 import { Toggle } from "@/components/ui/toggle"
 import { cn } from "@/lib/utils"
 
@@ -13,9 +16,41 @@ interface EmailListHeaderProps {
   threadCount: number
   filter: EmailFilter
   onFilterChange: (filter: EmailFilter) => void
+  selectedCount: number
+  onClearSelection: () => void
+  onDeleteSelected: () => void
+  onLabelSelected: () => void
 }
 
-export function EmailListHeader({ mailboxName, threadCount, filter, onFilterChange }: EmailListHeaderProps) {
+export function EmailListHeader({
+  mailboxName,
+  threadCount,
+  filter,
+  onFilterChange,
+  selectedCount,
+  onClearSelection,
+  onDeleteSelected,
+  onLabelSelected,
+}: EmailListHeaderProps) {
+  if (selectedCount > 0) {
+    return (
+      <div className="flex h-11 shrink-0 items-center gap-2 border-b bg-accent/40 px-3">
+        <Button variant="ghost" size="icon-sm" onClick={onClearSelection} aria-label="선택 해제">
+          <SquareMinus />
+        </Button>
+        <span className="text-sm font-medium">{selectedCount.toLocaleString()}개 선택됨</span>
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          <Button variant="ghost" size="icon-sm" onClick={onDeleteSelected} aria-label="선택 삭제">
+            <Trash2 data-icon="inline-start" />
+          </Button>
+          <Button variant="ghost" size="icon-sm" onClick={onLabelSelected} aria-label="라벨 지정">
+            <Tag data-icon="inline-start" />
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="flex h-11 shrink-0 items-center gap-3 border-b px-4">
       <h2 className="min-w-0 truncate text-sm font-medium">{mailboxName}</h2>

--- a/src/components/inbox/email-list-item.tsx
+++ b/src/components/inbox/email-list-item.tsx
@@ -129,14 +129,7 @@ function EmailListItemPreview({ thread, participantLabel }: EmailListItemPreview
   )
 }
 
-export function EmailListItem({
-  thread,
-  isSelected,
-  isChecked,
-  account,
-  onSelect,
-  onToggleCheck,
-}: EmailListItemProps) {
+export function EmailListItem({ thread, isSelected, isChecked, account, onSelect, onToggleCheck }: EmailListItemProps) {
   const isMobile = useIsMobile()
   const [open, setOpen] = useState(false)
   const [anchor, setAnchor] = useState<PopoverPrimitive.Positioner.Props["anchor"]>(null)

--- a/src/components/inbox/email-list-item.tsx
+++ b/src/components/inbox/email-list-item.tsx
@@ -3,27 +3,34 @@ import { Paperclip } from "lucide-react"
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
 
 import { Badge } from "@/components/ui/badge"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Separator } from "@/components/ui/separator"
 import { TableCell, TableRow } from "@/components/ui/table"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { formatFullDateTime, formatRelativeDate } from "@/lib/date"
+import { AccountIcon } from "@/lib/icon-entries"
 import { getMailAddressLabel } from "@/lib/mail-address"
 import { cn } from "@/lib/utils"
 import type { InboxThreadSummary } from "@/types/email"
+import type { MailAccount } from "@/types/mail-account"
 
 interface EmailListItemProps {
   thread: InboxThreadSummary
   isSelected: boolean
-  accountColor?: string
+  isChecked: boolean
+  account?: MailAccount
   onSelect: () => void
+  onToggleCheck: () => void
 }
 
 interface EmailListItemCellsProps {
   thread: InboxThreadSummary
   isUnread: boolean
-  accountColor?: string
+  isChecked: boolean
+  account?: MailAccount
   participantLabel: string
+  onToggleCheck: () => void
 }
 
 interface EmailListItemPreviewProps {
@@ -42,17 +49,35 @@ function createCursorAnchor(
   }
 }
 
-function EmailListItemCells({ thread, isUnread, accountColor, participantLabel }: EmailListItemCellsProps) {
+function EmailListItemCells({
+  thread,
+  isUnread,
+  isChecked,
+  account,
+  participantLabel,
+  onToggleCheck,
+}: EmailListItemCellsProps) {
   const hasAttachments = thread.attachments.length > 0
 
   return (
     <>
+      <TableCell onClick={(event) => event.stopPropagation()}>
+        <div className="flex justify-center">
+          <Checkbox checked={isChecked} onCheckedChange={onToggleCheck} aria-label="메일 선택" />
+        </div>
+      </TableCell>
       <TableCell>
-        <div className="flex items-center gap-2">
-          <span className={cn("size-2.5 rounded-full", isUnread ? "bg-primary" : "bg-transparent")} />
-          {accountColor ? (
-            <span className="hidden size-2 rounded-full md:inline-flex" style={{ backgroundColor: accountColor }} />
-          ) : null}
+        <div className="flex justify-center">
+          {account?.icon ? (
+            <div
+              className="flex size-7 items-center justify-center rounded-full"
+              style={{ backgroundColor: account.color || "#6B7280" }}
+            >
+              <AccountIcon name={account.icon} className="size-3.5 text-white" />
+            </div>
+          ) : (
+            <span className={cn("size-2.5 rounded-full", isUnread ? "bg-primary" : "bg-transparent")} />
+          )}
         </div>
       </TableCell>
       <TableCell className="truncate">
@@ -104,7 +129,14 @@ function EmailListItemPreview({ thread, participantLabel }: EmailListItemPreview
   )
 }
 
-export function EmailListItem({ thread, isSelected, accountColor, onSelect }: EmailListItemProps) {
+export function EmailListItem({
+  thread,
+  isSelected,
+  isChecked,
+  account,
+  onSelect,
+  onToggleCheck,
+}: EmailListItemProps) {
   const isMobile = useIsMobile()
   const [open, setOpen] = useState(false)
   const [anchor, setAnchor] = useState<PopoverPrimitive.Positioner.Props["anchor"]>(null)
@@ -146,8 +178,10 @@ export function EmailListItem({ thread, isSelected, accountColor, onSelect }: Em
         <EmailListItemCells
           thread={thread}
           isUnread={isUnread}
-          accountColor={accountColor}
+          isChecked={isChecked}
+          account={account}
           participantLabel={participantLabel}
+          onToggleCheck={onToggleCheck}
         />
       </TableRow>
     )

--- a/src/components/inbox/email-list.tsx
+++ b/src/components/inbox/email-list.tsx
@@ -1,14 +1,17 @@
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 import { InboxIcon } from "lucide-react"
+import { toast } from "sonner"
 
 import { EmailErrorState } from "@/components/inbox/email-error-state"
 import { EmailListHeader } from "@/components/inbox/email-list-header"
 import type { EmailFilter } from "@/components/inbox/email-list-header"
 import { EmailListItem } from "@/components/inbox/email-list-item"
+import { useDeleteThread, useRestoreTrashThread } from "@/mutations/trash"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table"
 import type { InboxThreadSummary } from "@/types/email"
+import type { MailAccount } from "@/types/mail-account"
 
 interface EmailListProps {
   mailboxName: string
@@ -21,7 +24,7 @@ interface EmailListProps {
   onFilterChange: (filter: EmailFilter) => void
   onSelectThread: (id: string) => void
   onLoadMore: () => void
-  getAccountColor: (accountId: string) => string | undefined
+  getAccount: (accountId: string) => MailAccount | undefined
   emptyTitle?: string
   emptyDescription?: string
   errorTitle?: string
@@ -35,6 +38,9 @@ interface EmailListProps {
 function LoadingRows() {
   return Array.from({ length: 10 }).map((_, index) => (
     <TableRow key={index}>
+      <TableCell className="w-10">
+        <Skeleton className="size-2.5 rounded-full" />
+      </TableCell>
       <TableCell className="w-10">
         <Skeleton className="size-2.5 rounded-full" />
       </TableCell>
@@ -65,7 +71,7 @@ export function EmailList({
   onFilterChange,
   onSelectThread,
   onLoadMore,
-  getAccountColor,
+  getAccount,
   emptyTitle = "메일이 없습니다",
   emptyDescription,
   errorTitle,
@@ -76,6 +82,21 @@ export function EmailList({
   onRetryLoadMore,
 }: EmailListProps) {
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const { mutate: deleteThread } = useDeleteThread()
+  const { mutate: restoreThread } = useRestoreTrashThread()
+
+  const toggleSelected = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
 
   useEffect(() => {
     const node = loadMoreRef.current
@@ -105,20 +126,31 @@ export function EmailList({
         threadCount={threads?.length ?? 0}
         filter={filter}
         onFilterChange={onFilterChange}
+        selectedCount={selectedIds.size}
+        onClearSelection={() => setSelectedIds(new Set())}
+        onDeleteSelected={() => {
+          const ids = Array.from(selectedIds)
+          if (ids.length === 0) return
+          setSelectedIds(new Set())
+          ids.forEach((id) => deleteThread(id))
+          toast(`${ids.length}개 메일을 휴지통으로 옮겼습니다`, {
+            action: {
+              label: "실행 취소",
+              onClick: () => {
+                ids.forEach((id) => restoreThread(id))
+                toast.success("삭제가 취소되었습니다")
+              },
+            },
+          })
+        }}
+        onLabelSelected={() => {
+          toast.info("라벨 기능은 준비 중입니다")
+        }}
       />
 
       <ScrollArea className="min-h-0 flex-1">
         {isLoading ? (
           <Table className="table-fixed">
-            <TableHeader className="sticky top-0 z-10 bg-background">
-              <TableRow>
-                <TableHead className="w-10">상태</TableHead>
-                <TableHead className="w-[22%]">보낸 사람</TableHead>
-                <TableHead className="w-[58%]">제목</TableHead>
-                <TableHead className="hidden w-14 text-center md:table-cell">첨부</TableHead>
-                <TableHead className="w-24 text-right">시간</TableHead>
-              </TableRow>
-            </TableHeader>
             <TableBody>
               <LoadingRows />
             </TableBody>
@@ -128,15 +160,14 @@ export function EmailList({
         ) : threads && threads.length > 0 ? (
           <>
             <Table className="table-fixed">
-              <TableHeader className="sticky top-0 z-10 bg-background">
-                <TableRow>
-                  <TableHead className="w-10">상태</TableHead>
-                  <TableHead className="w-[28%] md:w-[22%]">보낸 사람</TableHead>
-                  <TableHead className="w-[52%] md:w-[58%]">제목</TableHead>
-                  <TableHead className="hidden w-14 text-center md:table-cell">첨부</TableHead>
-                  <TableHead className="w-24 text-right">시간</TableHead>
-                </TableRow>
-              </TableHeader>
+              <colgroup>
+                <col className="w-10" />
+                <col className="w-10" />
+                <col className="w-[28%] md:w-[22%]" />
+                <col className="w-[52%] md:w-[58%]" />
+                <col className="hidden w-14 md:table-column" />
+                <col className="w-24" />
+              </colgroup>
               <TableBody>
                 {threads.map((thread) => {
                   return (
@@ -144,8 +175,10 @@ export function EmailList({
                       key={thread.threadId}
                       thread={thread}
                       isSelected={selectedThreadId === thread.threadId}
-                      accountColor={getAccountColor(thread.accountId)}
+                      isChecked={selectedIds.has(thread.threadId)}
+                      account={getAccount(thread.accountId)}
                       onSelect={() => onSelectThread(thread.threadId)}
+                      onToggleCheck={() => toggleSelected(thread.threadId)}
                     />
                   )
                 })}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -10,7 +10,7 @@ function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs outline-none transition-shadow focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground data-disabled:cursor-not-allowed data-disabled:opacity-50 data-indeterminate:border-primary data-indeterminate:bg-primary data-indeterminate:text-primary-foreground",
+        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-indeterminate:border-primary data-indeterminate:bg-primary data-indeterminate:text-primary-foreground data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground data-disabled:cursor-not-allowed data-disabled:opacity-50",
         className
       )}
       {...props}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs outline-none transition-shadow focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground data-disabled:cursor-not-allowed data-disabled:opacity-50 data-indeterminate:border-primary data-indeterminate:bg-primary data-indeterminate:text-primary-foreground",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current"
+      >
+        <Check className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -424,7 +424,7 @@ function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
     <ul
       data-slot="sidebar-menu"
       data-sidebar="menu"
-      className={cn("flex w-full min-w-0 flex-col gap-0", className)}
+      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
       {...props}
     />
   )

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -354,7 +354,7 @@ function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="sidebar-group"
       data-sidebar="group"
-      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      className={cn("relative flex w-full min-w-0 flex-col px-2", className)}
       {...props}
     />
   )

--- a/src/index.css
+++ b/src/index.css
@@ -72,7 +72,7 @@
   --foreground: oklch(0.3438 0.0269 95.7226);
   --card: oklch(0.997 0.0041 91.4451);
   --card-foreground: oklch(0.1908 0.002 106.5859);
-  --popover: oklch(1 0 0);
+  --popover: oklch(0.997 0.0041 91.4451);
   --popover-foreground: oklch(0.2671 0.0196 98.939);
   --primary: oklch(0.6171 0.1375 39.0427);
   --primary-foreground: oklch(1 0 0);
@@ -234,6 +234,8 @@
   }
   body {
     @apply bg-background text-foreground;
+
+    font-family: var(--font-sans);
   }
   html {
     scrollbar-gutter: stable;

--- a/src/mutations/trash.ts
+++ b/src/mutations/trash.ts
@@ -1,0 +1,46 @@
+import { useMutation } from "@tanstack/react-query"
+
+import { deleteMessage, deleteThread, restoreTrashMessage, restoreTrashThread } from "@/api/trash"
+import { queryClient } from "@/lib/query-client"
+import { emailKeys } from "@/queries/emails"
+import { trashKeys } from "@/queries/trash"
+
+function invalidateMailboxesAndTrash() {
+  void queryClient.invalidateQueries({ queryKey: emailKeys.all() })
+  void queryClient.invalidateQueries({ queryKey: trashKeys.all() })
+}
+
+export const trashMutationOptions = {
+  deleteThread: () => ({
+    mutationFn: (threadId: string) => deleteThread(threadId),
+    onSuccess: invalidateMailboxesAndTrash,
+  }),
+  deleteMessage: () => ({
+    mutationFn: (messageId: string) => deleteMessage(messageId),
+    onSuccess: invalidateMailboxesAndTrash,
+  }),
+  restoreThread: () => ({
+    mutationFn: (threadId: string) => restoreTrashThread(threadId),
+    onSuccess: invalidateMailboxesAndTrash,
+  }),
+  restoreMessage: () => ({
+    mutationFn: (messageId: string) => restoreTrashMessage(messageId),
+    onSuccess: invalidateMailboxesAndTrash,
+  }),
+}
+
+export function useDeleteThread() {
+  return useMutation(trashMutationOptions.deleteThread())
+}
+
+export function useDeleteMessage() {
+  return useMutation(trashMutationOptions.deleteMessage())
+}
+
+export function useRestoreTrashThread() {
+  return useMutation(trashMutationOptions.restoreThread())
+}
+
+export function useRestoreTrashMessage() {
+  return useMutation(trashMutationOptions.restoreMessage())
+}

--- a/src/queries/trash.ts
+++ b/src/queries/trash.ts
@@ -1,0 +1,28 @@
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
+
+import { getTrashThreadDetail, getTrashThreads } from "@/api/trash"
+
+export const trashKeys = {
+  all: () => ["trash"] as const,
+  list: (size: number) => [...trashKeys.all(), "list", size] as const,
+  thread: (id: string) => [...trashKeys.all(), "thread", id] as const,
+}
+
+export function useTrashThreads(options: { size?: number } = {}) {
+  const size = options.size ?? 50
+
+  return useInfiniteQuery({
+    queryKey: trashKeys.list(size),
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam }) => getTrashThreads({ marker: pageParam, size }),
+    getNextPageParam: (lastPage) => lastPage.nextMarker ?? undefined,
+  })
+}
+
+export function useTrashThread(id: string | null) {
+  return useQuery({
+    queryKey: trashKeys.thread(id ?? ""),
+    queryFn: () => getTrashThreadDetail(id!),
+    enabled: id != null,
+  })
+}

--- a/src/routes/_authenticated/inbox.tsx
+++ b/src/routes/_authenticated/inbox.tsx
@@ -85,8 +85,8 @@ function InboxPage() {
   const mailboxErrorCopy = isError ? getMailboxThreadsErrorCopy(error) : null
   const loadMoreErrorCopy = isFetchNextPageError ? getMailboxThreadsErrorCopy(error) : null
 
-  const getAccountColor = (accountId: string) => {
-    return accounts?.find((account) => account.id === accountId)?.color
+  const getAccount = (accountId: string) => {
+    return accounts?.find((account) => account.id === accountId)
   }
 
   const visibleSelectedThreadId = threads.some((thread) => thread.threadId === selectedThreadId)
@@ -124,7 +124,7 @@ function InboxPage() {
           void fetchNextPage()
         }
       }}
-      getAccountColor={getAccountColor}
+      getAccount={getAccount}
       emptyTitle={emptyTitle}
       emptyDescription={emptyDescription}
       errorTitle={supportedMailbox && isError && threads.length === 0 ? mailboxErrorCopy?.title : undefined}

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -61,7 +61,7 @@ function SettingsAccountPage() {
   }
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-6 pb-6">
       <Card>
         <CardHeader>
           <CardTitle>계정 정보</CardTitle>

--- a/src/types/trash.ts
+++ b/src/types/trash.ts
@@ -1,0 +1,27 @@
+export interface TrashMessage {
+  messageId: string
+  gmailMessageId: string
+  direction: "INBOUND" | "OUTBOUND"
+  subject: string
+  fromAddress: string
+  toAddresses: string[]
+  snippet: string
+  sentAt: string
+  deletedAt: string
+}
+
+export interface TrashThreadSummary {
+  threadId: string
+  gmailThreadId: string
+  accountId: string
+  accountEmail: string
+  deletedMessages: TrashMessage[]
+}
+
+export interface TrashThreadDetail {
+  threadId: string
+  gmailThreadId: string
+  accountId: string
+  accountEmail: string
+  messages: TrashMessage[]
+}


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#7

### 📌 Task

- Closes #17 
- Closes #18 

## 💡 작업 내용

- UI
  - 메일 리스트 체크박스 추가
  - 메일 선택 시 메일 헤더 UI 구현
  - sonner toast 알림 구현
  - 메일 목록 테이블 헤더 제거

- 삭제 기능
  - 메시지 삭제 기능 구현
  - 스레드 삭제 기능 구현
  - trash type 및 관련 API 코드 구현

## 📝 추가 설명

- 삭제 기능은 메시지 /스레드 단위로 분리 구현
- 삭제 후 toast 알림 적용
- 휴지통 연동을 위해 trash type 및 API 처리 로직 추가
- UI 정리(테이블 헤더 제거, 하단 여백 조정)로 목록 가독성 개선

### TODO

- 휴지통 리스트는 추후에 PR 한 번 더 올릴 예정입니다.
- 현재 체크박스를 선택한 상태에서 사이드바를 통해 다른 페이지로 이동하면 `email-list-header`의 상태가 그대로 유지되는 문제가 있습니다. 이 부분은 당장 수정하기보다, 추후 사이드바에 라우팅 기능(#inbox, #sent 등)을 작업할 때 함께 처리하여 개선하는 방향을 제안합니다.
- 메일 스레드를 삭제할 때 삭제하는 스레드의 수 만큼 요청이 발생하는 문제가 발생합니다. 이를 현재는 `forEach`로 처리하고, 추후에 다중 메일 삭제 API가 구현되면 바꾸는 것으로 제안합니다. 

  ``` typescript
          setSelectedIds(new Set())
          ids.forEach((id) => deleteThread(id))
          toast(`${ids.length}개 메일을 휴지통으로 옮겼습니다`, {
            action: {
              label: "실행 취소",
              onClick: () => {
                ids.forEach((id) => restoreThread(id))
                toast.success("삭제가 취소되었습니다")
  ```

## 🖼️ 스크린샷

- 메일 리스트 헤더 UI

| 선택 전 | 선택 후 |
| -- | -- |
| <img width="1608" height="862" alt="image" src="https://github.com/user-attachments/assets/d6d9bfb1-7ca6-4f4b-8b59-ac63ec32bc4b" /> | <img width="1611" height="860" alt="image" src="https://github.com/user-attachments/assets/2de67b3f-ea54-4479-9fb4-c87a15a9116d" /> |

- 삭제 및 undo 토스트 UI

| 삭제 toast | undo toast |
| -- | -- |
| <img width="517" height="187" alt="image" src="https://github.com/user-attachments/assets/fa11cb96-e9bb-40b5-b8fb-df580c17c42b" /> | <img width="517" height="139" alt="image" src="https://github.com/user-attachments/assets/9a38f550-9f8f-46bb-85ea-ce8495696dfa" /> |


- 체크박스 상태 유지 문제

| | |
| -- | -- |
| <img width="776" height="382" alt="image" src="https://github.com/user-attachments/assets/32c0a9b0-b4e0-434f-8b52-9ff7b1873f6a" />  | <img width="779" height="351" alt="image" src="https://github.com/user-attachments/assets/797f6bef-66e1-410c-ac12-7eea1b65e90b" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 휴지통(삭제/복원) 기능 추가 — 스레드 및 개별 메시지 삭제·복원 지원
  * 선택한 여러 이메일 일괄 삭제 및 실행 취소 토스트 제공
  * 상세보기에서 뒤로(Arrow) 내비게이션 및 각 메시지 ‘더보기’ 메뉴 추가

* **스타일**
  * 체크박스 컴포넌트 및 계정 아바타 개선
  * 기본 폰트와 팝오버 색상 조정, 사이드바 간격·설정 페이지 패딩 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->