### PR TITLE
[STORY-203] 메일 읽음 처리 및 안읽음 강조 표시 구현

### DIFF
--- a/src/api/emails.ts
+++ b/src/api/emails.ts
@@ -53,6 +53,10 @@ export async function getThreadDetail(threadId: string): Promise<InboxThreadDeta
   return normalizeThreadDetail(response)
 }
 
+export async function markThreadAsRead(threadId: string): Promise<void> {
+  return apiClient.post<void>(`/api/v1/threads/${threadId}/read`)
+}
+
 export async function getUnreadCount(): Promise<UnreadCountResponse> {
   return apiClient.get<UnreadCountResponse>("/api/v1/threads/inbox/unread-count")
 }

--- a/src/components/inbox/email-detail.tsx
+++ b/src/components/inbox/email-detail.tsx
@@ -207,7 +207,7 @@ function AttachmentChip({ attachment }: AttachmentChipProps) {
 function MessageBodyFrame({ html }: { html: string }) {
   const [height, setHeight] = useState(0)
 
-  const srcDoc = `<!doctype html><html><head><meta charset="utf-8"><base target="_blank"><style>html,body{margin:0;padding:0;font-family:ui-sans-serif,system-ui,sans-serif;font-size:14px;color:#111;word-break:break-word;overflow-wrap:anywhere}img{max-width:100%;height:auto}</style></head><body>${html}</body></html>`
+  const srcDoc = `<!doctype html><html><head><meta charset="utf-8"><base target="_blank"><style>html,body{margin:0;padding:0;font-family:ui-sans-serif,system-ui,sans-serif;font-size:14px;color:#111;word-break:break-word;overflow-wrap:anywhere;overflow:hidden}img{max-width:100%;height:auto}</style></head><body>${html}</body></html>`
 
   return (
     <iframe

--- a/src/components/inbox/email-list-item.tsx
+++ b/src/components/inbox/email-list-item.tsx
@@ -136,9 +136,10 @@ export function EmailListItem({ thread, isSelected, isChecked, account, onSelect
   const isUnread = !thread.isRead
   const participantLabel = getMailAddressLabel(thread.participant)
   const rowClassName = cn(
-    "cursor-pointer",
-    isUnread && "bg-accent/20 font-medium",
-    isSelected && "bg-accent hover:bg-accent"
+    "cursor-pointer border-l-2 transition-colors",
+    isSelected ? "border-l-primary bg-accent" : "border-l-transparent",
+    isUnread ? "font-semibold hover:bg-accent" : "bg-accent/50 hover:bg-accent",
+    isSelected && "hover:bg-accent"
   )
 
   const updateAnchor = (event: React.PointerEvent<HTMLTableRowElement>) => {

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -35,7 +35,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-accent/50",
         className
       )}
       {...props}

--- a/src/mutations/emails.ts
+++ b/src/mutations/emails.ts
@@ -1,0 +1,18 @@
+import { useMutation } from "@tanstack/react-query"
+import { toast } from "sonner"
+
+import { markThreadAsRead } from "@/api/emails"
+import { queryClient } from "@/lib/query-client"
+import { emailKeys } from "@/queries/emails"
+
+export function useMarkThreadAsRead() {
+  return useMutation({
+    mutationFn: (threadId: string) => markThreadAsRead(threadId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: emailKeys.all() })
+    },
+    onError: () => {
+      toast.error("읽음 처리에 실패했습니다")
+    },
+  })
+}

--- a/src/routes/_authenticated/mail/$mailbox.tsx
+++ b/src/routes/_authenticated/mail/$mailbox.tsx
@@ -10,6 +10,7 @@ import { getErrorMessage, getHttpStatus } from "@/lib/http-error"
 import { parseMailRouteSearch } from "@/lib/mail-routing"
 import { getMailAddressSearchText } from "@/lib/mail-address"
 import { cn } from "@/lib/utils"
+import { useMarkThreadAsRead } from "@/mutations/emails"
 import { useMailAccounts } from "@/queries/mail-accounts"
 import { useMailboxThreads } from "@/queries/emails"
 import { isSupportedMailboxId, MAILBOX_LABELS, parseMailboxId } from "@/types/email"
@@ -65,6 +66,7 @@ function MailboxPage() {
   const navigate = Route.useNavigate()
   const isMobile = useIsMobile()
   const { data: accounts } = useMailAccounts()
+  const { mutate: markAsRead } = useMarkThreadAsRead()
   const supportedMailbox = isSupportedMailboxId(mailbox) ? mailbox : null
   const {
     data,
@@ -165,6 +167,11 @@ function MailboxPage() {
         })
       }}
       onSelectThread={(threadId) => {
+        const thread = threads.find((t) => t.threadId === threadId)
+        if (thread && !thread.isRead) {
+          markAsRead(threadId)
+        }
+
         void navigate({
           search: (previous) => ({
             ...previous,


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#6

### 📌 Task

- Closes #15 
- Closes #16 

## 💡 작업 내용

- 메일 읽음 처리 동기화 API 구현
  - `src/mutations/emails.ts` 파일 추가
  - `src/api/emails.ts` 파일에 `markThreadAsRead( )` 추가
- 메일 읽음/ 안읽음 시 표시 UI 구현
- 보고 있는 메일 표시 -> 메일 행의 왼쪽 끝 부분에 line 추가
- 메일 목록 호버링 시 색 강조 UI 구현

## 📝 추가 설명

- 메일 상세보기 시 html 부분에 스크롤이 생겨 `overflow-hidden`을 추가하여 수정하였습니다.
- 메일 목록 테이블 기본 배경 색상을 `bg-muted`에서 `bg-accent/50`로 변경하였습니다.

## 🖼️ 스크린샷

- 스레드 클릭 시 읽음 처리 API 및 보고있는 메일 표시

<img width="1919" height="906" alt="image" src="https://github.com/user-attachments/assets/7376b4fa-14db-47a6-8e8f-f0a117e0d622" />

- 읽음/ 안읽음 메일 표시

<img width="1919" height="910" alt="image" src="https://github.com/user-attachments/assets/bf92cfaa-8f29-4499-9945-968107efded9" />

- 목록에 호버링 했을 때 UI

<img width="1919" height="907" alt="image" src="https://github.com/user-attachments/assets/54fcd9e2-b7fd-41c0-b35b-c1c2fff0037f" />
