### PR TITLE
[STORY-103] 메일 작성 시 계정 선택 구현

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,7 +1,9 @@
 import { Link } from "@tanstack/react-router"
-import { Mail, Pencil } from "lucide-react"
+import { ChevronDown, Mail, Pencil } from "lucide-react"
 
+import { Badge } from "@/components/ui/badge"
 import { buttonVariants } from "@/components/ui/button"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { NavAccounts } from "@/components/nav-accounts"
 import { NavFolders } from "@/components/nav-folders"
 import { NavUser } from "@/components/nav-user"
@@ -14,6 +16,8 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
+import { useMailAccounts } from "@/queries/mail-accounts"
+import { useUser } from "@/queries/user"
 import type { PrimaryMailboxId } from "@/types/email"
 
 interface AppSidebarProps {
@@ -30,6 +34,10 @@ export function AppSidebar({
   onAccountToggle,
   ...props
 }: AppSidebarProps & React.ComponentProps<typeof Sidebar>) {
+  const { data: user } = useUser()
+  const { data: mailAccounts } = useMailAccounts()
+  const hasMailAccounts = !!mailAccounts && mailAccounts.length > 0
+
   return (
     <Sidebar variant="inset" {...props}>
       <SidebarHeader className="md:hidden">
@@ -49,11 +57,36 @@ export function AppSidebar({
       </SidebarHeader>
 
       <SidebarContent>
-        <div className="mb-2 px-2">
-          <Link to="/compose" className={buttonVariants({ size: "lg", className: "w-full" })}>
+        <div className="mb-2 flex gap-px px-2">
+          <Link to="/compose" className={buttonVariants({ size: "lg", className: "flex-1 rounded-r-none" })}>
             <Pencil className="mr-1" />
             메일 작성
           </Link>
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              disabled={!hasMailAccounts}
+              className={buttonVariants({
+                size: "lg",
+                className: "cursor-pointer rounded-l-none px-2",
+              })}
+              aria-label="발신 계정 선택"
+            >
+              <ChevronDown className="size-4" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="min-w-56">
+              {(mailAccounts ?? []).map((mailAccount) => (
+                <DropdownMenuItem
+                  key={mailAccount.id}
+                  render={<Link to="/compose" search={{ from: mailAccount.emailAddress }} />}
+                >
+                  <span className="flex flex-1 items-center gap-2">
+                    <span className="truncate">{mailAccount.emailAddress}</span>
+                    {mailAccount.id === user?.defaultMailAccountId && <Badge variant="secondary">default</Badge>}
+                  </span>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
 
         <NavFolders mailbox={mailbox} onMailboxChange={onMailboxChange} />

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -16,7 +16,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
-import { useMailAccounts } from "@/queries/mail-accounts"
+import { useActiveMailAccounts } from "@/queries/mail-accounts"
 import { useUser } from "@/queries/user"
 import type { PrimaryMailboxId } from "@/types/email"
 
@@ -35,8 +35,8 @@ export function AppSidebar({
   ...props
 }: AppSidebarProps & React.ComponentProps<typeof Sidebar>) {
   const { data: user } = useUser()
-  const { data: mailAccounts } = useMailAccounts()
-  const hasMailAccounts = !!mailAccounts && mailAccounts.length > 0
+  const { data: activeMailAccounts } = useActiveMailAccounts()
+  const hasMailAccounts = !!activeMailAccounts && activeMailAccounts.length > 0
 
   return (
     <Sidebar variant="inset" {...props}>
@@ -74,7 +74,7 @@ export function AppSidebar({
               <ChevronDown className="size-4" />
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="min-w-56">
-              {(mailAccounts ?? []).map((mailAccount) => (
+              {(activeMailAccounts ?? []).map((mailAccount) => (
                 <DropdownMenuItem
                   key={mailAccount.id}
                   render={<Link to="/compose" search={{ from: mailAccount.emailAddress }} />}

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -12,7 +12,11 @@ import { useSendMail } from "@/mutations/emails"
 import { useMailAccounts } from "@/queries/mail-accounts"
 import { useUser } from "@/queries/user"
 
-export function ComposeEmail() {
+interface ComposeEmailProps {
+  initialFromAddress?: string
+}
+
+export function ComposeEmail({ initialFromAddress }: ComposeEmailProps = {}) {
   const navigate = useNavigate()
   const { data: user, isPending: isUserPending } = useUser()
   const { data: mailAccounts, isPending: isMailAccountsPending } = useMailAccounts()
@@ -24,7 +28,7 @@ export function ComposeEmail() {
   const [body, setBody] = useState("")
   const [showCc, setShowCc] = useState(false)
   const [showBcc, setShowBcc] = useState(false)
-  const [fromAddress, setFromAddress] = useState<string | null>(null)
+  const [fromAddress, setFromAddress] = useState<string | null>(initialFromAddress ?? null)
 
   const defaultFromAddress =
     mailAccounts?.find((mailAccount) => mailAccount.id === user?.defaultMailAccountId)?.emailAddress ??

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -88,7 +88,7 @@ export function ComposeEmail() {
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full w-full flex-col">
       <div className="flex h-11 shrink-0 items-center justify-between border-b px-4">
         <h1 className="text-sm font-medium">새 메일 작성</h1>
         <Button variant="ghost" size="icon-sm" onClick={handleClose} className="-mr-2" aria-label="메일 작성 닫기">
@@ -178,7 +178,7 @@ export function ComposeEmail() {
         >
           <SelectTrigger
             aria-labelledby="compose-from-label"
-            className="h-auto min-w-0 flex-1 border-0 bg-transparent px-0 py-0 shadow-none focus-visible:ring-0"
+            className="h-auto min-w-0 flex-1 border-0 bg-transparent px-0 py-0 shadow-none focus-visible:ring-0 dark:bg-transparent dark:hover:bg-transparent"
           >
             <SelectValue placeholder={isFromAddressPending ? "발신 계정을 불러오는 중..." : "발신 계정을 선택하세요"} />
           </SelectTrigger>

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -13,10 +13,11 @@ import { useActiveMailAccounts } from "@/queries/mail-accounts"
 import { useUser } from "@/queries/user"
 
 interface ComposeEmailProps {
-  initialFromAddress?: string
+  fromAddress: string | null
+  onFromAddressChange: (value: string | null) => void
 }
 
-export function ComposeEmail({ initialFromAddress }: ComposeEmailProps = {}) {
+export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailProps) {
   const navigate = useNavigate()
   const { data: user, isPending: isUserPending } = useUser()
   const { data: activeMailAccounts, isPending: isMailAccountsPending } = useActiveMailAccounts()
@@ -28,7 +29,6 @@ export function ComposeEmail({ initialFromAddress }: ComposeEmailProps = {}) {
   const [body, setBody] = useState("")
   const [showCc, setShowCc] = useState(false)
   const [showBcc, setShowBcc] = useState(false)
-  const [fromAddress, setFromAddress] = useState<string | null>(initialFromAddress ?? null)
 
   const activeFromAddressSet = useMemo(
     () => new Set((activeMailAccounts ?? []).map((mailAccount) => mailAccount.emailAddress)),
@@ -181,7 +181,7 @@ export function ComposeEmail({ initialFromAddress }: ComposeEmailProps = {}) {
         </span>
         <Select
           value={selectedFromAddress}
-          onValueChange={setFromAddress}
+          onValueChange={onFromAddressChange}
           items={fromAddressItems}
           disabled={isFromAddressPending || fromAddressItems.length === 0}
         >

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -1,9 +1,11 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { Loader2, X } from "lucide-react"
 import { useNavigate } from "@tanstack/react-router"
 import { toast } from "sonner"
 
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { getErrorMessage } from "@/lib/http-error"
 import { parseMailAddressInput } from "@/lib/mail-address"
 import { useSendMail } from "@/mutations/emails"
@@ -22,12 +24,23 @@ export function ComposeEmail() {
   const [body, setBody] = useState("")
   const [showCc, setShowCc] = useState(false)
   const [showBcc, setShowBcc] = useState(false)
+  const [fromAddress, setFromAddress] = useState<string | null>(null)
 
   const defaultFromAddress =
     mailAccounts?.find((mailAccount) => mailAccount.id === user?.defaultMailAccountId)?.emailAddress ??
-    mailAccounts?.find((mailAccount) => mailAccount.isActive)?.emailAddress
+    mailAccounts?.find((mailAccount) => mailAccount.isActive)?.emailAddress ??
+    null
+  const selectedFromAddress = fromAddress ?? defaultFromAddress
+  const fromAddressItems = useMemo(
+    () =>
+      (mailAccounts ?? []).map((mailAccount) => ({
+        value: mailAccount.emailAddress,
+        label: mailAccount.emailAddress,
+      })),
+    [mailAccounts]
+  )
   const isFromAddressPending = isUserPending || isMailAccountsPending
-  const cannotSend = sendMailMutation.isPending || isFromAddressPending || !defaultFromAddress
+  const cannotSend = sendMailMutation.isPending || isFromAddressPending || !selectedFromAddress
 
   const handleSend = async () => {
     if (isFromAddressPending) {
@@ -35,7 +48,7 @@ export function ComposeEmail() {
       return
     }
 
-    if (!defaultFromAddress) {
+    if (!selectedFromAddress) {
       toast.error("발신 메일 계정을 먼저 연결해주세요")
       return
     }
@@ -54,7 +67,7 @@ export function ComposeEmail() {
 
     try {
       await sendMailMutation.mutateAsync({
-        from: defaultFromAddress,
+        from: selectedFromAddress,
         to: toRecipients,
         cc: parseMailAddressInput(cc),
         bcc: parseMailAddressInput(bcc),
@@ -84,7 +97,7 @@ export function ComposeEmail() {
       </div>
 
       <div className="flex h-10 items-center border-b px-4 py-2">
-        <label htmlFor="compose-to" className="w-18 shrink-0 text-sm text-muted-foreground">
+        <label htmlFor="compose-to" className="w-20 shrink-0 text-sm text-muted-foreground">
           받는 사람
         </label>
         <input
@@ -109,7 +122,7 @@ export function ComposeEmail() {
 
       {showCc && (
         <div className="flex h-10 items-center border-b px-4 py-2">
-          <label htmlFor="compose-cc" className="w-18 shrink-0 text-sm text-muted-foreground">
+          <label htmlFor="compose-cc" className="w-20 shrink-0 text-sm text-muted-foreground">
             참조
           </label>
           <input
@@ -125,7 +138,7 @@ export function ComposeEmail() {
 
       {showBcc && (
         <div className="flex h-10 items-center border-b px-4 py-2">
-          <label htmlFor="compose-bcc" className="w-18 shrink-0 text-sm text-muted-foreground">
+          <label htmlFor="compose-bcc" className="w-20 shrink-0 text-sm text-muted-foreground">
             숨은 참조
           </label>
           <input
@@ -140,7 +153,7 @@ export function ComposeEmail() {
       )}
 
       <div className="flex h-10 items-center border-b px-4 py-2">
-        <label htmlFor="compose-subject" className="w-18 shrink-0 text-sm text-muted-foreground">
+        <label htmlFor="compose-subject" className="w-20 shrink-0 text-sm text-muted-foreground">
           제목
         </label>
         <input
@@ -151,6 +164,35 @@ export function ComposeEmail() {
           placeholder="메일 제목 입력"
           className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
         />
+      </div>
+
+      <div className="flex h-10 items-center border-b px-4 py-2">
+        <span id="compose-from-label" className="w-20 shrink-0 text-sm text-muted-foreground">
+          보내는 사람
+        </span>
+        <Select
+          value={selectedFromAddress}
+          onValueChange={setFromAddress}
+          items={fromAddressItems}
+          disabled={isFromAddressPending || fromAddressItems.length === 0}
+        >
+          <SelectTrigger
+            aria-labelledby="compose-from-label"
+            className="h-auto min-w-0 flex-1 border-0 bg-transparent px-0 py-0 shadow-none focus-visible:ring-0"
+          >
+            <SelectValue placeholder={isFromAddressPending ? "발신 계정을 불러오는 중..." : "발신 계정을 선택하세요"} />
+          </SelectTrigger>
+          <SelectContent align="start" alignItemWithTrigger={false}>
+            {(mailAccounts ?? []).map((mailAccount) => (
+              <SelectItem key={mailAccount.id} value={mailAccount.emailAddress} className="px-3 py-2">
+                <span className="flex items-center gap-2">
+                  {mailAccount.emailAddress}
+                  {mailAccount.id === user?.defaultMailAccountId && <Badge variant="secondary">default</Badge>}
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       <div className="flex-1 overflow-hidden">

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -9,7 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { getErrorMessage } from "@/lib/http-error"
 import { parseMailAddressInput } from "@/lib/mail-address"
 import { useSendMail } from "@/mutations/emails"
-import { useMailAccounts } from "@/queries/mail-accounts"
+import { useActiveMailAccounts } from "@/queries/mail-accounts"
 import { useUser } from "@/queries/user"
 
 interface ComposeEmailProps {
@@ -19,7 +19,7 @@ interface ComposeEmailProps {
 export function ComposeEmail({ initialFromAddress }: ComposeEmailProps = {}) {
   const navigate = useNavigate()
   const { data: user, isPending: isUserPending } = useUser()
-  const { data: mailAccounts, isPending: isMailAccountsPending } = useMailAccounts()
+  const { data: activeMailAccounts, isPending: isMailAccountsPending } = useActiveMailAccounts()
   const sendMailMutation = useSendMail()
   const [to, setTo] = useState("")
   const [cc, setCc] = useState("")
@@ -30,18 +30,23 @@ export function ComposeEmail({ initialFromAddress }: ComposeEmailProps = {}) {
   const [showBcc, setShowBcc] = useState(false)
   const [fromAddress, setFromAddress] = useState<string | null>(initialFromAddress ?? null)
 
+  const activeFromAddressSet = useMemo(
+    () => new Set((activeMailAccounts ?? []).map((mailAccount) => mailAccount.emailAddress)),
+    [activeMailAccounts]
+  )
   const defaultFromAddress =
-    mailAccounts?.find((mailAccount) => mailAccount.id === user?.defaultMailAccountId)?.emailAddress ??
-    mailAccounts?.find((mailAccount) => mailAccount.isActive)?.emailAddress ??
+    activeMailAccounts?.find((mailAccount) => mailAccount.id === user?.defaultMailAccountId)?.emailAddress ??
+    activeMailAccounts?.[0]?.emailAddress ??
     null
-  const selectedFromAddress = fromAddress ?? defaultFromAddress
+  const validatedFromAddress = fromAddress && activeFromAddressSet.has(fromAddress) ? fromAddress : null
+  const selectedFromAddress = validatedFromAddress ?? defaultFromAddress
   const fromAddressItems = useMemo(
     () =>
-      (mailAccounts ?? []).map((mailAccount) => ({
+      (activeMailAccounts ?? []).map((mailAccount) => ({
         value: mailAccount.emailAddress,
         label: mailAccount.emailAddress,
       })),
-    [mailAccounts]
+    [activeMailAccounts]
   )
   const isFromAddressPending = isUserPending || isMailAccountsPending
   const cannotSend = sendMailMutation.isPending || isFromAddressPending || !selectedFromAddress
@@ -187,7 +192,7 @@ export function ComposeEmail({ initialFromAddress }: ComposeEmailProps = {}) {
             <SelectValue placeholder={isFromAddressPending ? "발신 계정을 불러오는 중..." : "발신 계정을 선택하세요"} />
           </SelectTrigger>
           <SelectContent align="start" alignItemWithTrigger={false}>
-            {(mailAccounts ?? []).map((mailAccount) => (
+            {(activeMailAccounts ?? []).map((mailAccount) => (
               <SelectItem key={mailAccount.id} value={mailAccount.emailAddress} className="px-3 py-2">
                 <span className="flex items-center gap-2">
                   {mailAccount.emailAddress}

--- a/src/queries/mail-accounts.ts
+++ b/src/queries/mail-accounts.ts
@@ -23,3 +23,10 @@ export function useMailAccounts() {
     enabled: user != null,
   })
 }
+
+export function useActiveMailAccounts() {
+  const query = useMailAccounts()
+  const data = query.data?.filter((mailAccount) => mailAccount.isActive)
+
+  return { ...query, data }
+}

--- a/src/routes/_authenticated/compose.tsx
+++ b/src/routes/_authenticated/compose.tsx
@@ -20,11 +20,19 @@ export const Route = createFileRoute("/_authenticated/compose")({
 function ComposePage() {
   const isMobile = useIsMobile()
   const { from } = Route.useSearch()
+  const navigate = Route.useNavigate()
+
+  const handleFromAddressChange = (nextFrom: string | null) => {
+    navigate({
+      search: (prev) => ({ ...prev, from: nextFrom ?? undefined }),
+      replace: true,
+    })
+  }
 
   if (isMobile) {
     return (
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        <ComposeEmail initialFromAddress={from} />
+        <ComposeEmail fromAddress={from ?? null} onFromAddressChange={handleFromAddressChange} />
       </div>
     )
   }
@@ -36,7 +44,7 @@ function ComposePage() {
       </div>
       <Separator orientation="vertical" />
       <div className="min-h-0 min-w-0 basis-2/3">
-        <ComposeEmail initialFromAddress={from} />
+        <ComposeEmail fromAddress={from ?? null} onFromAddressChange={handleFromAddressChange} />
       </div>
     </div>
   )

--- a/src/routes/_authenticated/compose.tsx
+++ b/src/routes/_authenticated/compose.tsx
@@ -5,17 +5,26 @@ import { ReferencePlaceholder } from "@/components/compose/compose-reference"
 import { Separator } from "@/components/ui/separator"
 import { useIsMobile } from "@/hooks/use-mobile"
 
+interface ComposeRouteSearch {
+  from?: string
+}
+
 export const Route = createFileRoute("/_authenticated/compose")({
+  validateSearch: (search: Record<string, unknown>): ComposeRouteSearch => {
+    const from = typeof search.from === "string" ? search.from.trim() : ""
+    return from ? { from } : {}
+  },
   component: ComposePage,
 })
 
 function ComposePage() {
   const isMobile = useIsMobile()
+  const { from } = Route.useSearch()
 
   if (isMobile) {
     return (
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        <ComposeEmail />
+        <ComposeEmail initialFromAddress={from} />
       </div>
     )
   }
@@ -27,7 +36,7 @@ function ComposePage() {
       </div>
       <Separator orientation="vertical" />
       <div className="min-h-0 min-w-0 basis-2/3">
-        <ComposeEmail />
+        <ComposeEmail initialFromAddress={from} />
       </div>
     </div>
   )


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#3

### 📌 Task

- Closes #7 

## 💡 작업 내용

- 메일 작성 화면에서 `보내는 사람` 추가해서 발신 이메일 선택창 구현
- 사이드바에도 발신 이메일 선택창 추가
- default 이메일에 default 배지 추가
- 메일 계정이 활성화인지 확인하는 Hook 추가

## 📝 추가 설명

- 메일 작성 wrapper에 `w-full` 추가하여 너비가 줄어들었을 때 화면이 깨지지 않도록 수정하였습니다
- 이메일 전송이 성공적으로 되고 있는지 확인 완료 했습니다

## 🖼️ 스크린샷

- 사이드바 메일 작성 버튼

<img width="316" height="156" alt="image" src="https://github.com/user-attachments/assets/7d9af9e2-cb89-475f-b890-a8d4efb636d6" />

- 메일 작성 시 보내는 사람 선택 가능

<img width="1919" height="864" alt="image" src="https://github.com/user-attachments/assets/c7c9d1d0-a589-4daf-b9eb-ee8ee9c03516" />

- `w-full`

| `w-full` 추가 전 | `w-full` 추가 후 |
| -- | -- |
| <img width="872" height="868" alt="image" src="https://github.com/user-attachments/assets/67bb810d-2edd-4e58-a200-df95b1112a99" /> | <img width="870" height="863" alt="image" src="https://github.com/user-attachments/assets/8e3bbdcb-424f-4db0-bee4-f95a7d4562b6" /> |

