### PR TITLE
[STORY-301] 메일 작성 화면 구현

### DIFF
--- a/src/api/emails.ts
+++ b/src/api/emails.ts
@@ -1,6 +1,7 @@
 import { apiClient } from "@/lib/api-client"
 import { normalizeSnippetText } from "@/lib/html-entities"
 import type {
+  ComposeEmailData,
   InboxMessage,
   InboxThreadDetail,
   InboxThreadSummary,
@@ -28,6 +29,18 @@ function normalizeThreadDetail(thread: InboxThreadDetail): InboxThreadDetail {
   return {
     ...thread,
     messages: thread.messages.map(normalizeMessage),
+  }
+}
+
+function appendFormDataValues(formData: FormData, key: string, values?: string[]) {
+  for (const value of values ?? []) {
+    const normalizedValue = value.trim()
+
+    if (!normalizedValue) {
+      continue
+    }
+
+    formData.append(key, normalizedValue)
   }
 }
 
@@ -59,4 +72,24 @@ export async function markThreadAsRead(threadId: string): Promise<void> {
 
 export async function getUnreadCount(): Promise<UnreadCountResponse> {
   return apiClient.get<UnreadCountResponse>("/api/v1/threads/inbox/unread-count")
+}
+
+export async function sendMail(data: ComposeEmailData): Promise<void> {
+  const formData = new FormData()
+
+  if (data.from?.trim()) {
+    formData.append("from", data.from.trim())
+  }
+
+  appendFormDataValues(formData, "to", data.to)
+  appendFormDataValues(formData, "cc", data.cc)
+  appendFormDataValues(formData, "bcc", data.bcc)
+  formData.append("subject", data.subject)
+  formData.append("content", data.content)
+
+  for (const attachment of data.attachments ?? []) {
+    formData.append("attachments", attachment)
+  }
+
+  await apiClient.post<void>("/api/v1/mail/send", formData)
 }

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router"
-import { Mail } from "lucide-react"
+import { Mail, Pencil } from "lucide-react"
 
+import { buttonVariants } from "@/components/ui/button"
 import { NavAccounts } from "@/components/nav-accounts"
 import { NavFolders } from "@/components/nav-folders"
 import { NavUser } from "@/components/nav-user"
@@ -48,6 +49,13 @@ export function AppSidebar({
       </SidebarHeader>
 
       <SidebarContent>
+        <div className="mb-2 px-2">
+          <Link to="/compose" className={buttonVariants({ size: "lg", className: "w-full" })}>
+            <Pencil className="mr-1" />
+            메일 작성
+          </Link>
+        </div>
+
         <NavFolders mailbox={mailbox} onMailboxChange={onMailboxChange} />
         <NavAccounts activeAccountId={activeAccountId} onAccountToggle={onAccountToggle} className="mt-auto" />
       </SidebarContent>

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -12,8 +12,8 @@ import { useUser } from "@/queries/user"
 
 export function ComposeEmail() {
   const navigate = useNavigate()
-  const { data: user } = useUser()
-  const { data: mailAccounts } = useMailAccounts()
+  const { data: user, isPending: isUserPending } = useUser()
+  const { data: mailAccounts, isPending: isMailAccountsPending } = useMailAccounts()
   const sendMailMutation = useSendMail()
   const [to, setTo] = useState("")
   const [cc, setCc] = useState("")
@@ -26,8 +26,20 @@ export function ComposeEmail() {
   const defaultFromAddress =
     mailAccounts?.find((mailAccount) => mailAccount.id === user?.defaultMailAccountId)?.emailAddress ??
     mailAccounts?.find((mailAccount) => mailAccount.isActive)?.emailAddress
+  const isFromAddressPending = isUserPending || isMailAccountsPending
+  const cannotSend = sendMailMutation.isPending || isFromAddressPending || !defaultFromAddress
 
   const handleSend = async () => {
+    if (isFromAddressPending) {
+      toast.error("발신 계정을 불러오는 중입니다")
+      return
+    }
+
+    if (!defaultFromAddress) {
+      toast.error("발신 메일 계정을 먼저 연결해주세요")
+      return
+    }
+
     const toRecipients = parseMailAddressInput(to)
 
     if (toRecipients.length === 0) {
@@ -139,7 +151,7 @@ export function ComposeEmail() {
       </div>
 
       <div className="shrink-0 border-t px-4 py-3">
-        <Button className="w-full" size="lg" onClick={handleSend} disabled={sendMailMutation.isPending}>
+        <Button className="w-full" size="lg" onClick={handleSend} disabled={cannotSend}>
           {sendMailMutation.isPending ? <Loader2 className="size-4 animate-spin" /> : null}
           보내기
         </Button>

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -78,14 +78,17 @@ export function ComposeEmail() {
     <div className="flex h-full flex-col">
       <div className="flex h-11 shrink-0 items-center justify-between border-b px-4">
         <h1 className="text-sm font-medium">새 메일 작성</h1>
-        <Button variant="ghost" size="icon-sm" onClick={handleClose} className="-mr-2">
+        <Button variant="ghost" size="icon-sm" onClick={handleClose} className="-mr-2" aria-label="메일 작성 닫기">
           <X className="size-4" />
         </Button>
       </div>
 
       <div className="flex h-10 items-center border-b px-4 py-2">
-        <label className="w-18 shrink-0 text-sm text-muted-foreground">받는 사람</label>
+        <label htmlFor="compose-to" className="w-18 shrink-0 text-sm text-muted-foreground">
+          받는 사람
+        </label>
         <input
+          id="compose-to"
           type="text"
           value={to}
           onChange={(e) => setTo(e.target.value)}
@@ -106,8 +109,11 @@ export function ComposeEmail() {
 
       {showCc && (
         <div className="flex h-10 items-center border-b px-4 py-2">
-          <label className="w-18 shrink-0 text-sm text-muted-foreground">참조</label>
+          <label htmlFor="compose-cc" className="w-18 shrink-0 text-sm text-muted-foreground">
+            참조
+          </label>
           <input
+            id="compose-cc"
             type="text"
             value={cc}
             onChange={(e) => setCc(e.target.value)}
@@ -119,8 +125,11 @@ export function ComposeEmail() {
 
       {showBcc && (
         <div className="flex h-10 items-center border-b px-4 py-2">
-          <label className="w-18 shrink-0 text-sm text-muted-foreground">숨은 참조</label>
+          <label htmlFor="compose-bcc" className="w-18 shrink-0 text-sm text-muted-foreground">
+            숨은 참조
+          </label>
           <input
+            id="compose-bcc"
             type="text"
             value={bcc}
             onChange={(e) => setBcc(e.target.value)}
@@ -131,8 +140,11 @@ export function ComposeEmail() {
       )}
 
       <div className="flex h-10 items-center border-b px-4 py-2">
-        <label className="w-18 shrink-0 text-sm text-muted-foreground">제목</label>
+        <label htmlFor="compose-subject" className="w-18 shrink-0 text-sm text-muted-foreground">
+          제목
+        </label>
         <input
+          id="compose-subject"
           type="text"
           value={subject}
           onChange={(e) => setSubject(e.target.value)}
@@ -142,7 +154,11 @@ export function ComposeEmail() {
       </div>
 
       <div className="flex-1 overflow-hidden">
+        <label htmlFor="compose-body" className="sr-only">
+          메일 본문
+        </label>
         <textarea
+          id="compose-body"
           value={body}
           onChange={(e) => setBody(e.target.value)}
           placeholder="메일 내용을 입력하세요..."

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { X } from "lucide-react"
+import { Loader2, X } from "lucide-react"
 import { useNavigate } from "@tanstack/react-router"
 import { toast } from "sonner"
 
@@ -140,6 +140,7 @@ export function ComposeEmail() {
 
       <div className="shrink-0 border-t px-4 py-3">
         <Button className="w-full" size="lg" onClick={handleSend} disabled={sendMailMutation.isPending}>
+          {sendMailMutation.isPending ? <Loader2 className="size-4 animate-spin" /> : null}
           보내기
         </Button>
       </div>

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -1,0 +1,148 @@
+import { useState } from "react"
+import { X } from "lucide-react"
+import { useNavigate } from "@tanstack/react-router"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import { getErrorMessage } from "@/lib/http-error"
+import { parseMailAddressInput } from "@/lib/mail-address"
+import { useSendMail } from "@/mutations/emails"
+import { useMailAccounts } from "@/queries/mail-accounts"
+import { useUser } from "@/queries/user"
+
+export function ComposeEmail() {
+  const navigate = useNavigate()
+  const { data: user } = useUser()
+  const { data: mailAccounts } = useMailAccounts()
+  const sendMailMutation = useSendMail()
+  const [to, setTo] = useState("")
+  const [cc, setCc] = useState("")
+  const [bcc, setBcc] = useState("")
+  const [subject, setSubject] = useState("")
+  const [body, setBody] = useState("")
+  const [showCc, setShowCc] = useState(false)
+  const [showBcc, setShowBcc] = useState(false)
+
+  const defaultFromAddress =
+    mailAccounts?.find((mailAccount) => mailAccount.id === user?.defaultMailAccountId)?.emailAddress ??
+    mailAccounts?.find((mailAccount) => mailAccount.isActive)?.emailAddress
+
+  const handleSend = async () => {
+    const toRecipients = parseMailAddressInput(to)
+
+    if (toRecipients.length === 0) {
+      toast.error("받는 사람을 입력해주세요")
+      return
+    }
+
+    if (!subject.trim()) {
+      toast.error("제목을 입력해주세요")
+      return
+    }
+
+    try {
+      await sendMailMutation.mutateAsync({
+        from: defaultFromAddress,
+        to: toRecipients,
+        cc: parseMailAddressInput(cc),
+        bcc: parseMailAddressInput(bcc),
+        subject: subject.trim(),
+        content: body,
+      })
+      toast.success("메일이 발송되었습니다")
+      await navigate({ to: "/mail/$mailbox", params: { mailbox: "inbox" } })
+    } catch (error) {
+      toast.error("메일 발송에 실패했습니다", {
+        description: getErrorMessage(error, "잠시 후 다시 시도해주세요."),
+      })
+    }
+  }
+
+  const handleClose = () => {
+    navigate({ to: "/mail/$mailbox", params: { mailbox: "inbox" } })
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-11 shrink-0 items-center justify-between border-b px-4">
+        <h1 className="text-sm font-medium">새 메일 작성</h1>
+        <Button variant="ghost" size="icon-sm" onClick={handleClose} className="-mr-2">
+          <X className="size-4" />
+        </Button>
+      </div>
+
+      <div className="flex h-10 items-center border-b px-4 py-2">
+        <label className="w-18 shrink-0 text-sm text-muted-foreground">받는 사람</label>
+        <input
+          type="text"
+          value={to}
+          onChange={(e) => setTo(e.target.value)}
+          placeholder="이메일 주소 입력"
+          className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+        />
+        {!showCc && (
+          <Button variant="ghost" size="xs" onClick={() => setShowCc(true)}>
+            참조
+          </Button>
+        )}
+        {!showBcc && (
+          <Button variant="ghost" size="xs" onClick={() => setShowBcc(true)}>
+            숨은참조
+          </Button>
+        )}
+      </div>
+
+      {showCc && (
+        <div className="flex h-10 items-center border-b px-4 py-2">
+          <label className="w-18 shrink-0 text-sm text-muted-foreground">참조</label>
+          <input
+            type="text"
+            value={cc}
+            onChange={(e) => setCc(e.target.value)}
+            placeholder="이메일 주소 입력"
+            className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          />
+        </div>
+      )}
+
+      {showBcc && (
+        <div className="flex h-10 items-center border-b px-4 py-2">
+          <label className="w-18 shrink-0 text-sm text-muted-foreground">숨은 참조</label>
+          <input
+            type="text"
+            value={bcc}
+            onChange={(e) => setBcc(e.target.value)}
+            placeholder="이메일 주소 입력"
+            className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          />
+        </div>
+      )}
+
+      <div className="flex h-10 items-center border-b px-4 py-2">
+        <label className="w-18 shrink-0 text-sm text-muted-foreground">제목</label>
+        <input
+          type="text"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+          placeholder="메일 제목 입력"
+          className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+        />
+      </div>
+
+      <div className="flex-1 overflow-hidden">
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="메일 내용을 입력하세요..."
+          className="h-full w-full resize-none bg-transparent p-4 text-sm outline-none placeholder:text-muted-foreground"
+        />
+      </div>
+
+      <div className="shrink-0 border-t px-4 py-3">
+        <Button className="w-full" size="lg" onClick={handleSend} disabled={sendMailMutation.isPending}>
+          보내기
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/compose/compose-reference.tsx
+++ b/src/components/compose/compose-reference.tsx
@@ -1,0 +1,20 @@
+import { Mail } from "lucide-react"
+
+export function ReferencePlaceholder() {
+  return (
+    <>
+      <div className="flex h-11 shrink-0 items-center border-b px-4">
+        <h1 className="text-sm font-medium">참고 메일</h1>
+      </div>
+      <div className="flex min-h-full flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+        <div className="flex size-14 items-center justify-center rounded-full bg-muted">
+          <Mail className="size-7 text-muted-foreground/60" />
+        </div>
+        <div>
+          <p className="font-medium text-muted-foreground">레퍼런스 메일</p>
+          <p className="mt-1 text-sm text-muted-foreground">메일 작성시 참고할 메일이 여기 표시됩니다</p>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -237,7 +237,4 @@
 
     font-family: var(--font-sans);
   }
-  html {
-    scrollbar-gutter: stable;
-  }
 }

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -48,14 +48,43 @@ function buildUrl(path: string, params?: QueryParams) {
   return url
 }
 
-function buildHeaders(headers?: HeadersInit, hasBody = false) {
+function isBodyInit(body: unknown): body is BodyInit {
+  if (typeof body === "string") {
+    return true
+  }
+
+  if (typeof FormData !== "undefined" && body instanceof FormData) {
+    return true
+  }
+
+  if (typeof Blob !== "undefined" && body instanceof Blob) {
+    return true
+  }
+
+  if (typeof URLSearchParams !== "undefined" && body instanceof URLSearchParams) {
+    return true
+  }
+
+  return false
+}
+
+function buildHeaders(headers?: HeadersInit, body?: unknown) {
   const requestHeaders = new Headers(headers)
   requestHeaders.set("Accept", "application/json")
-  if (hasBody && !requestHeaders.has("Content-Type")) {
+
+  if (body !== undefined && !isBodyInit(body) && !requestHeaders.has("Content-Type")) {
     requestHeaders.set("Content-Type", "application/json")
   }
 
   return requestHeaders
+}
+
+function buildRequestBody(body?: unknown): BodyInit | undefined {
+  if (body === undefined) {
+    return undefined
+  }
+
+  return isBodyInit(body) ? body : JSON.stringify(body)
 }
 
 async function parseResponseBody(response: Response) {
@@ -86,13 +115,12 @@ function getErrorMessage(statusText: string, data: unknown) {
 
 async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
   const { method = "GET", params, body, headers, signal } = options
-  const hasBody = body !== undefined
 
   const response = await fetch(buildUrl(path, params), {
     method,
     credentials: "include",
-    headers: buildHeaders(headers, hasBody),
-    body: hasBody ? JSON.stringify(body) : undefined,
+    headers: buildHeaders(headers, body),
+    body: buildRequestBody(body),
     signal,
   })
 

--- a/src/lib/mail-address.ts
+++ b/src/lib/mail-address.ts
@@ -38,23 +38,27 @@ export function parseMailAddressInput(value: string) {
   let current = ""
   let inQuotes = false
   let angleDepth = 0
+  let backslashCount = 0
 
   for (const char of value) {
-    if (char === '"') {
+    if (char === '"' && backslashCount % 2 === 0) {
       inQuotes = !inQuotes
       current += char
+      backslashCount = 0
       continue
     }
 
     if (!inQuotes && char === "<") {
       angleDepth += 1
       current += char
+      backslashCount = 0
       continue
     }
 
     if (!inQuotes && char === ">" && angleDepth > 0) {
       angleDepth -= 1
       current += char
+      backslashCount = 0
       continue
     }
 
@@ -66,10 +70,12 @@ export function parseMailAddressInput(value: string) {
       }
 
       current = ""
+      backslashCount = 0
       continue
     }
 
     current += char
+    backslashCount = char === "\\" ? backslashCount + 1 : 0
   }
 
   const lastEntry = current.trim()

--- a/src/lib/mail-address.ts
+++ b/src/lib/mail-address.ts
@@ -32,3 +32,51 @@ export function getMailAddressSearchText(address?: MailAddress | null) {
 export function formatMailAddressList(addresses: MailAddress[]) {
   return addresses.map((address) => getMailAddressFullLabel(address)).join(", ")
 }
+
+export function parseMailAddressInput(value: string) {
+  const entries: string[] = []
+  let current = ""
+  let inQuotes = false
+  let angleDepth = 0
+
+  for (const char of value) {
+    if (char === '"') {
+      inQuotes = !inQuotes
+      current += char
+      continue
+    }
+
+    if (!inQuotes && char === "<") {
+      angleDepth += 1
+      current += char
+      continue
+    }
+
+    if (!inQuotes && char === ">" && angleDepth > 0) {
+      angleDepth -= 1
+      current += char
+      continue
+    }
+
+    if (!inQuotes && angleDepth === 0 && /[,\n;]/.test(char)) {
+      const entry = current.trim()
+
+      if (entry) {
+        entries.push(entry)
+      }
+
+      current = ""
+      continue
+    }
+
+    current += char
+  }
+
+  const lastEntry = current.trim()
+
+  if (lastEntry) {
+    entries.push(lastEntry)
+  }
+
+  return entries
+}

--- a/src/mutations/emails.ts
+++ b/src/mutations/emails.ts
@@ -1,9 +1,20 @@
 import { useMutation } from "@tanstack/react-query"
 import { toast } from "sonner"
 
-import { markThreadAsRead } from "@/api/emails"
+import type { ComposeEmailData } from "@/types/email"
+
+import { markThreadAsRead, sendMail } from "@/api/emails"
 import { queryClient } from "@/lib/query-client"
 import { emailKeys } from "@/queries/emails"
+
+export const emailMutationOptions = {
+  sendMail: () => ({
+    mutationFn: (data: ComposeEmailData) => sendMail(data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: emailKeys.all() })
+    },
+  }),
+}
 
 export function useMarkThreadAsRead() {
   return useMutation({
@@ -15,4 +26,8 @@ export function useMarkThreadAsRead() {
       toast.error("읽음 처리에 실패했습니다")
     },
   })
+}
+
+export function useSendMail() {
+  return useMutation(emailMutationOptions.sendMail())
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as GuestSignupRouteImport } from './routes/_guest/signup'
 import { Route as GuestLoginRouteImport } from './routes/_guest/login'
 import { Route as AuthenticatedSettingsRouteImport } from './routes/_authenticated/settings'
 import { Route as AuthenticatedMailRouteImport } from './routes/_authenticated/mail'
+import { Route as AuthenticatedComposeRouteImport } from './routes/_authenticated/compose'
 import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authenticated/settings/index'
 import { Route as AuthenticatedMailIndexRouteImport } from './routes/_authenticated/mail/index'
 import { Route as AuthenticatedSettingsAccountRouteImport } from './routes/_authenticated/settings/account'
@@ -54,6 +55,11 @@ const AuthenticatedMailRoute = AuthenticatedMailRouteImport.update({
   path: '/mail',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+const AuthenticatedComposeRoute = AuthenticatedComposeRouteImport.update({
+  id: '/compose',
+  path: '/compose',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
 const AuthenticatedSettingsIndexRoute =
   AuthenticatedSettingsIndexRouteImport.update({
     id: '/',
@@ -80,6 +86,7 @@ const AuthenticatedMailMailboxRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/compose': typeof AuthenticatedComposeRoute
   '/mail': typeof AuthenticatedMailRouteWithChildren
   '/settings': typeof AuthenticatedSettingsRouteWithChildren
   '/login': typeof GuestLoginRoute
@@ -91,6 +98,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/compose': typeof AuthenticatedComposeRoute
   '/login': typeof GuestLoginRoute
   '/signup': typeof GuestSignupRoute
   '/mail/$mailbox': typeof AuthenticatedMailMailboxRoute
@@ -103,6 +111,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/_authenticated': typeof AuthenticatedRouteWithChildren
   '/_guest': typeof GuestRouteWithChildren
+  '/_authenticated/compose': typeof AuthenticatedComposeRoute
   '/_authenticated/mail': typeof AuthenticatedMailRouteWithChildren
   '/_authenticated/settings': typeof AuthenticatedSettingsRouteWithChildren
   '/_guest/login': typeof GuestLoginRoute
@@ -116,6 +125,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/compose'
     | '/mail'
     | '/settings'
     | '/login'
@@ -127,6 +137,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/compose'
     | '/login'
     | '/signup'
     | '/mail/$mailbox'
@@ -138,6 +149,7 @@ export interface FileRouteTypes {
     | '/'
     | '/_authenticated'
     | '/_guest'
+    | '/_authenticated/compose'
     | '/_authenticated/mail'
     | '/_authenticated/settings'
     | '/_guest/login'
@@ -205,6 +217,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedMailRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/compose': {
+      id: '/_authenticated/compose'
+      path: '/compose'
+      fullPath: '/compose'
+      preLoaderRoute: typeof AuthenticatedComposeRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/settings/': {
       id: '/_authenticated/settings/'
       path: '/'
@@ -265,11 +284,13 @@ const AuthenticatedSettingsRouteWithChildren =
   )
 
 interface AuthenticatedRouteChildren {
+  AuthenticatedComposeRoute: typeof AuthenticatedComposeRoute
   AuthenticatedMailRoute: typeof AuthenticatedMailRouteWithChildren
   AuthenticatedSettingsRoute: typeof AuthenticatedSettingsRouteWithChildren
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
+  AuthenticatedComposeRoute: AuthenticatedComposeRoute,
   AuthenticatedMailRoute: AuthenticatedMailRouteWithChildren,
   AuthenticatedSettingsRoute: AuthenticatedSettingsRouteWithChildren,
 }

--- a/src/routes/_authenticated/compose.tsx
+++ b/src/routes/_authenticated/compose.tsx
@@ -1,0 +1,34 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { ComposeEmail } from "@/components/compose/compose-email"
+import { ReferencePlaceholder } from "@/components/compose/compose-reference"
+import { Separator } from "@/components/ui/separator"
+import { useIsMobile } from "@/hooks/use-mobile"
+
+export const Route = createFileRoute("/_authenticated/compose")({
+  component: ComposePage,
+})
+
+function ComposePage() {
+  const isMobile = useIsMobile()
+
+  if (isMobile) {
+    return (
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <ComposeEmail />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 overflow-hidden">
+      <div className="min-h-0 min-w-0 basis-1/2 border-r-0">
+        <ReferencePlaceholder />
+      </div>
+      <Separator orientation="vertical" />
+      <div className="min-h-0 min-w-0 basis-2/3">
+        <ComposeEmail />
+      </div>
+    </div>
+  )
+}

--- a/src/types/email.ts
+++ b/src/types/email.ts
@@ -87,3 +87,13 @@ export interface ListThreadsParams {
 export interface UnreadCountResponse {
   unreadCount: number
 }
+
+export interface ComposeEmailData {
+  from?: string
+  to: string[]
+  cc?: string[]
+  bcc?: string[]
+  subject: string
+  content: string
+  attachments?: File[]
+}


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#10

### 📌 Task

- Closes #27
- Closes #28

## 💡 작업 내용

- 메일 발송 API 연동 구현
- 메일 작성 페이지(`/compose`)를 추가
- 사이드바에서 메일 작성 페이지 버튼 추가
- 메일 전송 중 상태 UX 구현
- 메일 전송 실패 토스트 알림 UX 구현

## 📝 추가 설명

- 데스크톱에서는 참고 메일 영역과 작성 영역을 나란히 보여주고, 모바일에서는 작성 영역만 노출되도록 구성했습니다.
- 공용 API 클라이언트가 `FormData` 기반 `multipart/form-data` 요청을 처리할 수 있도록 확장했습니다.
- React Query 메일 mutation에 `useSendMail`을 추가하고, 발송 성공 시 메일 관련 쿼리를 invalidate 하도록 연결했습니다.
- **작성 화면에서 기본 발신 계정을 사용자 기본 메일 계정 또는 활성 계정 기준으로 선택해 전송하도록 임시로 연결했습니다.**
- 받는 사람, 참조, 숨은 참조 입력값을 파싱하는 유틸을 구현하였습니다.

## 🖼️ 스크린샷

<img width="1280" height="806" alt="image" src="https://github.com/user-attachments/assets/99170b21-7b7d-4058-a842-c7a88b7fa7ce" />