### PR TITLE
[STORY-204] 휴지통 페이지 구현

### DIFF
--- a/src/api/emails.ts
+++ b/src/api/emails.ts
@@ -81,6 +81,10 @@ export async function sendMail(data: ComposeEmailData): Promise<void> {
     formData.append("from", data.from.trim())
   }
 
+  if (data.replyTo?.trim()) {
+    formData.append("replyTo", data.replyTo.trim())
+  }
+
   appendFormDataValues(formData, "to", data.to)
   appendFormDataValues(formData, "cc", data.cc)
   appendFormDataValues(formData, "bcc", data.bcc)

--- a/src/api/trash.ts
+++ b/src/api/trash.ts
@@ -1,9 +1,9 @@
 import { apiClient } from "@/lib/api-client"
 import { normalizeSnippetText } from "@/lib/html-entities"
-import type { MarkerSliceResponse, ListThreadsParams } from "@/types/email"
-import type { TrashMessage, TrashThreadDetail, TrashThreadSummary } from "@/types/trash"
+import type { InboxMessage, ListThreadsParams, MarkerSliceResponse } from "@/types/email"
+import type { TrashThreadDetail, TrashThreadSummary } from "@/types/trash"
 
-function normalizeMessage(message: TrashMessage): TrashMessage {
+function normalizeMessage(message: InboxMessage): InboxMessage {
   return {
     ...message,
     snippet: normalizeSnippetText(message.snippet),
@@ -13,7 +13,7 @@ function normalizeMessage(message: TrashMessage): TrashMessage {
 function normalizeSummary(thread: TrashThreadSummary): TrashThreadSummary {
   return {
     ...thread,
-    deletedMessages: thread.deletedMessages.map(normalizeMessage),
+    snippet: normalizeSnippetText(thread.snippet),
   }
 }
 

--- a/src/api/trash.ts
+++ b/src/api/trash.ts
@@ -1,17 +1,45 @@
 import { apiClient } from "@/lib/api-client"
+import { normalizeSnippetText } from "@/lib/html-entities"
 import type { MarkerSliceResponse, ListThreadsParams } from "@/types/email"
-import type { TrashThreadDetail, TrashThreadSummary } from "@/types/trash"
+import type { TrashMessage, TrashThreadDetail, TrashThreadSummary } from "@/types/trash"
+
+function normalizeMessage(message: TrashMessage): TrashMessage {
+  return {
+    ...message,
+    snippet: normalizeSnippetText(message.snippet),
+  }
+}
+
+function normalizeSummary(thread: TrashThreadSummary): TrashThreadSummary {
+  return {
+    ...thread,
+    deletedMessages: thread.deletedMessages.map(normalizeMessage),
+  }
+}
+
+function normalizeDetail(thread: TrashThreadDetail): TrashThreadDetail {
+  return {
+    ...thread,
+    messages: thread.messages.map(normalizeMessage),
+  }
+}
 
 export async function getTrashThreads(
   params: ListThreadsParams = {}
 ): Promise<MarkerSliceResponse<TrashThreadSummary>> {
-  return apiClient.get<MarkerSliceResponse<TrashThreadSummary>>("/api/v1/trash/threads", {
+  const response = await apiClient.get<MarkerSliceResponse<TrashThreadSummary>>("/api/v1/trash/threads", {
     params: params as Record<string, string | number | boolean | null | undefined>,
   })
+
+  return {
+    ...response,
+    content: response.content.map(normalizeSummary),
+  }
 }
 
 export async function getTrashThreadDetail(threadId: string): Promise<TrashThreadDetail> {
-  return apiClient.get<TrashThreadDetail>(`/api/v1/trash/threads/${threadId}`)
+  const response = await apiClient.get<TrashThreadDetail>(`/api/v1/trash/threads/${threadId}`)
+  return normalizeDetail(response)
 }
 
 export async function deleteThread(threadId: string): Promise<void> {

--- a/src/components/inbox/email-detail.tsx
+++ b/src/components/inbox/email-detail.tsx
@@ -7,6 +7,7 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { getErrorMessage, getHttpStatus } from "@/lib/http-error"
@@ -463,7 +464,7 @@ export function EmailDetail({ threadId, onClose }: EmailDetailProps) {
       <ThreadToolbar onClose={onClose} onDelete={handleDeleteThread} isDeleting={isDeleting} />
       <ThreadHeader thread={thread} account={account} />
 
-      <div className="flex-1 overflow-auto">
+      <ScrollArea className="min-h-0 flex-1">
         <div className="p-2">
           <div className="divide-y overflow-hidden rounded-lg border bg-card">
             {messages.map((message) => (
@@ -477,7 +478,7 @@ export function EmailDetail({ threadId, onClose }: EmailDetailProps) {
             ))}
           </div>
         </div>
-      </div>
+      </ScrollArea>
       <ThreadFooter />
     </div>
   )

--- a/src/components/inbox/email-list-loading-rows.tsx
+++ b/src/components/inbox/email-list-loading-rows.tsx
@@ -1,0 +1,31 @@
+import { Skeleton } from "@/components/ui/skeleton"
+import { TableCell, TableRow } from "@/components/ui/table"
+
+interface EmailListLoadingRowsProps {
+  count?: number
+}
+
+export function EmailListLoadingRows({ count = 10 }: EmailListLoadingRowsProps) {
+  return Array.from({ length: count }).map((_, index) => (
+    <TableRow key={index}>
+      <TableCell className="w-10">
+        <Skeleton className="size-2.5 rounded-full" />
+      </TableCell>
+      <TableCell className="w-10">
+        <Skeleton className="size-2.5 rounded-full" />
+      </TableCell>
+      <TableCell className="w-[22%]">
+        <Skeleton className="h-5 w-28" />
+      </TableCell>
+      <TableCell className="w-[58%]">
+        <Skeleton className="h-5 w-full" />
+      </TableCell>
+      <TableCell className="hidden w-14 text-center md:table-cell">
+        <Skeleton className="mx-auto size-4 rounded-full" />
+      </TableCell>
+      <TableCell className="w-24 text-right">
+        <Skeleton className="ml-auto h-5 w-16" />
+      </TableCell>
+    </TableRow>
+  ))
+}

--- a/src/components/inbox/email-list.tsx
+++ b/src/components/inbox/email-list.tsx
@@ -5,10 +5,10 @@ import { toast } from "sonner"
 import { EmailErrorState } from "@/components/inbox/email-error-state"
 import { EmailListHeader } from "@/components/inbox/email-list-header"
 import { EmailListItem } from "@/components/inbox/email-list-item"
+import { EmailListLoadingRows } from "@/components/inbox/email-list-loading-rows"
 import { useDeleteThread, useRestoreTrashThread } from "@/mutations/trash"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { Skeleton } from "@/components/ui/skeleton"
-import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table"
+import { Table, TableBody } from "@/components/ui/table"
 import type { EmailFilter, InboxThreadSummary } from "@/types/email"
 import type { MailAccount } from "@/types/mail-account"
 
@@ -32,31 +32,6 @@ interface EmailListProps {
   loadMoreErrorTitle?: string
   loadMoreErrorDescription?: string
   onRetryLoadMore?: () => void
-}
-
-function LoadingRows() {
-  return Array.from({ length: 10 }).map((_, index) => (
-    <TableRow key={index}>
-      <TableCell className="w-10">
-        <Skeleton className="size-2.5 rounded-full" />
-      </TableCell>
-      <TableCell className="w-10">
-        <Skeleton className="size-2.5 rounded-full" />
-      </TableCell>
-      <TableCell className="w-[22%]">
-        <Skeleton className="h-4 w-28" />
-      </TableCell>
-      <TableCell className="w-[58%]">
-        <Skeleton className="h-4 w-full" />
-      </TableCell>
-      <TableCell className="hidden w-14 text-center md:table-cell">
-        <Skeleton className="mx-auto size-4 rounded-full" />
-      </TableCell>
-      <TableCell className="w-24 text-right">
-        <Skeleton className="ml-auto h-4 w-16" />
-      </TableCell>
-    </TableRow>
-  ))
 }
 
 export function EmailList({
@@ -151,7 +126,7 @@ export function EmailList({
         {isLoading ? (
           <Table className="table-fixed">
             <TableBody>
-              <LoadingRows />
+              <EmailListLoadingRows />
             </TableBody>
           </Table>
         ) : errorTitle && errorDescription ? (
@@ -181,7 +156,7 @@ export function EmailList({
                     />
                   )
                 })}
-                {isFetchingNextPage ? <LoadingRows /> : null}
+                {isFetchingNextPage ? <EmailListLoadingRows /> : null}
               </TableBody>
             </Table>
             {loadMoreErrorTitle && loadMoreErrorDescription ? (

--- a/src/components/trash/trash-detail.tsx
+++ b/src/components/trash/trash-detail.tsx
@@ -1,20 +1,24 @@
-import { ArrowLeft, MailOpen, Undo2 } from "lucide-react"
+import { useState } from "react"
+import { ArrowLeft, FileText, MailOpen, MoreVertical, Star, Undo2 } from "lucide-react"
 import { toast } from "sonner"
 
 import { EmailErrorState } from "@/components/inbox/email-error-state"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { getErrorMessage, getHttpStatus } from "@/lib/http-error"
 import { AccountIcon } from "@/lib/icon-entries"
+import { formatMailAddressList, getMailAddressLabel } from "@/lib/mail-address"
 import { useRestoreTrashMessage, useRestoreTrashThread } from "@/mutations/trash"
 import { useMailAccounts } from "@/queries/mail-accounts"
 import { useTrashThread } from "@/queries/trash"
+import type { Attachment, InboxMessage } from "@/types/email"
 import type { MailAccount } from "@/types/mail-account"
-import type { TrashMessage, TrashThreadDetail } from "@/types/trash"
+import type { TrashThreadDetail } from "@/types/trash"
 
 function formatDate(value: string) {
   return new Date(value).toLocaleDateString("ko-KR", {
@@ -25,6 +29,13 @@ function formatDate(value: string) {
     minute: "2-digit",
     hour12: true,
   })
+}
+
+function formatFileSize(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
 }
 
 function getInitials(value: string) {
@@ -78,7 +89,11 @@ function LoadingState() {
     <div className="flex h-full flex-col">
       <div className="flex h-11 w-full min-w-0 shrink-0 items-center justify-between gap-2 px-4">
         <Skeleton className="h-4 w-24" />
-        <Skeleton className="h-7 w-20 rounded-md" />
+        <div className="flex items-center gap-1">
+          {Array.from({ length: 2 }).map((_, index) => (
+            <Skeleton key={index} className="size-7 rounded-md" />
+          ))}
+        </div>
       </div>
       <div className="flex flex-col gap-4 p-6">
         <Skeleton className="h-7 w-3/4" />
@@ -113,9 +128,15 @@ function TrashToolbar({ onClose, onRestore, isRestoring }: TrashToolbarProps) {
         <span />
       )}
       <div className="ml-auto flex items-center gap-1">
-        <Button variant="ghost" size="sm" onClick={onRestore} disabled={isRestoring} aria-label="스레드 복구">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={onRestore}
+          disabled={isRestoring}
+          title="복구"
+          aria-label="메일 복구"
+        >
           <Undo2 className="size-4" />
-          복구
         </Button>
       </div>
     </div>
@@ -128,14 +149,13 @@ interface ThreadHeaderProps {
 }
 
 function ThreadHeader({ thread, account }: ThreadHeaderProps) {
-  const latestSubject = thread.messages.at(-1)?.subject || "(제목 없음)"
   const messageCount = thread.messages.length
   const hasInbound = thread.messages.some((m) => m.direction === "INBOUND")
   const hasOutbound = thread.messages.some((m) => m.direction === "OUTBOUND")
 
   return (
     <div className="shrink-0 border-b px-6 pt-2 pb-5">
-      <h2 className="text-xl leading-snug font-semibold wrap-break-word">{latestSubject}</h2>
+      <h2 className="text-xl leading-snug font-semibold wrap-break-word">{thread.latestSubject || "(제목 없음)"}</h2>
       <div className="mt-2 flex flex-wrap items-center gap-1">
         {account?.icon ? (
           <span
@@ -165,43 +185,157 @@ function ThreadHeader({ thread, account }: ThreadHeaderProps) {
   )
 }
 
-interface MessageItemProps {
-  message: TrashMessage
-  onRestore: () => void
-  isRestoring: boolean
+interface AttachmentChipProps {
+  attachment: Attachment
 }
 
-function MessageItem({ message, onRestore, isRestoring }: MessageItemProps) {
-  const senderLabel = message.fromAddress || "알 수 없음"
-  const receivers = message.toAddresses.length > 0 ? message.toAddresses.join(", ") : "-"
+function AttachmentChip({ attachment }: AttachmentChipProps) {
+  return (
+    <div className="inline-flex max-w-full items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-xs transition-colors hover:bg-muted">
+      <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+      <span className="truncate font-medium">{attachment.filename}</span>
+      <span className="shrink-0 text-muted-foreground">{formatFileSize(attachment.size)}</span>
+    </div>
+  )
+}
+
+function MessageBodyFrame({ html }: { html: string }) {
+  const [height, setHeight] = useState(0)
+
+  const srcDoc = `<!doctype html><html><head><meta charset="utf-8"><base target="_blank"><style>html,body{margin:0;padding:0;font-family:ui-sans-serif,system-ui,sans-serif;font-size:14px;color:#111;word-break:break-word;overflow-wrap:anywhere;overflow:hidden}img{max-width:100%;height:auto}</style></head><body>${html}</body></html>`
+
+  return (
+    <iframe
+      title="메일 본문"
+      sandbox="allow-same-origin allow-popups"
+      srcDoc={srcDoc}
+      className="w-full border-0 bg-white"
+      style={{ height: height || 200 }}
+      onLoad={(event) => {
+        const doc = event.currentTarget.contentDocument
+        if (!doc) return
+        const next = Math.max(doc.documentElement.scrollHeight, doc.body.scrollHeight)
+        setHeight(next)
+      }}
+    />
+  )
+}
+
+interface MessageItemProps {
+  message: InboxMessage
+  isExpanded: boolean
+  onToggle: () => void
+  onRestore: () => void
+}
+
+function MessageItem({ message, isExpanded, onToggle, onRestore }: MessageItemProps) {
+  const senderName = getMailAddressLabel(message.from)
+  const senderEmail = message.from.email
 
   return (
     <article className="w-full min-w-0 p-4">
-      <header className="flex items-start gap-3">
+      <header
+        className="flex cursor-pointer items-start gap-3"
+        onClick={onToggle}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault()
+            onToggle()
+          }
+        }}
+        aria-expanded={isExpanded}
+      >
         <Avatar>
-          <AvatarFallback>{getInitials(senderLabel)}</AvatarFallback>
+          <AvatarFallback>{getInitials(senderName)}</AvatarFallback>
         </Avatar>
 
         <div className="min-w-0 flex-1 overflow-hidden">
-          <p className="truncate text-sm font-semibold">{senderLabel}</p>
-          <p className="mt-0.5 text-xs break-all text-muted-foreground">받는 사람: {receivers}</p>
-          <p className="mt-1 truncate text-sm">{message.subject || "(제목 없음)"}</p>
-          {message.snippet ? (
-            <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{message.snippet}</p>
+          <div className="flex min-w-0 items-baseline gap-2">
+            <p className="shrink-0 truncate text-sm font-semibold">{senderName}</p>
+            {senderEmail && senderEmail !== senderName ? (
+              <p className="hidden min-w-0 flex-1 truncate text-xs text-muted-foreground sm:block">
+                &lt;{senderEmail}&gt;
+              </p>
+            ) : null}
+          </div>
+          {isExpanded ? (
+            <p className="mt-0.5 text-xs break-all text-muted-foreground">
+              받는 사람: {message.to.length > 0 ? formatMailAddressList(message.to) : "-"}
+            </p>
+          ) : (
+            <p className="mt-0.5 truncate text-xs text-muted-foreground">{message.snippet}</p>
+          )}
+          {isExpanded && message.cc.length > 0 ? (
+            <p className="mt-0.5 text-xs break-all text-muted-foreground">참조: {formatMailAddressList(message.cc)}</p>
           ) : null}
         </div>
 
-        <div className="flex shrink-0 flex-col items-end gap-2">
+        <div
+          className="flex shrink-0 items-center gap-1"
+          onClick={(event) => event.stopPropagation()}
+          onKeyDown={(event) => event.stopPropagation()}
+        >
           <span className="hidden truncate text-xs text-muted-foreground/80 sm:inline">
             {formatDate(message.sentAt)}
           </span>
-          <Button variant="outline" size="sm" onClick={onRestore} disabled={isRestoring} aria-label="메시지 복구">
-            <Undo2 className="size-4" />
-            복구
-          </Button>
+          <div className="flex shrink-0 items-center">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              disabled
+              title="즐겨찾기는 아직 지원되지 않습니다."
+              aria-label="즐겨찾기"
+            >
+              <Star className="size-4" />
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger render={<Button variant="ghost" size="icon-sm" aria-label="메시지 더보기" />}>
+                <MoreVertical className="size-4" />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={onRestore}>
+                  <Undo2 className="size-4" />
+                  복구
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
       </header>
+
+      {isExpanded ? (
+        <div className="mt-4 pl-0 sm:pl-13">
+          {message.bodyHtml ? (
+            <MessageBodyFrame html={message.bodyHtml} />
+          ) : (
+            <div className="prose prose-sm max-w-none text-sm whitespace-pre-wrap">{message.bodyText}</div>
+          )}
+
+          {message.attachments.length > 0 ? (
+            <div className="mt-4 flex flex-wrap gap-2">
+              {message.attachments.map((attachment) => (
+                <AttachmentChip key={attachment.id} attachment={attachment} />
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
     </article>
+  )
+}
+
+function TrashFooter({ onRestore, isRestoring }: { onRestore: () => void; isRestoring: boolean }) {
+  return (
+    <div className="shrink-0 border-t px-6 py-2">
+      <div className="flex flex-wrap gap-2">
+        <Button variant="outline" size="sm" onClick={onRestore} disabled={isRestoring}>
+          <Undo2 className="size-4" />
+          복구
+        </Button>
+      </div>
+    </div>
   )
 }
 
@@ -214,7 +348,27 @@ export function TrashDetail({ threadId, onClose }: TrashDetailProps) {
   const { data: thread, isLoading, isError, error, refetch } = useTrashThread(threadId)
   const { data: accounts } = useMailAccounts()
   const { mutate: restoreThread, isPending: isRestoringThread } = useRestoreTrashThread()
-  const { mutate: restoreMessage, isPending: isRestoringMessage } = useRestoreTrashMessage()
+  const { mutate: restoreMessage } = useRestoreTrashMessage()
+
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
+  const [expandedThreadId, setExpandedThreadId] = useState<string | null>(null)
+
+  if (thread && thread.threadId !== expandedThreadId) {
+    const next = new Set<string>()
+    const last = thread.messages.at(-1)
+    if (last) next.add(last.id)
+    setExpandedIds(next)
+    setExpandedThreadId(thread.threadId)
+  }
+
+  const toggleExpanded = (id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
 
   const handleRestoreThread = () => {
     if (!threadId) return
@@ -268,15 +422,18 @@ export function TrashDetail({ threadId, onClose }: TrashDetailProps) {
           <div className="divide-y overflow-hidden rounded-lg border bg-card">
             {messages.map((message) => (
               <MessageItem
-                key={message.messageId}
+                key={message.id}
                 message={message}
-                onRestore={() => handleRestoreMessage(message.messageId, messages.length === 1)}
-                isRestoring={isRestoringMessage}
+                isExpanded={expandedIds.has(message.id)}
+                onToggle={() => toggleExpanded(message.id)}
+                onRestore={() => handleRestoreMessage(message.id, messages.length === 1)}
               />
             ))}
           </div>
         </div>
       </ScrollArea>
+
+      <TrashFooter onRestore={handleRestoreThread} isRestoring={isRestoringThread} />
     </div>
   )
 }

--- a/src/components/trash/trash-detail.tsx
+++ b/src/components/trash/trash-detail.tsx
@@ -1,0 +1,281 @@
+import { ArrowLeft, MailOpen, Undo2 } from "lucide-react"
+import { toast } from "sonner"
+
+import { EmailErrorState } from "@/components/inbox/email-error-state"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { Skeleton } from "@/components/ui/skeleton"
+import { getErrorMessage, getHttpStatus } from "@/lib/http-error"
+import { AccountIcon } from "@/lib/icon-entries"
+import { useRestoreTrashMessage, useRestoreTrashThread } from "@/mutations/trash"
+import { useMailAccounts } from "@/queries/mail-accounts"
+import { useTrashThread } from "@/queries/trash"
+import type { MailAccount } from "@/types/mail-account"
+import type { TrashMessage, TrashThreadDetail } from "@/types/trash"
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  })
+}
+
+function getInitials(value: string) {
+  const localPart = value.split("@")[0]?.trim() ?? ""
+  return localPart.slice(0, 2).toUpperCase() || "?"
+}
+
+function getThreadDetailErrorCopy(error: unknown) {
+  switch (getHttpStatus(error)) {
+    case 401:
+      return {
+        title: "로그인이 필요합니다",
+        description: "세션이 만료되었거나 인증 정보가 없습니다. 다시 로그인한 뒤 스레드를 열어주세요.",
+      }
+    case 403:
+      return {
+        title: "이 스레드에 접근할 수 없습니다",
+        description: "현재 로그인한 사용자에게 이 스레드를 볼 권한이 없습니다.",
+      }
+    case 404:
+      return {
+        title: "스레드를 찾을 수 없습니다",
+        description: "영구 삭제되었거나 더 이상 접근할 수 없는 메일 스레드입니다.",
+      }
+    default:
+      return {
+        title: "스레드 내용을 불러오지 못했습니다",
+        description: getErrorMessage(error, "네트워크 상태를 확인한 뒤 다시 시도해주세요."),
+      }
+  }
+}
+
+function EmptyState() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3">
+      <div className="flex size-16 items-center justify-center rounded-full bg-muted">
+        <MailOpen className="size-8 text-muted-foreground" />
+      </div>
+      <div className="text-center">
+        <p className="font-medium text-muted-foreground">스레드를 선택해주세요</p>
+        <p className="mt-1 text-sm text-muted-foreground/70">
+          휴지통 목록에서 항목을 클릭하면 여기에 내용이 표시됩니다
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function LoadingState() {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-11 w-full min-w-0 shrink-0 items-center justify-between gap-2 px-4">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-7 w-20 rounded-md" />
+      </div>
+      <div className="flex flex-col gap-4 p-6">
+        <Skeleton className="h-7 w-3/4" />
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-10 rounded-full" />
+          <div className="space-y-1.5">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-48" />
+          </div>
+        </div>
+        <Separator />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    </div>
+  )
+}
+
+interface TrashToolbarProps {
+  onClose?: () => void
+  onRestore: () => void
+  isRestoring: boolean
+}
+
+function TrashToolbar({ onClose, onRestore, isRestoring }: TrashToolbarProps) {
+  return (
+    <div className="flex h-11 shrink-0 items-center justify-between gap-2 px-4">
+      {onClose ? (
+        <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="휴지통 목록으로 돌아가기">
+          <ArrowLeft className="size-4" />
+        </Button>
+      ) : (
+        <span />
+      )}
+      <div className="ml-auto flex items-center gap-1">
+        <Button variant="ghost" size="sm" onClick={onRestore} disabled={isRestoring} aria-label="스레드 복구">
+          <Undo2 className="size-4" />
+          복구
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+interface ThreadHeaderProps {
+  thread: TrashThreadDetail
+  account?: MailAccount
+}
+
+function ThreadHeader({ thread, account }: ThreadHeaderProps) {
+  const latestSubject = thread.messages.at(-1)?.subject || "(제목 없음)"
+  const messageCount = thread.messages.length
+  const hasInbound = thread.messages.some((m) => m.direction === "INBOUND")
+  const hasOutbound = thread.messages.some((m) => m.direction === "OUTBOUND")
+
+  return (
+    <div className="shrink-0 border-b px-6 pt-2 pb-5">
+      <h2 className="text-xl leading-snug font-semibold wrap-break-word">{latestSubject}</h2>
+      <div className="mt-2 flex flex-wrap items-center gap-1">
+        {account?.icon ? (
+          <span
+            className="inline-flex size-5 shrink-0 items-center justify-center rounded-full"
+            style={{ backgroundColor: account.color }}
+            aria-label={`${account.emailAddress} 계정`}
+            title={account.emailAddress}
+          >
+            <AccountIcon name={account.icon} className="size-3 text-white" />
+          </span>
+        ) : null}
+        {hasInbound && (
+          <Badge variant="outline" className="font-normal">
+            수신
+          </Badge>
+        )}
+        {hasOutbound && (
+          <Badge variant="outline" className="font-normal">
+            발신
+          </Badge>
+        )}
+        <Badge variant="secondary" className="font-normal">
+          메시지 {messageCount}개
+        </Badge>
+      </div>
+    </div>
+  )
+}
+
+interface MessageItemProps {
+  message: TrashMessage
+  onRestore: () => void
+  isRestoring: boolean
+}
+
+function MessageItem({ message, onRestore, isRestoring }: MessageItemProps) {
+  const senderLabel = message.fromAddress || "알 수 없음"
+  const receivers = message.toAddresses.length > 0 ? message.toAddresses.join(", ") : "-"
+
+  return (
+    <article className="w-full min-w-0 p-4">
+      <header className="flex items-start gap-3">
+        <Avatar>
+          <AvatarFallback>{getInitials(senderLabel)}</AvatarFallback>
+        </Avatar>
+
+        <div className="min-w-0 flex-1 overflow-hidden">
+          <p className="truncate text-sm font-semibold">{senderLabel}</p>
+          <p className="mt-0.5 text-xs break-all text-muted-foreground">받는 사람: {receivers}</p>
+          <p className="mt-1 truncate text-sm">{message.subject || "(제목 없음)"}</p>
+          {message.snippet ? (
+            <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{message.snippet}</p>
+          ) : null}
+        </div>
+
+        <div className="flex shrink-0 flex-col items-end gap-2">
+          <span className="hidden truncate text-xs text-muted-foreground/80 sm:inline">
+            {formatDate(message.sentAt)}
+          </span>
+          <Button variant="outline" size="sm" onClick={onRestore} disabled={isRestoring} aria-label="메시지 복구">
+            <Undo2 className="size-4" />
+            복구
+          </Button>
+        </div>
+      </header>
+    </article>
+  )
+}
+
+interface TrashDetailProps {
+  threadId: string | null
+  onClose?: () => void
+}
+
+export function TrashDetail({ threadId, onClose }: TrashDetailProps) {
+  const { data: thread, isLoading, isError, error, refetch } = useTrashThread(threadId)
+  const { data: accounts } = useMailAccounts()
+  const { mutate: restoreThread, isPending: isRestoringThread } = useRestoreTrashThread()
+  const { mutate: restoreMessage, isPending: isRestoringMessage } = useRestoreTrashMessage()
+
+  const handleRestoreThread = () => {
+    if (!threadId) return
+    restoreThread(threadId, {
+      onSuccess: () => {
+        onClose?.()
+        toast.success("스레드를 복구했습니다")
+      },
+      onError: (err) => {
+        toast.error("복구에 실패했습니다", {
+          description: getErrorMessage(err, "잠시 후 다시 시도해주세요."),
+        })
+      },
+    })
+  }
+
+  const handleRestoreMessage = (messageId: string, isLast: boolean) => {
+    restoreMessage(messageId, {
+      onSuccess: () => {
+        if (isLast) onClose?.()
+        toast.success("메시지를 복구했습니다")
+      },
+      onError: (err) => {
+        toast.error("복구에 실패했습니다", {
+          description: getErrorMessage(err, "잠시 후 다시 시도해주세요."),
+        })
+      },
+    })
+  }
+
+  if (!threadId) return <EmptyState />
+  if (isLoading) return <LoadingState />
+  if (isError) {
+    const errorCopy = getThreadDetailErrorCopy(error)
+    return (
+      <EmailErrorState title={errorCopy.title} description={errorCopy.description} onRetry={() => void refetch()} />
+    )
+  }
+  if (!thread) return <EmptyState />
+
+  const account = accounts?.find((item) => item.id === thread.accountId)
+  const messages = thread.messages
+
+  return (
+    <div className="flex h-full w-full min-w-0 flex-1 flex-col">
+      <TrashToolbar onClose={onClose} onRestore={handleRestoreThread} isRestoring={isRestoringThread} />
+      <ThreadHeader thread={thread} account={account} />
+
+      <div className="flex-1 overflow-auto">
+        <div className="p-2">
+          <div className="divide-y overflow-hidden rounded-lg border bg-card">
+            {messages.map((message) => (
+              <MessageItem
+                key={message.messageId}
+                message={message}
+                onRestore={() => handleRestoreMessage(message.messageId, messages.length === 1)}
+                isRestoring={isRestoringMessage}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/trash/trash-detail.tsx
+++ b/src/components/trash/trash-detail.tsx
@@ -5,6 +5,7 @@ import { EmailErrorState } from "@/components/inbox/email-error-state"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { getErrorMessage, getHttpStatus } from "@/lib/http-error"
@@ -262,7 +263,7 @@ export function TrashDetail({ threadId, onClose }: TrashDetailProps) {
       <TrashToolbar onClose={onClose} onRestore={handleRestoreThread} isRestoring={isRestoringThread} />
       <ThreadHeader thread={thread} account={account} />
 
-      <div className="flex-1 overflow-auto">
+      <ScrollArea className="min-h-0 flex-1">
         <div className="p-2">
           <div className="divide-y overflow-hidden rounded-lg border bg-card">
             {messages.map((message) => (
@@ -275,7 +276,7 @@ export function TrashDetail({ threadId, onClose }: TrashDetailProps) {
             ))}
           </div>
         </div>
-      </div>
+      </ScrollArea>
     </div>
   )
 }

--- a/src/components/trash/trash-list.tsx
+++ b/src/components/trash/trash-list.tsx
@@ -10,69 +10,23 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { Table, TableBody } from "@/components/ui/table"
 import { getErrorMessage } from "@/lib/http-error"
 import { useRestoreTrashThread } from "@/mutations/trash"
-import type { InboxThreadSummary, MailAddress } from "@/types/email"
+import type { InboxThreadSummary } from "@/types/email"
 import type { MailAccount } from "@/types/mail-account"
-import type { TrashMessage, TrashThreadSummary } from "@/types/trash"
-
-function getLatestMessage(thread: TrashThreadSummary): TrashMessage | undefined {
-  if (thread.deletedMessages.length === 0) {
-    return undefined
-  }
-
-  return thread.deletedMessages.reduce((latest, current) => {
-    const latestTime = new Date(latest.deletedAt).getTime()
-    const currentTime = new Date(current.deletedAt).getTime()
-
-    return currentTime > latestTime ? current : latest
-  })
-}
-
-function parseAddress(raw: string): MailAddress {
-  const match = raw.match(/^\s*(.*?)\s*<(.+)>\s*$/)
-  if (match) {
-    const name = match[1].replace(/^["']|["']$/g, "").trim()
-    return { ...(name ? { name } : {}), email: match[2].trim() }
-  }
-
-  return { email: raw.trim() }
-}
-
-function getParticipant(thread: TrashThreadSummary, latest: TrashMessage | undefined): MailAddress {
-  if (!latest) {
-    return { email: thread.accountEmail }
-  }
-
-  if (latest.direction === "INBOUND") {
-    return parseAddress(latest.fromAddress || thread.accountEmail)
-  }
-
-  const [first, ...rest] = latest.toAddresses
-  if (!first) {
-    return { email: thread.accountEmail }
-  }
-
-  const parsed = parseAddress(first)
-  if (rest.length === 0) {
-    return parsed
-  }
-
-  const base = parsed.name || parsed.email
-  return { name: `${base} 외 ${rest.length}명`, email: parsed.email }
-}
+import type { TrashThreadSummary } from "@/types/trash"
 
 function toInboxSummary(thread: TrashThreadSummary): InboxThreadSummary {
-  const latest = getLatestMessage(thread)
-
   return {
     threadId: thread.threadId,
     gmailThreadId: thread.gmailThreadId,
     accountId: thread.accountId,
-    latestSubject: latest?.subject ?? "",
-    participant: getParticipant(thread, latest),
-    snippet: latest?.snippet ?? "",
-    isRead: true,
-    lastMessageAt: latest?.deletedAt ?? "",
-    attachments: [],
+    latestSubject: thread.latestSubject,
+    participant: thread.participant,
+    snippet: thread.snippet,
+    isRead: thread.isRead,
+    lastMessageAt: thread.lastMessageAt,
+    attachments: thread.attachments,
+    messageCount: thread.messageCount,
+    labels: thread.labels,
   }
 }
 

--- a/src/components/trash/trash-list.tsx
+++ b/src/components/trash/trash-list.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useRef, useState } from "react"
+import { SquareMinus, Trash2, Undo2 } from "lucide-react"
+import { toast } from "sonner"
+
+import { EmailErrorState } from "@/components/inbox/email-error-state"
+import { EmailListItem } from "@/components/inbox/email-list-item"
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table"
+import { getErrorMessage } from "@/lib/http-error"
+import { useRestoreTrashThread } from "@/mutations/trash"
+import type { InboxThreadSummary, MailAddress } from "@/types/email"
+import type { MailAccount } from "@/types/mail-account"
+import type { TrashMessage, TrashThreadSummary } from "@/types/trash"
+
+function getLatestMessage(thread: TrashThreadSummary): TrashMessage | undefined {
+  if (thread.deletedMessages.length === 0) {
+    return undefined
+  }
+
+  return thread.deletedMessages.reduce((latest, current) => {
+    const latestTime = new Date(latest.deletedAt).getTime()
+    const currentTime = new Date(current.deletedAt).getTime()
+
+    return currentTime > latestTime ? current : latest
+  })
+}
+
+function parseAddress(raw: string): MailAddress {
+  const match = raw.match(/^\s*(.*?)\s*<(.+)>\s*$/)
+  if (match) {
+    const name = match[1].replace(/^["']|["']$/g, "").trim()
+    return { ...(name ? { name } : {}), email: match[2].trim() }
+  }
+
+  return { email: raw.trim() }
+}
+
+function getParticipant(thread: TrashThreadSummary, latest: TrashMessage | undefined): MailAddress {
+  if (!latest) {
+    return { email: thread.accountEmail }
+  }
+
+  if (latest.direction === "INBOUND") {
+    return parseAddress(latest.fromAddress || thread.accountEmail)
+  }
+
+  const [first, ...rest] = latest.toAddresses
+  if (!first) {
+    return { email: thread.accountEmail }
+  }
+
+  const parsed = parseAddress(first)
+  if (rest.length === 0) {
+    return parsed
+  }
+
+  const base = parsed.name || parsed.email
+  return { name: `${base} 외 ${rest.length}명`, email: parsed.email }
+}
+
+function toInboxSummary(thread: TrashThreadSummary): InboxThreadSummary {
+  const latest = getLatestMessage(thread)
+
+  return {
+    threadId: thread.threadId,
+    gmailThreadId: thread.gmailThreadId,
+    accountId: thread.accountId,
+    latestSubject: latest?.subject ?? "",
+    participant: getParticipant(thread, latest),
+    snippet: latest?.snippet ?? "",
+    isRead: true,
+    lastMessageAt: latest?.deletedAt ?? "",
+    attachments: [],
+  }
+}
+
+interface TrashListProps {
+  mailboxName: string
+  threads: TrashThreadSummary[] | undefined
+  isLoading: boolean
+  isFetchingNextPage: boolean
+  hasNextPage: boolean
+  selectedThreadId: string | null
+  onSelectThread: (id: string) => void
+  onLoadMore: () => void
+  getAccount: (accountId: string) => MailAccount | undefined
+  emptyTitle?: string
+  emptyDescription?: string
+  errorTitle?: string
+  errorDescription?: string
+  onRetry?: () => void
+  loadMoreErrorTitle?: string
+  loadMoreErrorDescription?: string
+  onRetryLoadMore?: () => void
+}
+
+function LoadingRows() {
+  return Array.from({ length: 10 }).map((_, index) => (
+    <TableRow key={index}>
+      <TableCell className="w-10">
+        <Skeleton className="size-2.5 rounded-full" />
+      </TableCell>
+      <TableCell className="w-10">
+        <Skeleton className="size-2.5 rounded-full" />
+      </TableCell>
+      <TableCell className="w-[22%]">
+        <Skeleton className="h-4 w-28" />
+      </TableCell>
+      <TableCell className="w-[58%]">
+        <Skeleton className="h-4 w-full" />
+      </TableCell>
+      <TableCell className="hidden w-14 text-center md:table-cell">
+        <Skeleton className="mx-auto size-4 rounded-full" />
+      </TableCell>
+      <TableCell className="w-24 text-right">
+        <Skeleton className="ml-auto h-4 w-16" />
+      </TableCell>
+    </TableRow>
+  ))
+}
+
+export function TrashList({
+  mailboxName,
+  threads,
+  isLoading,
+  isFetchingNextPage,
+  hasNextPage,
+  selectedThreadId,
+  onSelectThread,
+  onLoadMore,
+  getAccount,
+  emptyTitle = "휴지통이 비어있습니다",
+  emptyDescription,
+  errorTitle,
+  errorDescription,
+  onRetry,
+  loadMoreErrorTitle,
+  loadMoreErrorDescription,
+  onRetryLoadMore,
+}: TrashListProps) {
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const { mutate: restoreThread } = useRestoreTrashThread()
+
+  const toggleSelected = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  useEffect(() => {
+    const node = loadMoreRef.current
+
+    if (!node || !hasNextPage) {
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && !isFetchingNextPage) {
+          onLoadMore()
+        }
+      },
+      { rootMargin: "200px 0px" }
+    )
+
+    observer.observe(node)
+
+    return () => observer.disconnect()
+  }, [hasNextPage, isFetchingNextPage, onLoadMore])
+
+  const header =
+    selectedIds.size > 0 ? (
+      <div className="flex h-11 shrink-0 items-center gap-2 border-b bg-accent/40 px-3">
+        <Button variant="ghost" size="icon-sm" onClick={() => setSelectedIds(new Set())} aria-label="선택 해제">
+          <SquareMinus />
+        </Button>
+        <span className="text-sm font-medium">{selectedIds.size.toLocaleString()}개 선택됨</span>
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => {
+              const ids = Array.from(selectedIds)
+              if (ids.length === 0) return
+              setSelectedIds(new Set())
+              ids.forEach((id) =>
+                restoreThread(id, {
+                  onError: (err) => {
+                    toast.error("복구에 실패했습니다", {
+                      description: getErrorMessage(err, "잠시 후 다시 시도해주세요."),
+                    })
+                  },
+                })
+              )
+              toast.success(`${ids.length}개 스레드를 복구했습니다`)
+            }}
+            aria-label="선택 복구"
+          >
+            <Undo2 data-icon="inline-start" />
+          </Button>
+        </div>
+      </div>
+    ) : (
+      <div className="flex h-11 shrink-0 items-center gap-3 border-b px-4">
+        <h2 className="min-w-0 truncate text-sm font-medium">{mailboxName}</h2>
+        <span className="hidden rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground sm:inline-flex">
+          {(threads?.length ?? 0).toLocaleString()}개
+        </span>
+      </div>
+    )
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-[inherit]">
+      {header}
+
+      <ScrollArea className="min-h-0 flex-1">
+        {isLoading ? (
+          <Table className="table-fixed">
+            <TableBody>
+              <LoadingRows />
+            </TableBody>
+          </Table>
+        ) : errorTitle && errorDescription ? (
+          <EmailErrorState title={errorTitle} description={errorDescription} onRetry={onRetry} />
+        ) : threads && threads.length > 0 ? (
+          <>
+            <Table className="table-fixed">
+              <colgroup>
+                <col className="w-10" />
+                <col className="w-10" />
+                <col className="w-[28%] md:w-[22%]" />
+                <col className="w-[52%] md:w-[58%]" />
+                <col className="hidden w-14 md:table-column" />
+                <col className="w-24" />
+              </colgroup>
+              <TableBody>
+                {threads.map((thread) => (
+                  <EmailListItem
+                    key={thread.threadId}
+                    thread={toInboxSummary(thread)}
+                    isSelected={selectedThreadId === thread.threadId}
+                    isChecked={selectedIds.has(thread.threadId)}
+                    account={getAccount(thread.accountId)}
+                    onSelect={() => onSelectThread(thread.threadId)}
+                    onToggleCheck={() => toggleSelected(thread.threadId)}
+                  />
+                ))}
+                {isFetchingNextPage ? <LoadingRows /> : null}
+              </TableBody>
+            </Table>
+            {loadMoreErrorTitle && loadMoreErrorDescription ? (
+              <div className="border-t px-4 py-3">
+                <EmailErrorState
+                  title={loadMoreErrorTitle}
+                  description={loadMoreErrorDescription}
+                  retryLabel="추가 메일 다시 불러오기"
+                  onRetry={onRetryLoadMore}
+                />
+              </div>
+            ) : null}
+            <div ref={loadMoreRef} className="h-1" />
+          </>
+        ) : (
+          <div className="flex min-h-full flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+            <div className="flex size-14 items-center justify-center rounded-full bg-muted">
+              <Trash2 className="size-7 text-muted-foreground/60" />
+            </div>
+            <div>
+              <p className="font-medium text-muted-foreground">{emptyTitle}</p>
+              {emptyDescription ? <p className="mt-1 text-sm text-muted-foreground">{emptyDescription}</p> : null}
+            </div>
+          </div>
+        )}
+      </ScrollArea>
+    </div>
+  )
+}

--- a/src/components/trash/trash-list.tsx
+++ b/src/components/trash/trash-list.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { SquareMinus, Trash2, Undo2 } from "lucide-react"
 import { toast } from "sonner"
 
@@ -117,7 +117,7 @@ export function TrashList({
 }: TrashListProps) {
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
-  const { mutate: restoreThread } = useRestoreTrashThread()
+  const { mutateAsync: restoreThread } = useRestoreTrashThread()
 
   const toggleSelected = (id: string) => {
     setSelectedIds((prev) => {
@@ -152,31 +152,69 @@ export function TrashList({
     return () => observer.disconnect()
   }, [hasNextPage, isFetchingNextPage, onLoadMore])
 
+  const visibleSelectedIds = useMemo(() => {
+    if (selectedIds.size === 0 || !threads || threads.length === 0) {
+      return selectedIds
+    }
+
+    const visibleIds = new Set(threads.map((thread) => thread.threadId))
+    const next = new Set<string>()
+    for (const id of selectedIds) {
+      if (visibleIds.has(id)) {
+        next.add(id)
+      }
+    }
+
+    return next.size === selectedIds.size ? selectedIds : next
+  }, [selectedIds, threads])
+
   const header =
-    selectedIds.size > 0 ? (
+    visibleSelectedIds.size > 0 ? (
       <div className="flex h-11 shrink-0 items-center gap-2 border-b bg-accent/40 px-3">
         <Button variant="ghost" size="icon-sm" onClick={() => setSelectedIds(new Set())} aria-label="선택 해제">
           <SquareMinus />
         </Button>
-        <span className="text-sm font-medium">{selectedIds.size.toLocaleString()}개 선택됨</span>
+        <span className="text-sm font-medium">{visibleSelectedIds.size.toLocaleString()}개 선택됨</span>
         <div className="ml-auto flex shrink-0 items-center gap-2">
           <Button
             variant="ghost"
             size="icon-sm"
-            onClick={() => {
-              const ids = Array.from(selectedIds)
+            onClick={async () => {
+              const ids = Array.from(visibleSelectedIds)
               if (ids.length === 0) return
               setSelectedIds(new Set())
-              ids.forEach((id) =>
-                restoreThread(id, {
-                  onError: (err) => {
-                    toast.error("복구에 실패했습니다", {
-                      description: getErrorMessage(err, "잠시 후 다시 시도해주세요."),
-                    })
-                  },
+
+              const results = await Promise.allSettled(ids.map((id) => restoreThread(id)))
+              const failed = results
+                .map((result, index) => ({ result, id: ids[index] }))
+                .filter(
+                  (entry): entry is { result: PromiseRejectedResult; id: string } => entry.result.status === "rejected"
+                )
+              const succeededCount = ids.length - failed.length
+
+              if (failed.length === 0) {
+                toast.success(`${ids.length}개 스레드를 복구했습니다`)
+                return
+              }
+
+              setSelectedIds((prev) => {
+                const next = new Set(prev)
+                for (const { id } of failed) {
+                  next.add(id)
+                }
+                return next
+              })
+
+              if (succeededCount === 0) {
+                toast.error("복구에 실패했습니다", {
+                  description: getErrorMessage(failed[0].result.reason, "잠시 후 다시 시도해주세요."),
                 })
-              )
-              toast.success(`${ids.length}개 스레드를 복구했습니다`)
+                return
+              }
+
+              toast.warning(`${succeededCount}개 복구, ${failed.length}개 실패`, {
+                description: getErrorMessage(failed[0].result.reason, "실패한 항목은 선택 상태로 두었습니다."),
+              })
             }}
             aria-label="선택 복구"
           >
@@ -223,7 +261,7 @@ export function TrashList({
                     key={thread.threadId}
                     thread={toInboxSummary(thread)}
                     isSelected={selectedThreadId === thread.threadId}
-                    isChecked={selectedIds.has(thread.threadId)}
+                    isChecked={visibleSelectedIds.has(thread.threadId)}
                     account={getAccount(thread.accountId)}
                     onSelect={() => onSelectThread(thread.threadId)}
                     onToggleCheck={() => toggleSelected(thread.threadId)}

--- a/src/components/trash/trash-list.tsx
+++ b/src/components/trash/trash-list.tsx
@@ -4,10 +4,10 @@ import { toast } from "sonner"
 
 import { EmailErrorState } from "@/components/inbox/email-error-state"
 import { EmailListItem } from "@/components/inbox/email-list-item"
+import { EmailListLoadingRows } from "@/components/inbox/email-list-loading-rows"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { Skeleton } from "@/components/ui/skeleton"
-import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table"
+import { Table, TableBody } from "@/components/ui/table"
 import { getErrorMessage } from "@/lib/http-error"
 import { useRestoreTrashThread } from "@/mutations/trash"
 import type { InboxThreadSummary, MailAddress } from "@/types/email"
@@ -94,31 +94,6 @@ interface TrashListProps {
   loadMoreErrorTitle?: string
   loadMoreErrorDescription?: string
   onRetryLoadMore?: () => void
-}
-
-function LoadingRows() {
-  return Array.from({ length: 10 }).map((_, index) => (
-    <TableRow key={index}>
-      <TableCell className="w-10">
-        <Skeleton className="size-2.5 rounded-full" />
-      </TableCell>
-      <TableCell className="w-10">
-        <Skeleton className="size-2.5 rounded-full" />
-      </TableCell>
-      <TableCell className="w-[22%]">
-        <Skeleton className="h-4 w-28" />
-      </TableCell>
-      <TableCell className="w-[58%]">
-        <Skeleton className="h-4 w-full" />
-      </TableCell>
-      <TableCell className="hidden w-14 text-center md:table-cell">
-        <Skeleton className="mx-auto size-4 rounded-full" />
-      </TableCell>
-      <TableCell className="w-24 text-right">
-        <Skeleton className="ml-auto h-4 w-16" />
-      </TableCell>
-    </TableRow>
-  ))
 }
 
 export function TrashList({
@@ -226,7 +201,7 @@ export function TrashList({
         {isLoading ? (
           <Table className="table-fixed">
             <TableBody>
-              <LoadingRows />
+              <EmailListLoadingRows />
             </TableBody>
           </Table>
         ) : errorTitle && errorDescription ? (
@@ -254,7 +229,7 @@ export function TrashList({
                     onToggleCheck={() => toggleSelected(thread.threadId)}
                   />
                 ))}
-                {isFetchingNextPage ? <LoadingRows /> : null}
+                {isFetchingNextPage ? <EmailListLoadingRows /> : null}
               </TableBody>
             </Table>
             {loadMoreErrorTitle && loadMoreErrorDescription ? (

--- a/src/routes/_authenticated/mail/$mailbox.tsx
+++ b/src/routes/_authenticated/mail/$mailbox.tsx
@@ -17,7 +17,7 @@ import { useMailAccounts } from "@/queries/mail-accounts"
 import { useMailboxThreads } from "@/queries/emails"
 import { useTrashThreads } from "@/queries/trash"
 import { isSupportedMailboxId, MAILBOX_LABELS, parseMailboxId, type PrimaryMailboxId } from "@/types/email"
-import type { TrashMessage, TrashThreadSummary } from "@/types/trash"
+import type { TrashThreadSummary } from "@/types/trash"
 
 export const Route = createFileRoute("/_authenticated/mail/$mailbox")({
   params: {
@@ -270,17 +270,11 @@ function matchTrashThread(thread: TrashThreadSummary, terms: string[]): boolean 
     return true
   }
 
-  const parts: string[] = [thread.accountEmail]
+  const text = [thread.latestSubject, thread.snippet, thread.participant.email, thread.participant.name]
+    .filter(Boolean)
+    .join(" ")
 
-  for (const message of thread.deletedMessages) {
-    parts.push(message.subject ?? "", message.fromAddress ?? "", message.snippet ?? "", ...(message.toAddresses ?? []))
-  }
-
-  return matchesSearch(parts.filter(Boolean).join(" "), terms)
-}
-
-function hasRecentDeletion(messages: TrashMessage[]): boolean {
-  return messages.length > 0
+  return matchesSearch(text, terms)
 }
 
 function TrashMailboxView() {
@@ -322,10 +316,6 @@ function TrashMailboxView() {
 
   const threads = loadedThreads.filter((thread) => {
     if (selectedAccount && thread.accountId !== selectedAccount.id) {
-      return false
-    }
-
-    if (!hasRecentDeletion(thread.deletedMessages)) {
       return false
     }
 

--- a/src/routes/_authenticated/mail/$mailbox.tsx
+++ b/src/routes/_authenticated/mail/$mailbox.tsx
@@ -4,6 +4,8 @@ import { toast } from "sonner"
 
 import { EmailDetail } from "@/components/inbox/email-detail"
 import { EmailList } from "@/components/inbox/email-list"
+import { TrashDetail } from "@/components/trash/trash-detail"
+import { TrashList } from "@/components/trash/trash-list"
 import { Separator } from "@/components/ui/separator"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { getErrorMessage, getHttpStatus } from "@/lib/http-error"
@@ -13,7 +15,9 @@ import { cn } from "@/lib/utils"
 import { useMarkThreadAsRead } from "@/mutations/emails"
 import { useMailAccounts } from "@/queries/mail-accounts"
 import { useMailboxThreads } from "@/queries/emails"
-import { isSupportedMailboxId, MAILBOX_LABELS, parseMailboxId } from "@/types/email"
+import { useTrashThreads } from "@/queries/trash"
+import { isSupportedMailboxId, MAILBOX_LABELS, parseMailboxId, type PrimaryMailboxId } from "@/types/email"
+import type { TrashMessage, TrashThreadSummary } from "@/types/trash"
 
 export const Route = createFileRoute("/_authenticated/mail/$mailbox")({
   params: {
@@ -62,6 +66,15 @@ function getMailboxThreadsErrorCopy(error: unknown) {
 
 function MailboxPage() {
   const { mailbox } = Route.useParams()
+
+  if (mailbox === "trash") {
+    return <TrashMailboxView />
+  }
+
+  return <MailboxView mailbox={mailbox} />
+}
+
+function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
   const { query = "", filter = "all", accountId, thread: selectedThreadId = null } = Route.useSearch()
   const navigate = Route.useNavigate()
   const isMobile = useIsMobile()
@@ -245,6 +258,167 @@ function MailboxPage() {
                 })
               }}
             />
+          </div>
+        </>
+      ) : null}
+    </div>
+  )
+}
+
+function matchTrashThread(thread: TrashThreadSummary, terms: string[]): boolean {
+  if (terms.length === 0) {
+    return true
+  }
+
+  const parts: string[] = [thread.accountEmail]
+
+  for (const message of thread.deletedMessages) {
+    parts.push(message.subject ?? "", message.fromAddress ?? "", message.snippet ?? "", ...(message.toAddresses ?? []))
+  }
+
+  return matchesSearch(parts.filter(Boolean).join(" "), terms)
+}
+
+function hasRecentDeletion(messages: TrashMessage[]): boolean {
+  return messages.length > 0
+}
+
+function TrashMailboxView() {
+  const { query = "", accountId, thread: selectedThreadId = null } = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const isMobile = useIsMobile()
+  const { data: accounts } = useMailAccounts()
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isFetchNextPageError,
+  } = useTrashThreads()
+
+  const loadedThreads = data?.pages.flatMap((page) => page.content) ?? []
+  const searchTerms = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
+  const selectedAccount = accountId ? (accounts?.find((account) => account.id === accountId) ?? null) : null
+
+  useEffect(() => {
+    if (!accountId || accounts === undefined || selectedAccount) {
+      return
+    }
+
+    toast.error("유효하지 않은 계정입니다")
+
+    void navigate({
+      search: (previous) => ({
+        ...previous,
+        accountId: undefined,
+      }),
+      replace: true,
+    })
+  }, [accounts, navigate, selectedAccount, accountId])
+
+  const threads = loadedThreads.filter((thread) => {
+    if (selectedAccount && thread.accountId !== selectedAccount.id) {
+      return false
+    }
+
+    if (!hasRecentDeletion(thread.deletedMessages)) {
+      return false
+    }
+
+    return matchTrashThread(thread, searchTerms)
+  })
+
+  const mailboxErrorCopy = isError ? getMailboxThreadsErrorCopy(error) : null
+  const loadMoreErrorCopy = isFetchNextPageError ? getMailboxThreadsErrorCopy(error) : null
+
+  const getAccount = (id: string) => accounts?.find((account) => account.id === id)
+
+  const visibleSelectedThreadId = threads.some((thread) => thread.threadId === selectedThreadId)
+    ? selectedThreadId
+    : null
+  const hasSelection = visibleSelectedThreadId != null
+
+  let emptyTitle = "휴지통이 비어있습니다"
+  let emptyDescription: string | undefined
+
+  if (searchTerms.length > 0) {
+    emptyTitle = "검색 결과가 없습니다"
+    emptyDescription = "현재까지 불러온 휴지통 항목에서 검색 결과를 찾지 못했습니다."
+  } else if (selectedAccount?.id) {
+    emptyTitle = "선택한 계정의 휴지통 항목이 없습니다"
+    emptyDescription = `${selectedAccount.alias} (${selectedAccount.emailAddress}) 계정에서 삭제된 메일이 없습니다.`
+  }
+
+  const trashList = (
+    <TrashList
+      mailboxName={MAILBOX_LABELS.trash}
+      threads={threads}
+      isLoading={isLoading}
+      isFetchingNextPage={isFetchingNextPage}
+      hasNextPage={!!hasNextPage}
+      selectedThreadId={visibleSelectedThreadId}
+      onSelectThread={(threadId) => {
+        void navigate({
+          search: (previous) => ({
+            ...previous,
+            thread: threadId,
+          }),
+        })
+      }}
+      onLoadMore={() => {
+        if (hasNextPage && !isFetchingNextPage) {
+          void fetchNextPage()
+        }
+      }}
+      getAccount={getAccount}
+      emptyTitle={emptyTitle}
+      emptyDescription={emptyDescription}
+      errorTitle={isError && threads.length === 0 ? mailboxErrorCopy?.title : undefined}
+      errorDescription={isError && threads.length === 0 ? mailboxErrorCopy?.description : undefined}
+      onRetry={isError ? () => void refetch() : undefined}
+      loadMoreErrorTitle={threads.length > 0 ? loadMoreErrorCopy?.title : undefined}
+      loadMoreErrorDescription={threads.length > 0 ? loadMoreErrorCopy?.description : undefined}
+      onRetryLoadMore={threads.length > 0 && isFetchNextPageError ? () => void fetchNextPage() : undefined}
+    />
+  )
+
+  const closeThread = () => {
+    void navigate({
+      search: (previous) => ({
+        ...previous,
+        thread: undefined,
+      }),
+      replace: true,
+    })
+  }
+
+  if (isMobile) {
+    return (
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        {hasSelection ? <TrashDetail threadId={visibleSelectedThreadId} onClose={closeThread} /> : trashList}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 overflow-hidden">
+      <div
+        className={cn(
+          "min-h-0 min-w-0 border-r-0 transition-[flex-basis,width] duration-300 ease-out",
+          hasSelection ? "basis-1/2" : "basis-full"
+        )}
+      >
+        {trashList}
+      </div>
+      {hasSelection ? (
+        <>
+          <Separator orientation="vertical" />
+          <div className="min-h-0 min-w-0 basis-2/3">
+            <TrashDetail threadId={visibleSelectedThreadId} onClose={closeThread} />
           </div>
         </>
       ) : null}

--- a/src/types/email.ts
+++ b/src/types/email.ts
@@ -35,12 +35,19 @@ export interface MailAddress {
   email: string
 }
 
+export interface LabelSummary {
+  labelId: string
+  name: string
+  colorCode: string
+}
+
 export interface InboxMessage {
   id: string
   gmailMessageId: string
   subject: string
   direction: "INBOUND" | "OUTBOUND"
   from: MailAddress
+  replyTo?: MailAddress
   to: MailAddress[]
   cc: MailAddress[]
   snippet: string
@@ -49,6 +56,7 @@ export interface InboxMessage {
   bodyText: string
   bodyHtml: string
   attachments: Attachment[]
+  labels: LabelSummary[]
 }
 
 export interface InboxThreadSummary {
@@ -61,6 +69,8 @@ export interface InboxThreadSummary {
   isRead: boolean
   lastMessageAt: string
   attachments: Attachment[]
+  messageCount: number
+  labels: LabelSummary[]
 }
 
 export interface InboxThreadDetail {
@@ -90,6 +100,7 @@ export interface UnreadCountResponse {
 
 export interface ComposeEmailData {
   from?: string
+  replyTo?: string
   to: string[]
   cc?: string[]
   bcc?: string[]

--- a/src/types/trash.ts
+++ b/src/types/trash.ts
@@ -1,27 +1,31 @@
-export interface TrashMessage {
-  messageId: string
-  gmailMessageId: string
-  direction: "INBOUND" | "OUTBOUND"
-  subject: string
-  fromAddress: string
-  toAddresses: string[]
-  snippet: string
-  sentAt: string
-  deletedAt: string
+import type { Attachment, InboxMessage, MailAddress } from "./email"
+
+export interface LabelSummary {
+  labelId: string
+  name: string
+  colorCode: string
 }
 
 export interface TrashThreadSummary {
   threadId: string
   gmailThreadId: string
   accountId: string
-  accountEmail: string
-  deletedMessages: TrashMessage[]
+  latestSubject: string
+  participant: MailAddress
+  snippet: string
+  isRead: boolean
+  lastMessageAt: string
+  attachments: Attachment[]
+  messageCount: number
+  labels: LabelSummary[]
 }
 
 export interface TrashThreadDetail {
   threadId: string
   gmailThreadId: string
   accountId: string
-  accountEmail: string
-  messages: TrashMessage[]
+  latestSubject: string
+  isRead: boolean
+  lastMessageAt: string
+  messages: InboxMessage[]
 }

--- a/src/types/trash.ts
+++ b/src/types/trash.ts
@@ -1,10 +1,6 @@
-import type { Attachment, InboxMessage, MailAddress } from "./email"
+import type { Attachment, InboxMessage, LabelSummary, MailAddress } from "./email"
 
-export interface LabelSummary {
-  labelId: string
-  name: string
-  colorCode: string
-}
+export type { LabelSummary }
 
 export interface TrashThreadSummary {
   threadId: string


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#7

### 📌 Task

- #17 

## 💡 작업 내용

- 휴지통 메일함 라우팅 분기 추가 (`/mail/trash` → `TrashMailboxView`)
- 휴지통 리스트 컴포넌트(`TrashList`) 신규 구현 — 계정 필터, 무한 스크롤, 복원/영구삭제 액션 포함
- 휴지통 상세 컴포넌트(`TrashDetail`) 신규 구현 — 스레드/개별 메시지 복원 액션 포함
- 휴지통 API에 snippet 텍스트 정규화(`normalizeSnippetText`) 적용
- 메일 리스트 로딩 스켈레톤을 `EmailListLoadingRows` 컴포넌트로 분리해 휴지통 리스트와 공유
- 메일 상세(`EmailDetail`) 본문 영역 스크롤을 `ScrollArea`로 교체
- 수정된 API에 따라 코드 수정

## 📝 추가 설명

- TrashList는 기존 EmailListItem을 재사용하기 위해 TrashThreadSummary → InboxThreadSummary 형태로 변환해 렌더링
- 휴지통은 읽음/안읽음 필터가 없어 TrashMailboxView로 별도 분기
- 영구 삭제 기능은 API 미구현 상태로 추후 작업 예정
- 2026.05.04 기준 API 코드 구현 완료

| 파일 | 변경 사항 |
| -- | -- |
| `email.ts` | `LabelSummary` 인터페이스 추가 (trash.ts에서 이동) |
| `email.ts` | `InboxMessage`에 `replyTo?: MailAddress, labels: LabelSummary[ ]` 추가 |
| `email.ts` | `InboxThreadSummary`에 `messageCount: number, labels: LabelSummary[ ]` 추가 |
| `email.ts` | `ComposeEmailData`에 `replyTo?: string` 추가 |
| `emails.ts` | `sendMail`에서 `replyTo` 필드를 FormData에 포함하도록 수정 |
| `trash.ts` | 중복 `LabelSummary` 정의 제거 → `email.ts`에서 import 후 re-export |



## 🖼️ 스크린샷

- 휴지통 리스트

<img width="1919" height="869" alt="image" src="https://github.com/user-attachments/assets/bb9a13f3-17b2-48d7-b2b8-ce43524950b0" />

- 휴지통 스레드 상세보기

<img width="1916" height="864" alt="image" src="https://github.com/user-attachments/assets/5c9b5c5c-0562-45c2-9c55-f67435c8aa44" />
