### PR TITLE
[STORY-302] 메일 작성 파일 및 이미지 첨부 구현

### DIFF
--- a/src/api/emails.ts
+++ b/src/api/emails.ts
@@ -1,4 +1,4 @@
-import { apiClient } from "@/lib/api-client"
+import { apiClient, buildApiUrl } from "@/lib/api-client"
 import { getVisibleAttachments } from "@/lib/email-attachments"
 import { normalizeSnippetText } from "@/lib/html-entities"
 import type {
@@ -75,6 +75,10 @@ export async function markThreadAsRead(threadId: string): Promise<void> {
 
 export async function getUnreadCount(): Promise<UnreadCountResponse> {
   return apiClient.get<UnreadCountResponse>("/api/v1/threads/inbox/unread-count")
+}
+
+export function getAttachmentDownloadUrl(attachmentId: string) {
+  return buildApiUrl(`/api/v1/mail/attachments/${attachmentId}`)
 }
 
 export async function sendMail(data: ComposeEmailData): Promise<void> {

--- a/src/api/emails.ts
+++ b/src/api/emails.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@/lib/api-client"
+import { getVisibleAttachments } from "@/lib/email-attachments"
 import { normalizeSnippetText } from "@/lib/html-entities"
 import type {
   ComposeEmailData,
@@ -14,6 +15,7 @@ import type {
 function normalizeThreadSummary(thread: InboxThreadSummary): InboxThreadSummary {
   return {
     ...thread,
+    attachments: getVisibleAttachments(thread.attachments),
     snippet: normalizeSnippetText(thread.snippet),
   }
 }
@@ -21,6 +23,7 @@ function normalizeThreadSummary(thread: InboxThreadSummary): InboxThreadSummary 
 function normalizeMessage(message: InboxMessage): InboxMessage {
   return {
     ...message,
+    attachments: getVisibleAttachments(message.attachments),
     snippet: normalizeSnippetText(message.snippet),
   }
 }

--- a/src/api/emails.ts
+++ b/src/api/emails.ts
@@ -32,7 +32,7 @@ function normalizeThreadDetail(thread: InboxThreadDetail): InboxThreadDetail {
   }
 }
 
-function appendFormDataValues(formData: FormData, key: string, values?: string[]) {
+function appendFormDataValues(formData: FormData, key: string, values?: readonly string[]) {
   for (const value of values ?? []) {
     const normalizedValue = value.trim()
 
@@ -95,5 +95,20 @@ export async function sendMail(data: ComposeEmailData): Promise<void> {
     formData.append("attachments", attachment)
   }
 
-  await apiClient.post<void>("/api/v1/mail/send", formData)
+  for (const inlineImage of data.inlineImages ?? []) {
+    const cid = inlineImage.cid.trim()
+
+    if (!cid) {
+      continue
+    }
+
+    formData.append("inlineImages", inlineImage.file)
+    formData.append("inlineImageCids", cid)
+  }
+
+  await apiClient.post<void>("/api/v1/mail/send", formData, {
+    params: {
+      messageId: data.messageId,
+    },
+  })
 }

--- a/src/api/trash.ts
+++ b/src/api/trash.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@/lib/api-client"
+import { getVisibleAttachments } from "@/lib/email-attachments"
 import { normalizeSnippetText } from "@/lib/html-entities"
 import type { InboxMessage, ListThreadsParams, MarkerSliceResponse } from "@/types/email"
 import type { TrashThreadDetail, TrashThreadSummary } from "@/types/trash"
@@ -6,6 +7,7 @@ import type { TrashThreadDetail, TrashThreadSummary } from "@/types/trash"
 function normalizeMessage(message: InboxMessage): InboxMessage {
   return {
     ...message,
+    attachments: getVisibleAttachments(message.attachments),
     snippet: normalizeSnippetText(message.snippet),
   }
 }
@@ -13,6 +15,7 @@ function normalizeMessage(message: InboxMessage): InboxMessage {
 function normalizeSummary(thread: TrashThreadSummary): TrashThreadSummary {
   return {
     ...thread,
+    attachments: getVisibleAttachments(thread.attachments),
     snippet: normalizeSnippetText(thread.snippet),
   }
 }

--- a/src/components/attachment-chip.tsx
+++ b/src/components/attachment-chip.tsx
@@ -1,0 +1,28 @@
+import { FileText } from "lucide-react"
+
+import { buttonVariants } from "@/components/ui/button"
+import { getAttachmentDownloadUrl } from "@/api/emails"
+import { formatFileSize } from "@/lib/file-size"
+import { cn } from "@/lib/utils"
+import type { Attachment } from "@/types/email"
+
+interface AttachmentChipProps {
+  attachment: Attachment
+}
+
+export function AttachmentChip({ attachment }: AttachmentChipProps) {
+  return (
+    <a
+      href={getAttachmentDownloadUrl(attachment.id)}
+      target="_blank"
+      rel="noopener noreferrer"
+      download={attachment.filename}
+      className={cn(buttonVariants({ variant: "outline", size: "sm" }), "gap-2")}
+      title={`${attachment.filename} 다운로드`}
+    >
+      <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+      <span className="truncate font-medium">{attachment.filename}</span>
+      <span className="shrink-0 text-muted-foreground">{formatFileSize(attachment.size)}</span>
+    </a>
+  )
+}

--- a/src/components/attachment-chip.tsx
+++ b/src/components/attachment-chip.tsx
@@ -1,6 +1,6 @@
-import { FileText } from "lucide-react"
+import { FileText, X } from "lucide-react"
 
-import { buttonVariants } from "@/components/ui/button"
+import { Button, buttonVariants } from "@/components/ui/button"
 import { getAttachmentDownloadUrl } from "@/api/emails"
 import { formatFileSize } from "@/lib/file-size"
 import { cn } from "@/lib/utils"
@@ -10,19 +10,58 @@ interface AttachmentChipProps {
   attachment: Attachment
 }
 
+interface FileAttachmentChipProps {
+  file: File
+  onRemove?: () => void
+}
+
+function AttachmentChipBody({ filename, size }: { filename: string; size: number }) {
+  return (
+    <>
+      <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 truncate font-medium">{filename}</span>
+      <span className="shrink-0 text-muted-foreground">{formatFileSize(size)}</span>
+    </>
+  )
+}
+
+function RemoveAttachmentButton({ filename, onRemove }: { filename: string; onRemove: () => void }) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-xs"
+      className="-mr-1 size-5"
+      onClick={onRemove}
+      aria-label={`${filename} 첨부파일 제거`}
+    >
+      <X className="size-3" />
+    </Button>
+  )
+}
+
 export function AttachmentChip({ attachment }: AttachmentChipProps) {
+  const className = cn(buttonVariants({ variant: "outline", size: "sm" }), "max-w-full gap-2")
+
   return (
     <a
       href={getAttachmentDownloadUrl(attachment.id)}
       target="_blank"
       rel="noopener noreferrer"
       download={attachment.filename}
-      className={cn(buttonVariants({ variant: "outline", size: "sm" }), "gap-2")}
+      className={className}
       title={`${attachment.filename} 다운로드`}
     >
-      <FileText className="size-3.5 shrink-0 text-muted-foreground" />
-      <span className="truncate font-medium">{attachment.filename}</span>
-      <span className="shrink-0 text-muted-foreground">{formatFileSize(attachment.size)}</span>
+      <AttachmentChipBody filename={attachment.filename} size={attachment.size} />
     </a>
+  )
+}
+
+export function FileAttachmentChip({ file, onRemove }: FileAttachmentChipProps) {
+  return (
+    <Button variant="outline" size="sm" className="gap-2 hover:bg-background active:not-aria-[haspopup]:translate-y-0">
+      <AttachmentChipBody filename={file.name} size={file.size} />
+      {onRemove ? <RemoveAttachmentButton filename={file.name} onRemove={onRemove} /> : null}
+    </Button>
   )
 }

--- a/src/components/compose/compose-editor-toolbar.tsx
+++ b/src/components/compose/compose-editor-toolbar.tsx
@@ -83,6 +83,13 @@ function ToolbarSeparator() {
 function getActiveAlignment(editor: ComposeEditor | null) {
   if (!editor) return "left"
 
+  const selectedNode = getSelectedNode(editor)
+  const selectedAlignment = selectedNode?.attrs.align ?? selectedNode?.attrs.alignment
+
+  if (typeof selectedAlignment === "string" && selectedAlignment.length > 0) {
+    return selectedAlignment
+  }
+
   const { $from } = editor.state.selection
 
   for (let depth = $from.depth; depth >= 0; depth -= 1) {
@@ -95,6 +102,28 @@ function getActiveAlignment(editor: ComposeEditor | null) {
   }
 
   return "left"
+}
+
+function getSelectedNode(editor: ComposeEditor) {
+  const selection = editor.state.selection
+
+  if (!("node" in selection)) {
+    return null
+  }
+
+  return selection.node as { attrs: Record<string, unknown>; type: { name: string } } | null
+}
+
+function setEditorAlignment(editor: ComposeEditor, alignment: "left" | "center" | "right") {
+  const selectedNode = getSelectedNode(editor)
+
+  if (selectedNode?.type.name === "image") {
+    editor.chain().focus().updateAttributes("image", { alignment }).run()
+    return
+  }
+
+  editor.commands.focus()
+  setTextAlignment(editor, alignment)
 }
 
 function getToolbarState(editor: ComposeEditor | null) {
@@ -366,36 +395,21 @@ export function ComposeEditorToolbar({ editor, disabled, onInsertImage }: Compos
           icon={AlignLeft}
           active={toolbarState?.activeAlignment === "left"}
           disabled={isDisabled}
-          onClick={() =>
-            runCommand((editor) => {
-              editor.commands.focus()
-              setTextAlignment(editor, "left")
-            })
-          }
+          onClick={() => runCommand((editor) => setEditorAlignment(editor, "left"))}
         />
         <ToolbarIconButton
           label="가운데 정렬"
           icon={AlignCenter}
           active={toolbarState?.activeAlignment === "center"}
           disabled={isDisabled}
-          onClick={() =>
-            runCommand((editor) => {
-              editor.commands.focus()
-              setTextAlignment(editor, "center")
-            })
-          }
+          onClick={() => runCommand((editor) => setEditorAlignment(editor, "center"))}
         />
         <ToolbarIconButton
           label="오른쪽 정렬"
           icon={AlignRight}
           active={toolbarState?.activeAlignment === "right"}
           disabled={isDisabled}
-          onClick={() =>
-            runCommand((editor) => {
-              editor.commands.focus()
-              setTextAlignment(editor, "right")
-            })
-          }
+          onClick={() => runCommand((editor) => setEditorAlignment(editor, "right"))}
         />
 
         <ToolbarSeparator />

--- a/src/components/compose/compose-editor-toolbar.tsx
+++ b/src/components/compose/compose-editor-toolbar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react"
 import type { EmailEditorRef } from "@react-email/editor"
 import type {} from "@react-email/editor/extensions"
+import type {} from "@react-email/editor/plugins"
 import { defaultSlashCommands } from "@react-email/editor/ui"
 import { setTextAlignment } from "@react-email/editor/utils"
 import { useEditorState } from "@tiptap/react"
@@ -208,10 +209,9 @@ function insertLinkedText(editor: ComposeEditor, range: LinkSelectionRange, text
 interface ComposeEditorToolbarProps {
   editor: ComposeEditor | null
   disabled: boolean
-  onInsertImage?: () => void
 }
 
-export function ComposeEditorToolbar({ editor, disabled, onInsertImage }: ComposeEditorToolbarProps) {
+export function ComposeEditorToolbar({ editor, disabled }: ComposeEditorToolbarProps) {
   const linkTextInputRef = useRef<HTMLInputElement>(null)
   const linkSelectionRangeRef = useRef<LinkSelectionRange | null>(null)
   const [isLinkEditorOpen, setIsLinkEditorOpen] = useState(false)
@@ -356,8 +356,8 @@ export function ComposeEditorToolbar({ editor, disabled, onInsertImage }: Compos
         <ToolbarIconButton
           label="이미지 삽입"
           icon={ImageIcon}
-          disabled={isDisabled || !onInsertImage}
-          onClick={() => onInsertImage?.()}
+          disabled={isDisabled}
+          onClick={() => runCommand((editor) => editor.chain().focus().uploadImage().run())}
         />
 
         <ToolbarSeparator />

--- a/src/components/compose/compose-editor-toolbar.tsx
+++ b/src/components/compose/compose-editor-toolbar.tsx
@@ -13,6 +13,7 @@ import {
   Heading1,
   Heading2,
   Heading3,
+  Image as ImageIcon,
   Italic,
   Link as LinkIcon,
   List,
@@ -178,9 +179,10 @@ function insertLinkedText(editor: ComposeEditor, range: LinkSelectionRange, text
 interface ComposeEditorToolbarProps {
   editor: ComposeEditor | null
   disabled: boolean
+  onInsertImage?: () => void
 }
 
-export function ComposeEditorToolbar({ editor, disabled }: ComposeEditorToolbarProps) {
+export function ComposeEditorToolbar({ editor, disabled, onInsertImage }: ComposeEditorToolbarProps) {
   const linkTextInputRef = useRef<HTMLInputElement>(null)
   const linkSelectionRangeRef = useRef<LinkSelectionRange | null>(null)
   const [isLinkEditorOpen, setIsLinkEditorOpen] = useState(false)
@@ -321,6 +323,12 @@ export function ComposeEditorToolbar({ editor, disabled }: ComposeEditorToolbarP
           active={toolbarState?.isLink ?? false}
           disabled={isDisabled}
           onClick={() => runCommand(openLinkEditor)}
+        />
+        <ToolbarIconButton
+          label="이미지 삽입"
+          icon={ImageIcon}
+          disabled={isDisabled || !onInsertImage}
+          onClick={() => onInsertImage?.()}
         />
 
         <ToolbarSeparator />

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -384,12 +384,6 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
     setInlineImages(nextInlineImages)
   }
 
-  const handleInsertImage = () => {
-    editor?.chain().focus().run()
-    const commands = editor?.commands as { uploadImage?: () => boolean } | undefined
-    commands?.uploadImage?.()
-  }
-
   const createSendPreview = async () => {
     if (isFromAddressPending) {
       toast.error("발신 계정을 불러오는 중입니다")
@@ -599,7 +593,7 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
         </Select>
       </div>
 
-      <ComposeEditorToolbar editor={editor} disabled={!isEditorReady} onInsertImage={handleInsertImage} />
+      <ComposeEditorToolbar editor={editor} disabled={!isEditorReady} />
 
       <div className="flex-1 overflow-hidden" aria-label="메일 본문">
         <EmailEditor

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -306,25 +306,22 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
       return
     }
 
-    setAttachments((currentAttachments) => {
-      const nextAttachments = [...currentAttachments, ...selectedFiles]
+    const nextAttachments = [...attachmentsRef.current, ...selectedFiles]
 
-      if (getSendFileSize(nextAttachments, inlineImagesRef.current) > MAX_SEND_FILE_BYTES) {
-        showUploadLimitError()
-        return currentAttachments
-      }
+    if (getSendFileSize(nextAttachments, inlineImagesRef.current) > MAX_SEND_FILE_BYTES) {
+      showUploadLimitError()
+      return
+    }
 
-      attachmentsRef.current = nextAttachments
-      return nextAttachments
-    })
+    attachmentsRef.current = nextAttachments
+    setAttachments(nextAttachments)
   }
 
   const removeAttachment = (index: number) => {
-    setAttachments((currentAttachments) => {
-      const nextAttachments = currentAttachments.filter((_, currentIndex) => currentIndex !== index)
-      attachmentsRef.current = nextAttachments
-      return nextAttachments
-    })
+    const nextAttachments = attachmentsRef.current.filter((_, currentIndex) => currentIndex !== index)
+
+    attachmentsRef.current = nextAttachments
+    setAttachments(nextAttachments)
   }
 
   const uploadInlineImage = useCallback(async (file: File) => {
@@ -354,11 +351,10 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
       objectUrl,
     }
 
-    setInlineImages((currentInlineImages) => {
-      const nextInlineImages = [...currentInlineImages, inlineImage]
-      inlineImagesRef.current = nextInlineImages
-      return nextInlineImages
-    })
+    const nextInlineImages = [...inlineImagesRef.current, inlineImage]
+
+    inlineImagesRef.current = nextInlineImages
+    setInlineImages(nextInlineImages)
 
     return { url: objectUrl }
   }, [])
@@ -366,30 +362,26 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
   const pruneUnusedInlineImages = (content: JSONContent) => {
     const imageMetadata = collectImageMetadata(content)
 
-    setInlineImages((currentInlineImages) => {
-      if (currentInlineImages.length === 0) {
-        return currentInlineImages
+    if (inlineImagesRef.current.length === 0) {
+      return
+    }
+
+    const nextInlineImages = inlineImagesRef.current.filter((inlineImage) => imageMetadata.has(inlineImage.objectUrl))
+
+    if (nextInlineImages.length === inlineImagesRef.current.length) {
+      return
+    }
+
+    const nextInlineImageObjectUrls = new Set(nextInlineImages.map((inlineImage) => inlineImage.objectUrl))
+
+    for (const inlineImage of inlineImagesRef.current) {
+      if (!nextInlineImageObjectUrls.has(inlineImage.objectUrl)) {
+        URL.revokeObjectURL(inlineImage.objectUrl)
       }
+    }
 
-      let didRemoveImage = false
-      const nextInlineImages = currentInlineImages.filter((inlineImage) => {
-        const isUsed = imageMetadata.has(inlineImage.objectUrl)
-
-        if (!isUsed) {
-          didRemoveImage = true
-          URL.revokeObjectURL(inlineImage.objectUrl)
-        }
-
-        return isUsed
-      })
-
-      if (!didRemoveImage) {
-        return currentInlineImages
-      }
-
-      inlineImagesRef.current = nextInlineImages
-      return nextInlineImages
-    })
+    inlineImagesRef.current = nextInlineImages
+    setInlineImages(nextInlineImages)
   }
 
   const handleInsertImage = () => {

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -24,6 +24,7 @@ interface ComposeEmailProps {
 }
 
 interface PendingInlineImage extends ComposeInlineImage {
+  fileKey: string
   id: string
   objectUrl: string
 }
@@ -42,8 +43,16 @@ function getFilesSize(files: readonly File[]) {
   return files.reduce((total, file) => total + file.size, 0)
 }
 
+function getFileKey(file: File) {
+  return [file.name, file.type, file.size, file.lastModified].join(":")
+}
+
+function getInlineImagesSize(inlineImages: readonly PendingInlineImage[]) {
+  return getFilesSize(Array.from(new Map(inlineImages.map((image) => [image.fileKey, image.file])).values()))
+}
+
 function getSendFileSize(attachments: readonly File[], inlineImages: readonly PendingInlineImage[]) {
-  return getFilesSize(attachments) + getFilesSize(inlineImages.map((image) => image.file))
+  return getFilesSize(attachments) + getInlineImagesSize(inlineImages)
 }
 
 function normalizeImageAlignment(value: unknown): ComposeImageMetadata["alignment"] {
@@ -140,7 +149,7 @@ function buildMailContentWithImages(
   const document = parser.parseFromString(html, "text/html")
   const imageByObjectUrl = new Map(inlineImages.map((image) => [image.objectUrl, image]))
   const usedInlineImages: PendingInlineImage[] = []
-  const usedObjectUrls = new Set<string>()
+  const usedInlineImageCids = new Set<string>()
 
   for (const imageElement of Array.from(document.querySelectorAll<HTMLImageElement>("img[src]"))) {
     const src = imageElement.getAttribute("src")
@@ -155,9 +164,9 @@ function buildMailContentWithImages(
       imageElement.setAttribute("src", `cid:${inlineImage.cid}`)
     }
 
-    if (!usedObjectUrls.has(src)) {
+    if (!usedInlineImageCids.has(inlineImage.cid)) {
       usedInlineImages.push(inlineImage)
-      usedObjectUrls.add(src)
+      usedInlineImageCids.add(inlineImage.cid)
     }
   }
 
@@ -273,17 +282,24 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
       throw new Error("Only image files can be inserted inline")
     }
 
-    if (getSendFileSize(attachmentsRef.current, inlineImagesRef.current) + file.size > MAX_SEND_FILE_BYTES) {
+    const fileKey = getFileKey(file)
+    const reusableInlineImage = inlineImagesRef.current.find((inlineImage) => inlineImage.fileKey === fileKey)
+    const inlineImagesSizeDelta = reusableInlineImage ? 0 : file.size
+
+    if (
+      getSendFileSize(attachmentsRef.current, inlineImagesRef.current) + inlineImagesSizeDelta >
+      MAX_SEND_FILE_BYTES
+    ) {
       showUploadLimitError()
       throw new Error("Inline image exceeds upload size limit")
     }
 
-    const cid = createInlineImageCid()
     const objectUrl = URL.createObjectURL(file)
     const inlineImage: PendingInlineImage = {
-      id: cid,
-      cid,
-      file,
+      fileKey,
+      id: objectUrl,
+      cid: reusableInlineImage?.cid ?? createInlineImageCid(),
+      file: reusableInlineImage?.file ?? file,
       objectUrl,
     }
 
@@ -571,35 +587,30 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
           onChange={handleAttachmentInputChange}
         />
 
-        {(attachments.length > 0 || inlineImages.length > 0) && (
+        {attachments.length > 0 && (
           <div className="mb-3 flex flex-col gap-2">
-            {attachments.length > 0 && (
-              <ul className="flex flex-col gap-1.5">
-                {attachments.map((attachment, index) => (
-                  <li
-                    key={`${attachment.name}-${attachment.lastModified}-${index}`}
-                    className="flex min-h-9 items-center gap-2 rounded-md border bg-background px-3 text-sm"
+            <ul className="flex flex-col gap-1.5">
+              {attachments.map((attachment, index) => (
+                <li
+                  key={`${attachment.name}-${attachment.lastModified}-${index}`}
+                  className="flex min-h-9 items-center gap-2 rounded-md border bg-background px-3 text-sm"
+                >
+                  <FileText className="size-4 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1 truncate">{attachment.name}</span>
+                  <span className="shrink-0 text-xs text-muted-foreground">{formatFileSize(attachment.size)}</span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    className="-mr-2"
+                    onClick={() => removeAttachment(index)}
+                    aria-label={`${attachment.name} 첨부파일 제거`}
                   >
-                    <FileText className="size-4 shrink-0 text-muted-foreground" />
-                    <span className="min-w-0 flex-1 truncate">{attachment.name}</span>
-                    <span className="shrink-0 text-xs text-muted-foreground">{formatFileSize(attachment.size)}</span>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      className="-mr-2"
-                      onClick={() => removeAttachment(index)}
-                      aria-label={`${attachment.name} 첨부파일 제거`}
-                    >
-                      <X className="size-4" />
-                    </Button>
-                  </li>
-                ))}
-              </ul>
-            )}
-            {inlineImages.length > 0 && (
-              <div className="text-xs text-muted-foreground">본문 이미지 {inlineImages.length}개가 포함됩니다</div>
-            )}
+                    <X className="size-4" />
+                  </Button>
+                </li>
+              ))}
+            </ul>
           </div>
         )}
 

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react"
 import { EmailEditor, type EmailEditorRef } from "@react-email/editor"
-import { Loader2, X } from "lucide-react"
+import type { JSONContent } from "@tiptap/core"
+import { FileText, Loader2, Paperclip, X } from "lucide-react"
 import { useNavigate } from "@tanstack/react-router"
 import { toast } from "sonner"
 
@@ -9,20 +10,95 @@ import { ComposeSendPreviewDialog, type ComposeSendPreviewData } from "@/compone
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { formatFileSize } from "@/lib/file-size"
 import { getErrorMessage } from "@/lib/http-error"
 import { parseMailAddressInput } from "@/lib/mail-address"
 import { useSendMail } from "@/mutations/emails"
 import { useActiveMailAccounts } from "@/queries/mail-accounts"
 import { useUser } from "@/queries/user"
+import type { ComposeInlineImage } from "@/types/email"
 
 interface ComposeEmailProps {
   fromAddress: string | null
   onFromAddressChange: (value: string | null) => void
 }
 
+interface PendingInlineImage extends ComposeInlineImage {
+  id: string
+  objectUrl: string
+}
+
+const MAX_SEND_FILE_BYTES = 20 * 1024 * 1024
+
+function createInlineImageCid() {
+  return `inline-${crypto.randomUUID()}`
+}
+
+function getFilesSize(files: readonly File[]) {
+  return files.reduce((total, file) => total + file.size, 0)
+}
+
+function getSendFileSize(attachments: readonly File[], inlineImages: readonly PendingInlineImage[]) {
+  return getFilesSize(attachments) + getFilesSize(inlineImages.map((image) => image.file))
+}
+
+function collectImageSources(content: JSONContent) {
+  const sources = new Set<string>()
+
+  const visit = (node: JSONContent) => {
+    if (node.type === "image" && typeof node.attrs?.src === "string") {
+      sources.add(node.attrs.src)
+    }
+
+    for (const child of node.content ?? []) {
+      visit(child)
+    }
+  }
+
+  visit(content)
+
+  return sources
+}
+
+function buildMailContentWithCidImages(html: string, inlineImages: readonly PendingInlineImage[]) {
+  const parser = new DOMParser()
+  const document = parser.parseFromString(html, "text/html")
+  const imageByObjectUrl = new Map(inlineImages.map((image) => [image.objectUrl, image]))
+  const usedInlineImages: PendingInlineImage[] = []
+  const usedObjectUrls = new Set<string>()
+
+  for (const imageElement of Array.from(document.querySelectorAll("img[src]"))) {
+    const src = imageElement.getAttribute("src")
+    if (!src) continue
+
+    const inlineImage = imageByObjectUrl.get(src)
+    if (!inlineImage) continue
+
+    imageElement.setAttribute("src", `cid:${inlineImage.cid}`)
+
+    if (!usedObjectUrls.has(src)) {
+      usedInlineImages.push(inlineImage)
+      usedObjectUrls.add(src)
+    }
+  }
+
+  const isFullHtmlDocument = /^\s*(<!doctype|<html[\s>])/i.test(html)
+  const content = isFullHtmlDocument
+    ? `<!doctype html>\n${document.documentElement.outerHTML}`
+    : document.body.innerHTML
+
+  return {
+    content,
+    inlineImages: usedInlineImages.map(({ file, cid }) => ({ file, cid })),
+  }
+}
+
 export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailProps) {
   const navigate = useNavigate()
   const editorRef = useRef<EmailEditorRef>(null)
+  const attachmentInputRef = useRef<HTMLInputElement>(null)
+  const attachmentsRef = useRef<File[]>([])
+  const inlineImagesRef = useRef<PendingInlineImage[]>([])
   const { data: user, isPending: isUserPending } = useUser()
   const { data: activeMailAccounts, isPending: isMailAccountsPending } = useActiveMailAccounts()
   const sendMailMutation = useSendMail()
@@ -37,6 +113,8 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
   const [sendPreview, setSendPreview] = useState<ComposeSendPreviewData | null>(null)
   const [showCc, setShowCc] = useState(false)
   const [showBcc, setShowBcc] = useState(false)
+  const [attachments, setAttachments] = useState<File[]>([])
+  const [inlineImages, setInlineImages] = useState<PendingInlineImage[]>([])
 
   const activeFromAddressSet = useMemo(
     () => new Set((activeMailAccounts ?? []).map((mailAccount) => mailAccount.emailAddress)),
@@ -60,6 +138,119 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
   const isSendPreviewOpen = sendPreview !== null
   const cannotSend =
     sendMailMutation.isPending || isPreparingPreview || isFromAddressPending || !selectedFromAddress || !isEditorReady
+
+  useEffect(() => {
+    attachmentsRef.current = attachments
+  }, [attachments])
+
+  useEffect(() => {
+    inlineImagesRef.current = inlineImages
+  }, [inlineImages])
+
+  useEffect(() => {
+    return () => {
+      for (const inlineImage of inlineImagesRef.current) {
+        URL.revokeObjectURL(inlineImage.objectUrl)
+      }
+    }
+  }, [])
+
+  const showUploadLimitError = () => {
+    toast.error("첨부 용량은 본문 이미지를 포함해 20MB 이하만 가능합니다")
+  }
+
+  const handleAttachmentInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const selectedFiles = Array.from(event.target.files ?? [])
+    event.target.value = ""
+
+    if (selectedFiles.length === 0) {
+      return
+    }
+
+    setAttachments((currentAttachments) => {
+      const nextAttachments = [...currentAttachments, ...selectedFiles]
+
+      if (getSendFileSize(nextAttachments, inlineImagesRef.current) > MAX_SEND_FILE_BYTES) {
+        showUploadLimitError()
+        return currentAttachments
+      }
+
+      attachmentsRef.current = nextAttachments
+      return nextAttachments
+    })
+  }
+
+  const removeAttachment = (index: number) => {
+    setAttachments((currentAttachments) => {
+      const nextAttachments = currentAttachments.filter((_, currentIndex) => currentIndex !== index)
+      attachmentsRef.current = nextAttachments
+      return nextAttachments
+    })
+  }
+
+  const uploadInlineImage = useCallback(async (file: File) => {
+    if (!file.type.startsWith("image/")) {
+      toast.error("이미지 파일만 본문에 삽입할 수 있습니다")
+      throw new Error("Only image files can be inserted inline")
+    }
+
+    if (getSendFileSize(attachmentsRef.current, inlineImagesRef.current) + file.size > MAX_SEND_FILE_BYTES) {
+      showUploadLimitError()
+      throw new Error("Inline image exceeds upload size limit")
+    }
+
+    const cid = createInlineImageCid()
+    const objectUrl = URL.createObjectURL(file)
+    const inlineImage: PendingInlineImage = {
+      id: cid,
+      cid,
+      file,
+      objectUrl,
+    }
+
+    setInlineImages((currentInlineImages) => {
+      const nextInlineImages = [...currentInlineImages, inlineImage]
+      inlineImagesRef.current = nextInlineImages
+      return nextInlineImages
+    })
+
+    return { url: objectUrl }
+  }, [])
+
+  const pruneUnusedInlineImages = (content: JSONContent) => {
+    const imageSources = collectImageSources(content)
+
+    setInlineImages((currentInlineImages) => {
+      if (currentInlineImages.length === 0) {
+        return currentInlineImages
+      }
+
+      let didRemoveImage = false
+      const nextInlineImages = currentInlineImages.filter((inlineImage) => {
+        const isUsed = imageSources.has(inlineImage.objectUrl)
+
+        if (!isUsed) {
+          didRemoveImage = true
+          URL.revokeObjectURL(inlineImage.objectUrl)
+        }
+
+        return isUsed
+      })
+
+      if (!didRemoveImage) {
+        return currentInlineImages
+      }
+
+      inlineImagesRef.current = nextInlineImages
+      return nextInlineImages
+    })
+  }
+
+  const handleInsertImage = () => {
+    editor?.chain().focus().run()
+    const commands = editor?.commands as { uploadImage?: () => boolean } | undefined
+    commands?.uploadImage?.()
+  }
 
   const createSendPreview = async () => {
     if (isFromAddressPending) {
@@ -101,6 +292,8 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
       return null
     }
 
+    const sendContent = buildMailContentWithCidImages(emailContent.html, inlineImagesRef.current)
+
     return {
       mail: {
         from: selectedFromAddress,
@@ -108,9 +301,12 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
         cc: parseMailAddressInput(cc),
         bcc: parseMailAddressInput(bcc),
         subject: subject.trim(),
-        content: emailContent.html,
+        content: sendContent.content,
+        attachments,
+        inlineImages: sendContent.inlineImages,
       },
       text: emailContent.text,
+      html: emailContent.html,
     } satisfies ComposeSendPreviewData
   }
 
@@ -259,7 +455,7 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
         </Select>
       </div>
 
-      <ComposeEditorToolbar editor={editor} disabled={!isEditorReady} />
+      <ComposeEditorToolbar editor={editor} disabled={!isEditorReady} onInsertImage={handleInsertImage} />
 
       <div className="flex-1 overflow-hidden" aria-label="메일 본문">
         <EmailEditor
@@ -267,6 +463,7 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
           theme="basic"
           placeholder="메일 내용을 입력하세요. / 로 블록을 추가할 수 있습니다."
           className="compose-email-editor h-full overflow-auto text-sm outline-none"
+          onUploadImage={uploadInlineImage}
           onReady={(ref) => {
             setIsEditorReady(true)
             setIsEditorEmpty(ref.editor?.isEmpty ?? true)
@@ -274,15 +471,68 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
           }}
           onUpdate={(ref) => {
             setIsEditorEmpty(ref.editor?.isEmpty ?? true)
+            pruneUnusedInlineImages(ref.getJSON())
           }}
         />
       </div>
 
       <div className="shrink-0 border-t px-4 py-3">
-        <Button className="w-full" size="lg" onClick={handleSendPreview} disabled={cannotSend}>
-          {isPreparingPreview || sendMailMutation.isPending ? <Loader2 className="size-4 animate-spin" /> : null}
-          보내기
-        </Button>
+        <input
+          ref={attachmentInputRef}
+          type="file"
+          multiple
+          className="sr-only"
+          onChange={handleAttachmentInputChange}
+        />
+
+        {(attachments.length > 0 || inlineImages.length > 0) && (
+          <div className="mb-3 flex flex-col gap-2">
+            {attachments.length > 0 && (
+              <ul className="flex flex-col gap-1.5">
+                {attachments.map((attachment, index) => (
+                  <li
+                    key={`${attachment.name}-${attachment.lastModified}-${index}`}
+                    className="flex min-h-9 items-center gap-2 rounded-md border bg-background px-3 text-sm"
+                  >
+                    <FileText className="size-4 shrink-0 text-muted-foreground" />
+                    <span className="min-w-0 flex-1 truncate">{attachment.name}</span>
+                    <span className="shrink-0 text-xs text-muted-foreground">{formatFileSize(attachment.size)}</span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="-mr-2"
+                      onClick={() => removeAttachment(index)}
+                      aria-label={`${attachment.name} 첨부파일 제거`}
+                    >
+                      <X className="size-4" />
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {inlineImages.length > 0 && (
+              <div className="text-xs text-muted-foreground">본문 이미지 {inlineImages.length}개가 포함됩니다</div>
+            )}
+          </div>
+        )}
+
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="lg"
+            onClick={() => attachmentInputRef.current?.click()}
+            disabled={sendMailMutation.isPending || isPreparingPreview}
+            aria-label="첨부파일 추가"
+          >
+            <Paperclip className="size-4" />
+          </Button>
+          <Button className="flex-1" size="lg" onClick={handleSendPreview} disabled={cannotSend}>
+            {isPreparingPreview || sendMailMutation.isPending ? <Loader2 className="size-4 animate-spin" /> : null}
+            보내기
+          </Button>
+        </div>
       </div>
 
       <ComposeSendPreviewDialog

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -28,6 +28,10 @@ interface PendingInlineImage extends ComposeInlineImage {
   objectUrl: string
 }
 
+interface ComposeImageMetadata {
+  alignment: "left" | "center" | "right" | null
+}
+
 const MAX_SEND_FILE_BYTES = 20 * 1024 * 1024
 
 function createInlineImageCid() {
@@ -42,12 +46,18 @@ function getSendFileSize(attachments: readonly File[], inlineImages: readonly Pe
   return getFilesSize(attachments) + getFilesSize(inlineImages.map((image) => image.file))
 }
 
-function collectImageSources(content: JSONContent) {
-  const sources = new Set<string>()
+function normalizeImageAlignment(value: unknown): ComposeImageMetadata["alignment"] {
+  return value === "left" || value === "center" || value === "right" ? value : null
+}
+
+function collectImageMetadata(content: JSONContent) {
+  const metadata = new Map<string, ComposeImageMetadata>()
 
   const visit = (node: JSONContent) => {
     if (node.type === "image" && typeof node.attrs?.src === "string") {
-      sources.add(node.attrs.src)
+      metadata.set(node.attrs.src, {
+        alignment: normalizeImageAlignment(node.attrs.align ?? node.attrs.alignment),
+      })
     }
 
     for (const child of node.content ?? []) {
@@ -57,24 +67,93 @@ function collectImageSources(content: JSONContent) {
 
   visit(content)
 
-  return sources
+  return metadata
 }
 
-function buildMailContentWithCidImages(html: string, inlineImages: readonly PendingInlineImage[]) {
+function mergeInlineStyle(element: HTMLElement, styles: Record<string, string>) {
+  for (const [property, value] of Object.entries(styles)) {
+    element.style.setProperty(property, value)
+  }
+}
+
+function isSingleImageLink(element: Element | null, imageElement: HTMLImageElement): element is HTMLAnchorElement {
+  return (
+    element instanceof HTMLAnchorElement && element.children.length === 1 && element.firstElementChild === imageElement
+  )
+}
+
+function applyImageAlignment(
+  document: Document,
+  imageElement: HTMLImageElement,
+  alignment: ComposeImageMetadata["alignment"]
+) {
+  if (!alignment) return
+
+  mergeInlineStyle(imageElement, {
+    display: "inline-block",
+    "margin-left": "0",
+    "margin-right": "0",
+    "vertical-align": "top",
+  })
+
+  const parentElement = imageElement.parentElement
+  const alignmentTarget: HTMLElement = isSingleImageLink(parentElement, imageElement) ? parentElement : imageElement
+
+  if (!alignmentTarget.parentNode) {
+    return
+  }
+
+  const table = document.createElement("table")
+  const tbody = document.createElement("tbody")
+  const row = document.createElement("tr")
+  const cell = document.createElement("td")
+
+  table.setAttribute("role", "presentation")
+  table.setAttribute("border", "0")
+  table.setAttribute("cellpadding", "0")
+  table.setAttribute("cellspacing", "0")
+  table.setAttribute("width", "100%")
+  mergeInlineStyle(table, {
+    width: "100%",
+    "border-collapse": "collapse",
+  })
+  cell.setAttribute("align", alignment)
+  mergeInlineStyle(cell, {
+    "text-align": alignment,
+    "line-height": "0",
+  })
+
+  alignmentTarget.parentNode.insertBefore(table, alignmentTarget)
+  cell.appendChild(alignmentTarget)
+  row.appendChild(cell)
+  tbody.appendChild(row)
+  table.appendChild(tbody)
+}
+
+function buildMailContentWithImages(
+  html: string,
+  inlineImages: readonly PendingInlineImage[],
+  imageMetadata: ReadonlyMap<string, ComposeImageMetadata>,
+  options: { replaceInlineImageSrcWithCid: boolean }
+) {
   const parser = new DOMParser()
   const document = parser.parseFromString(html, "text/html")
   const imageByObjectUrl = new Map(inlineImages.map((image) => [image.objectUrl, image]))
   const usedInlineImages: PendingInlineImage[] = []
   const usedObjectUrls = new Set<string>()
 
-  for (const imageElement of Array.from(document.querySelectorAll("img[src]"))) {
+  for (const imageElement of Array.from(document.querySelectorAll<HTMLImageElement>("img[src]"))) {
     const src = imageElement.getAttribute("src")
     if (!src) continue
+
+    applyImageAlignment(document, imageElement, imageMetadata.get(src)?.alignment ?? null)
 
     const inlineImage = imageByObjectUrl.get(src)
     if (!inlineImage) continue
 
-    imageElement.setAttribute("src", `cid:${inlineImage.cid}`)
+    if (options.replaceInlineImageSrcWithCid) {
+      imageElement.setAttribute("src", `cid:${inlineImage.cid}`)
+    }
 
     if (!usedObjectUrls.has(src)) {
       usedInlineImages.push(inlineImage)
@@ -218,7 +297,7 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
   }, [])
 
   const pruneUnusedInlineImages = (content: JSONContent) => {
-    const imageSources = collectImageSources(content)
+    const imageMetadata = collectImageMetadata(content)
 
     setInlineImages((currentInlineImages) => {
       if (currentInlineImages.length === 0) {
@@ -227,7 +306,7 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
 
       let didRemoveImage = false
       const nextInlineImages = currentInlineImages.filter((inlineImage) => {
-        const isUsed = imageSources.has(inlineImage.objectUrl)
+        const isUsed = imageMetadata.has(inlineImage.objectUrl)
 
         if (!isUsed) {
           didRemoveImage = true
@@ -286,13 +365,19 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
     }
 
     const emailContent = await editorRef.current.getEmail()
+    const imageMetadata = collectImageMetadata(editorRef.current.getJSON())
 
     if (!emailContent.text.trim() && !emailContent.html.trim()) {
       toast.error("메일 내용을 입력해주세요")
       return null
     }
 
-    const sendContent = buildMailContentWithCidImages(emailContent.html, inlineImagesRef.current)
+    const previewContent = buildMailContentWithImages(emailContent.html, inlineImagesRef.current, imageMetadata, {
+      replaceInlineImageSrcWithCid: false,
+    })
+    const sendContent = buildMailContentWithImages(emailContent.html, inlineImagesRef.current, imageMetadata, {
+      replaceInlineImageSrcWithCid: true,
+    })
 
     return {
       mail: {
@@ -306,7 +391,7 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
         inlineImages: sendContent.inlineImages,
       },
       text: emailContent.text,
-      html: emailContent.html,
+      html: previewContent.content,
     } satisfies ComposeSendPreviewData
   }
 
@@ -462,6 +547,7 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
           ref={editorRef}
           theme="basic"
           placeholder="메일 내용을 입력하세요. / 로 블록을 추가할 수 있습니다."
+          bubbleMenu={{ hideWhenActiveNodes: ["button", "image"] }}
           className="compose-email-editor h-full overflow-auto text-sm outline-none"
           onUploadImage={uploadInlineImage}
           onReady={(ref) => {

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react"
 import { EmailEditor, type EmailEditorRef } from "@react-email/editor"
+import {
+  EDITOR_THEMES,
+  extendTheme,
+  setCurrentTheme,
+  setGlobalStyles,
+  themeStylesToPanelOverrides,
+} from "@react-email/editor/plugins"
 import type { JSONContent } from "@tiptap/core"
 import { FileText, Loader2, Paperclip, X } from "lucide-react"
 import { useNavigate } from "@tanstack/react-router"
@@ -34,6 +41,18 @@ interface ComposeImageMetadata {
 }
 
 const MAX_SEND_FILE_BYTES = 20 * 1024 * 1024
+const EDITOR_THEME = extendTheme("basic", {
+  body: { backgroundColor: "transparent" },
+  container: {
+    backgroundColor: "#fff",
+    padding: "1rem",
+  },
+  paragraph: {
+    paddingTop: "0.25em",
+    paddingBottom: "0.25em",
+  },
+})
+const EDITOR_THEME_STYLES = themeStylesToPanelOverrides(EDITOR_THEME.styles, EDITOR_THEMES.basic)
 
 function createInlineImageCid() {
   return `inline-${crypto.randomUUID()}`
@@ -53,6 +72,27 @@ function getInlineImagesSize(inlineImages: readonly PendingInlineImage[]) {
 
 function getSendFileSize(attachments: readonly File[], inlineImages: readonly PendingInlineImage[]) {
   return getFilesSize(attachments) + getInlineImagesSize(inlineImages)
+}
+
+function getGlobalContentData(content: JSONContent) {
+  const globalContent = content.content?.find((node) => node.type === "globalContent")
+  const data = globalContent?.attrs?.data
+
+  return data && typeof data === "object" && !Array.isArray(data) ? (data as Record<string, unknown>) : null
+}
+
+function hasEditorTheme(content: JSONContent) {
+  const data = getGlobalContentData(content)
+
+  return data?.theme === (EDITOR_THEME.extends ?? "basic") && Array.isArray(data.styles)
+}
+
+function applyEditorTheme(editor: ComposeEditor | null, content?: JSONContent) {
+  if (!editor) return
+  if (content && hasEditorTheme(content)) return
+
+  setCurrentTheme(editor, EDITOR_THEME.extends ?? "basic")
+  setGlobalStyles(editor, EDITOR_THEME_STYLES)
 }
 
 function normalizeImageAlignment(value: unknown): ComposeImageMetadata["alignment"] {
@@ -139,6 +179,15 @@ function applyImageAlignment(
   table.appendChild(tbody)
 }
 
+function applyListIndentation(document: Document) {
+  for (const listElement of Array.from(document.querySelectorAll<HTMLElement>("ul, ol"))) {
+    mergeInlineStyle(listElement, {
+      "padding-bottom": "0.5rem",
+      "padding-left": "0.25rem",
+    })
+  }
+}
+
 function buildMailContentWithImages(
   html: string,
   inlineImages: readonly PendingInlineImage[],
@@ -169,6 +218,8 @@ function buildMailContentWithImages(
       usedInlineImageCids.add(inlineImage.cid)
     }
   }
+
+  applyListIndentation(document)
 
   const isFullHtmlDocument = /^\s*(<!doctype|<html[\s>])/i.test(html)
   const content = isFullHtmlDocument
@@ -561,19 +612,23 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
       <div className="flex-1 overflow-hidden" aria-label="메일 본문">
         <EmailEditor
           ref={editorRef}
-          theme="basic"
+          theme={EDITOR_THEME}
           placeholder="메일 내용을 입력하세요. / 로 블록을 추가할 수 있습니다."
           bubbleMenu={{ hideWhenActiveNodes: ["button", "image"] }}
           className="compose-email-editor h-full overflow-auto text-sm outline-none"
           onUploadImage={uploadInlineImage}
           onReady={(ref) => {
+            applyEditorTheme(ref.editor)
             setIsEditorReady(true)
             setIsEditorEmpty(ref.editor?.isEmpty ?? true)
             setEditor(ref.editor)
           }}
           onUpdate={(ref) => {
+            const content = ref.getJSON()
+
+            applyEditorTheme(ref.editor, content)
             setIsEditorEmpty(ref.editor?.isEmpty ?? true)
-            pruneUnusedInlineImages(ref.getJSON())
+            pruneUnusedInlineImages(content)
           }}
         />
       </div>

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -8,16 +8,16 @@ import {
   themeStylesToPanelOverrides,
 } from "@react-email/editor/plugins"
 import type { JSONContent } from "@tiptap/core"
-import { FileText, Loader2, Paperclip, X } from "lucide-react"
+import { Loader2, Paperclip, X } from "lucide-react"
 import { useNavigate } from "@tanstack/react-router"
 import { toast } from "sonner"
 
+import { FileAttachmentChip } from "@/components/attachment-chip"
 import { ComposeEditorToolbar, type ComposeEditor } from "@/components/compose/compose-editor-toolbar"
 import { ComposeSendPreviewDialog, type ComposeSendPreviewData } from "@/components/compose/compose-send-preview-dialog"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { formatFileSize } from "@/lib/file-size"
 import { getErrorMessage } from "@/lib/http-error"
 import { parseMailAddressInput } from "@/lib/mail-address"
 import { useSendMail } from "@/mutations/emails"
@@ -629,29 +629,16 @@ export function ComposeEmail({ fromAddress, onFromAddressChange }: ComposeEmailP
         />
 
         {attachments.length > 0 && (
-          <div className="mb-3 flex flex-col gap-2">
-            <ul className="flex flex-col gap-1.5">
-              {attachments.map((attachment, index) => (
-                <li
-                  key={`${attachment.name}-${attachment.lastModified}-${index}`}
-                  className="flex min-h-9 items-center gap-2 rounded-md border bg-background px-3 text-sm"
-                >
-                  <FileText className="size-4 shrink-0 text-muted-foreground" />
-                  <span className="min-w-0 flex-1 truncate">{attachment.name}</span>
-                  <span className="shrink-0 text-xs text-muted-foreground">{formatFileSize(attachment.size)}</span>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
-                    className="-mr-2"
-                    onClick={() => removeAttachment(index)}
-                    aria-label={`${attachment.name} 첨부파일 제거`}
-                  >
-                    <X className="size-4" />
-                  </Button>
-                </li>
+          <div className="mb-3">
+            <div className="flex max-h-20 flex-wrap gap-2 overflow-y-auto pr-1">
+              {attachments.map((file, index) => (
+                <FileAttachmentChip
+                  key={`${file.name}-${file.lastModified}-${index}`}
+                  file={file}
+                  onRemove={() => removeAttachment(index)}
+                />
               ))}
-            </ul>
+            </div>
           </div>
         )}
 

--- a/src/components/compose/compose-send-preview-dialog.tsx
+++ b/src/components/compose/compose-send-preview-dialog.tsx
@@ -1,15 +1,8 @@
 import { Loader2, Send } from "lucide-react"
 
+import { FileAttachmentChip } from "@/components/attachment-chip"
 import { Button } from "@/components/ui/button"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
-import { formatFileSize } from "@/lib/file-size"
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import type { ComposeEmailData } from "@/types/email"
 
 export interface ComposeSendPreviewData {
@@ -70,7 +63,7 @@ function EmailPreviewFrame({ html, text }: { html: string; text: string }) {
       title="최종 발송 본문 미리보기"
       sandbox="allow-popups allow-same-origin"
       srcDoc={srcDoc}
-      className="h-[min(52vh,34rem)] w-full rounded-lg border bg-white"
+      className="h-[min(40vh,30rem)] w-full rounded-lg border bg-white"
     />
   )
 }
@@ -89,11 +82,10 @@ export function ComposeSendPreviewDialog({
       <DialogContent className="sm:max-w-3xl">
         <DialogHeader>
           <DialogTitle>메일 미리보기</DialogTitle>
-          <DialogDescription>아래 내용으로 메일이 발송됩니다.</DialogDescription>
         </DialogHeader>
 
         {mail && (
-          <div className="grid gap-4">
+          <div className="grid gap-4 overflow-y-auto">
             <dl className="overflow-hidden rounded-lg border text-sm">
               <PreviewField label="보내는 사람" value={mail.from ?? ""} />
               <PreviewField label="받는 사람" value={mail.to.join(", ")} />
@@ -102,21 +94,18 @@ export function ComposeSendPreviewDialog({
               <PreviewField label="제목" value={mail.subject} />
             </dl>
 
+            <EmailPreviewFrame html={preview.html} text={preview.text} />
+
             {mail.attachments && mail.attachments.length > 0 && (
               <div className="rounded-lg border px-4 py-3 text-sm">
                 <div className="mb-2 font-medium">첨부파일</div>
-                <ul className="flex flex-col gap-1.5">
-                  {mail.attachments.map((attachment, index) => (
-                    <li key={`${attachment.name}-${attachment.lastModified}-${index}`} className="flex min-w-0 gap-2">
-                      <span className="min-w-0 flex-1 truncate">{attachment.name}</span>
-                      <span className="shrink-0 text-muted-foreground">{formatFileSize(attachment.size)}</span>
-                    </li>
+                <div className="flex max-h-20 flex-wrap gap-2 overflow-y-auto pr-1">
+                  {mail.attachments.map((file, index) => (
+                    <FileAttachmentChip key={`${file.name}-${file.lastModified}-${index}`} file={file} />
                   ))}
-                </ul>
+                </div>
               </div>
             )}
-
-            <EmailPreviewFrame html={preview.html} text={preview.text} />
           </div>
         )}
 

--- a/src/components/compose/compose-send-preview-dialog.tsx
+++ b/src/components/compose/compose-send-preview-dialog.tsx
@@ -9,11 +9,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { formatFileSize } from "@/lib/file-size"
 import type { ComposeEmailData } from "@/types/email"
 
 export interface ComposeSendPreviewData {
   mail: ComposeEmailData
   text: string
+  html: string
 }
 
 interface ComposeSendPreviewDialogProps {
@@ -45,7 +47,10 @@ function escapeHtml(value: string) {
 function EmailPreviewFrame({ html, text }: { html: string; text: string }) {
   const fallbackText = text.trim()
   const body = html.trim() || `<pre>${escapeHtml(fallbackText)}</pre>`
-  const srcDoc = `<!doctype html>
+  const isFullHtmlDocument = /^\s*(<!doctype|<html[\s>])/i.test(body)
+  const srcDoc = isFullHtmlDocument
+    ? body
+    : `<!doctype html>
 <html>
   <head>
     <meta charset="utf-8">
@@ -63,7 +68,7 @@ function EmailPreviewFrame({ html, text }: { html: string; text: string }) {
   return (
     <iframe
       title="최종 발송 본문 미리보기"
-      sandbox="allow-popups"
+      sandbox="allow-popups allow-same-origin"
       srcDoc={srcDoc}
       className="h-[min(52vh,34rem)] w-full rounded-lg border bg-white"
     />
@@ -97,7 +102,21 @@ export function ComposeSendPreviewDialog({
               <PreviewField label="제목" value={mail.subject} />
             </dl>
 
-            <EmailPreviewFrame html={mail.content} text={preview.text} />
+            {mail.attachments && mail.attachments.length > 0 && (
+              <div className="rounded-lg border px-4 py-3 text-sm">
+                <div className="mb-2 font-medium">첨부파일</div>
+                <ul className="flex flex-col gap-1.5">
+                  {mail.attachments.map((attachment, index) => (
+                    <li key={`${attachment.name}-${attachment.lastModified}-${index}`} className="flex min-w-0 gap-2">
+                      <span className="min-w-0 flex-1 truncate">{attachment.name}</span>
+                      <span className="shrink-0 text-muted-foreground">{formatFileSize(attachment.size)}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            <EmailPreviewFrame html={preview.html} text={preview.text} />
           </div>
         )}
 

--- a/src/components/inbox/email-detail.tsx
+++ b/src/components/inbox/email-detail.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react"
-import { Archive, ArrowLeft, FileText, Forward, MailOpen, MoreVertical, Reply, Star, Trash2 } from "lucide-react"
+import { Archive, ArrowLeft, Forward, MailOpen, MoreVertical, Reply, Star, Trash2 } from "lucide-react"
 import { toast } from "sonner"
 
+import { AttachmentChip } from "@/components/attachment-chip"
 import { EmailErrorState } from "@/components/inbox/email-error-state"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
@@ -16,7 +17,7 @@ import { formatMailAddressList, getMailAddressLabel } from "@/lib/mail-address"
 import { useDeleteMessage, useDeleteThread, useRestoreTrashMessage, useRestoreTrashThread } from "@/mutations/trash"
 import { useThread } from "@/queries/emails"
 import { useMailAccounts } from "@/queries/mail-accounts"
-import type { Attachment, InboxMessage, InboxThreadDetail } from "@/types/email"
+import type { InboxMessage, InboxThreadDetail } from "@/types/email"
 import type { MailAccount } from "@/types/mail-account"
 
 function formatDate(value: string) {
@@ -28,13 +29,6 @@ function formatDate(value: string) {
     minute: "2-digit",
     hour12: true,
   })
-}
-
-function formatFileSize(bytes: number) {
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
 }
 
 function getInitials(value: string) {
@@ -187,20 +181,6 @@ function ThreadHeader({ thread, account }: ThreadHeaderProps) {
           메시지 {messageCount}개
         </Badge>
       </div>
-    </div>
-  )
-}
-
-interface AttachmentChipProps {
-  attachment: Attachment
-}
-
-function AttachmentChip({ attachment }: AttachmentChipProps) {
-  return (
-    <div className="inline-flex max-w-full items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-xs transition-colors hover:bg-muted">
-      <FileText className="size-3.5 shrink-0 text-muted-foreground" />
-      <span className="truncate font-medium">{attachment.filename}</span>
-      <span className="shrink-0 text-muted-foreground">{formatFileSize(attachment.size)}</span>
     </div>
   )
 }

--- a/src/components/trash/trash-detail.tsx
+++ b/src/components/trash/trash-detail.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react"
-import { ArrowLeft, FileText, MailOpen, MoreVertical, Star, Undo2 } from "lucide-react"
+import { ArrowLeft, MailOpen, MoreVertical, Star, Undo2 } from "lucide-react"
 import { toast } from "sonner"
 
+import { AttachmentChip } from "@/components/attachment-chip"
 import { EmailErrorState } from "@/components/inbox/email-error-state"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
@@ -16,7 +17,7 @@ import { formatMailAddressList, getMailAddressLabel } from "@/lib/mail-address"
 import { useRestoreTrashMessage, useRestoreTrashThread } from "@/mutations/trash"
 import { useMailAccounts } from "@/queries/mail-accounts"
 import { useTrashThread } from "@/queries/trash"
-import type { Attachment, InboxMessage } from "@/types/email"
+import type { InboxMessage } from "@/types/email"
 import type { MailAccount } from "@/types/mail-account"
 import type { TrashThreadDetail } from "@/types/trash"
 
@@ -29,13 +30,6 @@ function formatDate(value: string) {
     minute: "2-digit",
     hour12: true,
   })
-}
-
-function formatFileSize(bytes: number) {
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
 }
 
 function getInitials(value: string) {
@@ -181,20 +175,6 @@ function ThreadHeader({ thread, account }: ThreadHeaderProps) {
           메시지 {messageCount}개
         </Badge>
       </div>
-    </div>
-  )
-}
-
-interface AttachmentChipProps {
-  attachment: Attachment
-}
-
-function AttachmentChip({ attachment }: AttachmentChipProps) {
-  return (
-    <div className="inline-flex max-w-full items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-xs transition-colors hover:bg-muted">
-      <FileText className="size-3.5 shrink-0 text-muted-foreground" />
-      <span className="truncate font-medium">{attachment.filename}</span>
-      <span className="shrink-0 text-muted-foreground">{formatFileSize(attachment.size)}</span>
     </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -78,6 +78,25 @@
   line-height: 1.25;
 }
 
+.compose-email-editor .tiptap img[alignment] {
+  display: block;
+}
+
+.compose-email-editor .tiptap img[alignment="left"] {
+  margin-left: 0;
+  margin-right: auto;
+}
+
+.compose-email-editor .tiptap img[alignment="center"] {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.compose-email-editor .tiptap img[alignment="right"] {
+  margin-left: auto;
+  margin-right: 0;
+}
+
 .compose-email-editor .tiptap ul,
 .compose-email-editor .tiptap ol {
   color: var(--foreground) !important;

--- a/src/index.css
+++ b/src/index.css
@@ -35,13 +35,11 @@
   caret-color: var(--foreground);
   min-height: 100%;
   outline: none;
-  padding: 1.25rem 1rem;
   width: 100%;
   max-width: 100%;
   overflow-wrap: anywhere;
 }
 
-.compose-email-editor .tiptap .node-container,
 .compose-email-editor .tiptap .node-section,
 .compose-email-editor .tiptap .node-paragraph,
 .compose-email-editor .tiptap .node-bulletList,
@@ -51,6 +49,7 @@
 }
 
 .compose-email-editor .tiptap .node-container {
+  background-color: transparent !important;
   max-width: 100% !important;
   min-width: 0 !important;
   width: 100% !important;
@@ -65,17 +64,14 @@
 
 .compose-email-editor .tiptap p {
   color: var(--foreground) !important;
-  margin: 0.125rem 0 !important;
-  padding-top: 0.0625rem !important;
-  padding-bottom: 0.0625rem !important;
-  line-height: 1.55 !important;
+  margin: 0 !important;
 }
 
 .compose-email-editor .tiptap h1,
 .compose-email-editor .tiptap h2,
 .compose-email-editor .tiptap h3 {
   color: var(--foreground) !important;
-  line-height: 1.25;
+  margin: 0 !important;
 }
 
 .compose-email-editor .tiptap img[alignment] {
@@ -100,13 +96,11 @@
 .compose-email-editor .tiptap ul,
 .compose-email-editor .tiptap ol {
   color: var(--foreground) !important;
-  margin: 0.25rem 0 !important;
-  padding-left: 1.35rem !important;
+  padding-bottom: 0.5rem !important;
 }
 
 .compose-email-editor .tiptap li {
   color: var(--foreground) !important;
-  margin: 0.0625rem 0 !important;
 }
 
 .compose-email-editor .tiptap li p {
@@ -116,7 +110,6 @@
 }
 
 .compose-email-editor .tiptap blockquote {
-  margin: 0.375rem 0 !important;
   color: var(--muted-foreground) !important;
   border-left-color: var(--border);
 }

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -48,6 +48,10 @@ function buildUrl(path: string, params?: QueryParams) {
   return url
 }
 
+export function buildApiUrl(path: string, params?: QueryParams) {
+  return buildUrl(path, params).toString()
+}
+
 function isBodyInit(body: unknown): body is BodyInit {
   if (typeof body === "string") {
     return true
@@ -70,7 +74,10 @@ function isBodyInit(body: unknown): body is BodyInit {
 
 function buildHeaders(headers?: HeadersInit, body?: unknown) {
   const requestHeaders = new Headers(headers)
-  requestHeaders.set("Accept", "application/json")
+
+  if (!requestHeaders.has("Accept")) {
+    requestHeaders.set("Accept", "application/json")
+  }
 
   if (body !== undefined && !isBodyInit(body) && !requestHeaders.has("Content-Type")) {
     requestHeaders.set("Content-Type", "application/json")

--- a/src/lib/email-attachments.ts
+++ b/src/lib/email-attachments.ts
@@ -1,0 +1,5 @@
+import type { Attachment } from "@/types/email"
+
+export function getVisibleAttachments(attachments: readonly Attachment[]) {
+  return attachments.filter((attachment) => attachment.disposition !== "INLINE")
+}

--- a/src/lib/file-size.ts
+++ b/src/lib/file-size.ts
@@ -1,0 +1,23 @@
+const FILE_SIZE_UNITS = ["KB", "MB", "GB"] as const
+
+export function formatFileSize(bytes: number) {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return "0 B"
+  }
+
+  if (bytes < 1024) {
+    return `${bytes} B`
+  }
+
+  let size = bytes / 1024
+  let unitIndex = 0
+
+  while (size >= 1024 && unitIndex < FILE_SIZE_UNITS.length - 1) {
+    size /= 1024
+    unitIndex += 1
+  }
+
+  const formattedSize = size >= 10 ? size.toFixed(0) : size.toFixed(1)
+
+  return `${formattedSize} ${FILE_SIZE_UNITS[unitIndex]}`
+}

--- a/src/mutations/emails.ts
+++ b/src/mutations/emails.ts
@@ -9,6 +9,7 @@ import { emailKeys } from "@/queries/emails"
 
 export const emailMutationOptions = {
   sendMail: () => ({
+    mutationKey: [...emailKeys.all(), "send"] as const,
     mutationFn: (data: ComposeEmailData) => sendMail(data),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: emailKeys.all() })

--- a/src/types/email.ts
+++ b/src/types/email.ts
@@ -27,6 +27,8 @@ export interface Attachment {
   gmailAttachmentId: string
   filename: string
   mimeType: string
+  contentId?: string
+  disposition?: "ATTACHMENT" | "INLINE"
   size: number
 }
 
@@ -87,18 +89,28 @@ export interface MarkerSliceResponse<T> {
   content: T[]
   nextMarker: string | null
   hasNext: boolean
+  unreadCount?: number
+  totalCount?: number
 }
 
 export interface ListThreadsParams {
   marker?: string
   size?: number
+  labelId?: string[]
+  read?: boolean
 }
 
 export interface UnreadCountResponse {
   unreadCount: number
 }
 
+export interface ComposeInlineImage {
+  file: File
+  cid: string
+}
+
 export interface ComposeEmailData {
+  messageId?: string
   from?: string
   replyTo?: string
   to: string[]
@@ -107,4 +119,5 @@ export interface ComposeEmailData {
   subject: string
   content: string
   attachments?: File[]
+  inlineImages?: ComposeInlineImage[]
 }


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#11

### 📌 Task

- Closes #34 
- Closes #52

## 💡 작업 내용

- 메일 발송 API 업데이트 반영
- 첨부 파일 기능 추가
- CID 기반 이미지 삽입 기능 추가
- 첨부파일 다운로드 기능 추가

## 📝 추가 설명

- 메일 발송 API 변경사항에 맞춰 작성 화면의 발송 payload를 최신화했습니다.
  - 일반 첨부파일, 본문 이미지 파일, 본문 이미지 CID 목록을 multipart form data로 전송합니다.
  - 답장/연계 발송을 위한 `messageId` query parameter를 지원합니다.
- 메일 작성 화면에 일반 첨부파일 기능을 추가했습니다.
  - 파일 선택, 선택 파일 목록 표시, 개별 제거, 총 용량 제한 검증을 처리합니다.
  - 발송 전 미리보기에서 첨부파일 목록을 함께 확인할 수 있습니다.
- React Email Editor 기반 본문 이미지 삽입 기능을 추가했습니다.
  - toolbar 이미지 삽입, paste/drop/slash command 이미지 업로드 경로를 지원합니다.
  - 작성 중에는 object URL로 이미지를 미리보고, 최종 발송 HTML에서는 `cid:*` 참조로 변환합니다.
  - 동일 이미지가 여러 번 삽입된 경우 파일은 한 번만 전송하고 동일 CID를 재사용하도록 최적화했습니다.
- 본문 이미지 정렬이 메일 클라이언트에서 안정적으로 보이도록 최종 HTML 렌더링을 보정했습니다.
  - React Email Editor의 이미지 `alignment` 속성을 최종 HTML에 반영합니다.
  - 이메일 클라이언트 호환성을 위해 이미지 정렬 렌더링에 presentation table을 사용합니다.
  - 작성 화면에서도 이미지 정렬 상태가 보이도록 editor CSS를 보정했습니다.
- 조회 화면에서 CID 본문 이미지용 첨부파일이 일반 첨부파일처럼 표시되지 않도록 API 응답 정규화를 추가했습니다.
  - 백엔드가 제공하는 `disposition` 값을 신뢰해 `INLINE` 첨부파일을 API client 레벨에서 제외합니다.
  - 받은메일/휴지통 상세 컴포넌트는 별도 필터링 없이 정규화된 첨부파일만 렌더링합니다.
- 첨부파일 다운로드 기능을 추가했습니다.
  - `GET /api/v1/mail/attachments/{attachmentId}` 다운로드 URL을 생성합니다.
  - 첨부파일 칩은 기존 thread detail 디자인을 유지하면서 링크 방식으로 다운로드 API를 엽니다.
  - 파일명 처리는 백엔드의 `Content-Disposition` 응답 헤더에 위임합니다.
- 작성 메일의 React Email 컨테이너 테마를 정리했습니다.
  - `extendTheme("basic", ...)`로 최종 메일 HTML의 컨테이너 배경과 padding을 지정합니다.
  - `Cmd+A`/전체 삭제로 editor 내부 `globalContent.styles`가 제거되는 경우를 감지해 theme 상태를 복구합니다.
  - 작성 화면에서는 컨테이너 배경색을 변경하지 않고, 최종 미리보기/발송 HTML에만 컨테이너 배경이 반영되도록 분리했습니다.

## 🖼️ 스크린샷

<img width="3024" height="1748" alt="image" src="https://github.com/user-attachments/assets/ab3db2ff-b4ce-4fa3-a86f-d7e88fd9b61c" />