### PR TITLE
[STORY-203] 메일함 읽지않음 카운터 추가

### DIFF
--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -498,7 +498,7 @@ export function ComposeEmail({
   }
 
   return (
-    <div className="flex h-full w-full flex-col">
+    <div className="flex h-full w-full min-w-0 flex-1 flex-col">
       <div className="flex h-11 shrink-0 items-center justify-between border-b px-4">
         <h1 className="text-sm font-medium">{messageId ? "답장" : "새 메일 작성"}</h1>
         <Button variant="ghost" size="icon-sm" onClick={handleClose} className="-mr-2" aria-label="메일 작성 닫기">

--- a/src/components/compose/compose-reference.tsx
+++ b/src/components/compose/compose-reference.tsx
@@ -37,7 +37,7 @@ function getThreadDetailErrorCopy(error: unknown) {
 
 function ReferenceEmptyState() {
   return (
-    <div className="flex min-h-full flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+    <div className="flex min-h-full w-full flex-col items-center justify-center gap-3 px-6 py-16 text-center">
       <div className="flex size-14 items-center justify-center rounded-full bg-muted">
         <Mail className="size-7 text-muted-foreground/60" />
       </div>
@@ -97,7 +97,7 @@ export function ComposeReference({ threadId }: ComposeReferenceProps) {
   const errorCopy = isError ? getThreadDetailErrorCopy(error) : null
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
+    <div className="flex h-full w-full min-w-0 flex-1 flex-col overflow-hidden">
       <div className="flex h-11 shrink-0 items-center border-b px-4">
         <h1 className="text-sm font-medium">참고 메일</h1>
       </div>

--- a/src/components/inbox/email-detail.tsx
+++ b/src/components/inbox/email-detail.tsx
@@ -43,7 +43,7 @@ function getThreadDetailErrorCopy(error: unknown) {
 
 function EmptyState() {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-3">
+    <div className="flex h-full w-full min-w-0 flex-1 flex-col items-center justify-center gap-3">
       <div className="flex size-16 items-center justify-center rounded-full bg-muted">
         <MailOpen className="size-8 text-muted-foreground" />
       </div>
@@ -57,7 +57,7 @@ function EmptyState() {
 
 function LoadingState() {
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full w-full min-w-0 flex-1 flex-col">
       <div className="flex h-11 w-full min-w-0 shrink-0 items-center justify-between gap-2 px-4">
         <Skeleton className="h-4 w-24" />
         <div className="flex items-center gap-1">

--- a/src/components/inbox/email-error-state.tsx
+++ b/src/components/inbox/email-error-state.tsx
@@ -11,7 +11,7 @@ interface EmailErrorStateProps {
 
 export function EmailErrorState({ title, description, retryLabel = "다시 시도", onRetry }: EmailErrorStateProps) {
   return (
-    <div className="flex min-h-full flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+    <div className="flex min-h-full w-full flex-col items-center justify-center gap-3 px-6 py-16 text-center">
       <div className="flex size-14 items-center justify-center rounded-full bg-destructive/10">
         <AlertTriangle className="size-7 text-destructive" />
       </div>

--- a/src/components/inbox/email-list-header.tsx
+++ b/src/components/inbox/email-list-header.tsx
@@ -12,7 +12,8 @@ const filterOptions: Array<{ value: EmailFilter; label: string }> = [
 
 interface EmailListHeaderProps {
   mailboxName: string
-  threadCount: number
+  currentCount: number
+  totalCount?: number
   filter: EmailFilter
   onFilterChange: (filter: EmailFilter) => void
   selectedCount: number
@@ -23,7 +24,7 @@ interface EmailListHeaderProps {
 
 export function EmailListHeader({
   mailboxName,
-  threadCount,
+  totalCount,
   filter,
   onFilterChange,
   selectedCount,
@@ -54,7 +55,7 @@ export function EmailListHeader({
     <div className="flex h-11 shrink-0 items-center gap-3 border-b px-4">
       <h2 className="min-w-0 truncate text-sm font-medium">{mailboxName}</h2>
       <span className="hidden rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground sm:inline-flex">
-        {threadCount.toLocaleString()}개
+        {(totalCount ?? 0).toLocaleString()}개
       </span>
       <div className="ml-auto flex shrink-0 items-center gap-1">
         {filterOptions.map((option) => (

--- a/src/components/inbox/email-list-header.tsx
+++ b/src/components/inbox/email-list-header.tsx
@@ -1,4 +1,4 @@
-import { Tag, Trash2, SquareMinus } from "lucide-react"
+import { RefreshCw, Tag, Trash2, SquareMinus } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Toggle } from "@/components/ui/toggle"
@@ -16,6 +16,8 @@ interface EmailListHeaderProps {
   totalCount?: number
   filter: EmailFilter
   onFilterChange: (filter: EmailFilter) => void
+  isRefreshing?: boolean
+  onRefresh?: () => void
   selectedCount: number
   onClearSelection: () => void
   onDeleteSelected: () => void
@@ -27,6 +29,8 @@ export function EmailListHeader({
   totalCount,
   filter,
   onFilterChange,
+  isRefreshing = false,
+  onRefresh,
   selectedCount,
   onClearSelection,
   onDeleteSelected,
@@ -58,6 +62,18 @@ export function EmailListHeader({
         {(totalCount ?? 0).toLocaleString()}개
       </span>
       <div className="ml-auto flex shrink-0 items-center gap-1">
+        {onRefresh ? (
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onRefresh}
+            disabled={isRefreshing}
+            aria-label="메일 목록 새로고침"
+            title="새로고침"
+          >
+            <RefreshCw className={cn("size-4", isRefreshing && "animate-spin")} />
+          </Button>
+        ) : null}
         {filterOptions.map((option) => (
           <Toggle
             key={option.value}

--- a/src/components/inbox/email-list.tsx
+++ b/src/components/inbox/email-list.tsx
@@ -100,7 +100,7 @@ export function EmailList({
   }, [hasNextPage, isFetchingNextPage, onLoadMore])
 
   return (
-    <div className="flex h-full flex-col overflow-hidden rounded-[inherit]">
+    <div className="flex h-full w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[inherit]">
       <EmailListHeader
         mailboxName={mailboxName}
         currentCount={threads?.length ?? 0}
@@ -181,7 +181,7 @@ export function EmailList({
             <div ref={loadMoreRef} className="h-1" />
           </>
         ) : (
-          <div className="flex min-h-full flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+          <div className="flex min-h-full w-full flex-col items-center justify-center gap-3 px-6 py-16 text-center">
             <div className="flex size-14 items-center justify-center rounded-full bg-muted">
               <InboxIcon className="size-7 text-muted-foreground/60" />
             </div>

--- a/src/components/inbox/email-list.tsx
+++ b/src/components/inbox/email-list.tsx
@@ -19,11 +19,13 @@ interface EmailListProps {
   isLoading: boolean
   isFetchingNextPage: boolean
   hasNextPage: boolean
+  isRefreshing?: boolean
   selectedThreadId: string | null
   filter: EmailFilter
   onFilterChange: (filter: EmailFilter) => void
   onSelectThread: (id: string) => void
   onLoadMore: () => void
+  onRefresh?: () => void
   getAccount: (accountId: string) => MailAccount | undefined
   emptyTitle?: string
   emptyDescription?: string
@@ -42,11 +44,13 @@ export function EmailList({
   isLoading,
   isFetchingNextPage,
   hasNextPage,
+  isRefreshing = false,
   selectedThreadId,
   filter,
   onFilterChange,
   onSelectThread,
   onLoadMore,
+  onRefresh,
   getAccount,
   emptyTitle = "메일이 없습니다",
   emptyDescription,
@@ -103,6 +107,8 @@ export function EmailList({
         totalCount={totalCount}
         filter={filter}
         onFilterChange={onFilterChange}
+        isRefreshing={isRefreshing}
+        onRefresh={onRefresh}
         selectedCount={selectedIds.size}
         onClearSelection={() => setSelectedIds(new Set())}
         onDeleteSelected={() => {

--- a/src/components/inbox/email-list.tsx
+++ b/src/components/inbox/email-list.tsx
@@ -15,6 +15,7 @@ import type { MailAccount } from "@/types/mail-account"
 interface EmailListProps {
   mailboxName: string
   threads: InboxThreadSummary[] | undefined
+  totalCount?: number
   isLoading: boolean
   isFetchingNextPage: boolean
   hasNextPage: boolean
@@ -37,6 +38,7 @@ interface EmailListProps {
 export function EmailList({
   mailboxName,
   threads,
+  totalCount,
   isLoading,
   isFetchingNextPage,
   hasNextPage,
@@ -97,7 +99,8 @@ export function EmailList({
     <div className="flex h-full flex-col overflow-hidden rounded-[inherit]">
       <EmailListHeader
         mailboxName={mailboxName}
-        threadCount={threads?.length ?? 0}
+        currentCount={threads?.length ?? 0}
+        totalCount={totalCount}
         filter={filter}
         onFilterChange={onFilterChange}
         selectedCount={selectedIds.size}

--- a/src/components/nav/nav-folders.tsx
+++ b/src/components/nav/nav-folders.tsx
@@ -1,6 +1,5 @@
 import { Inbox, Send, AlertTriangle, Trash2 } from "lucide-react"
 
-import { Badge } from "@/components/ui/badge"
 import {
   SidebarGroup,
   SidebarGroupLabel,
@@ -61,9 +60,7 @@ export function NavFolders({ mailbox, onMailboxChange }: NavFoldersProps) {
               </SidebarMenuButton>
               {unreadCount > 0 ? (
                 <SidebarMenuBadge aria-label={`${MAILBOX_LABELS[mailboxId]} 안읽음 ${unreadCount.toLocaleString()}개`}>
-                  <Badge variant="secondary" className="h-5 min-w-5 px-1.5 text-[11px]">
-                    {formatUnreadCount(unreadCount)}
-                  </Badge>
+                  <div className="h-4 min-w-5 px-1.5 text-[11px]">{formatUnreadCount(unreadCount)}</div>
                 </SidebarMenuBadge>
               ) : null}
             </SidebarMenuItem>

--- a/src/components/nav/nav-folders.tsx
+++ b/src/components/nav/nav-folders.tsx
@@ -1,12 +1,16 @@
 import { Inbox, Send, AlertTriangle, Trash2 } from "lucide-react"
 
+import { Badge } from "@/components/ui/badge"
 import {
   SidebarGroup,
   SidebarGroupLabel,
   SidebarMenu,
+  SidebarMenuBadge,
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
+import { useMailboxThreads } from "@/queries/emails"
+import { useTrashThreads } from "@/queries/trash"
 import { MAILBOX_LABELS, PRIMARY_MAILBOX_IDS } from "@/types/email"
 import type { PrimaryMailboxId } from "@/types/email"
 
@@ -22,23 +26,49 @@ interface NavFoldersProps {
   onMailboxChange: (mailbox: PrimaryMailboxId) => void
 }
 
+function formatUnreadCount(count: number) {
+  return count > 99 ? "99+" : count.toLocaleString()
+}
+
 export function NavFolders({ mailbox, onMailboxChange }: NavFoldersProps) {
+  const { data: inboxData } = useMailboxThreads("inbox", { size: 1 })
+  const { data: sentData } = useMailboxThreads("sent", { size: 1 })
+  const { data: trashData } = useTrashThreads({ size: 1 })
+
+  const unreadCounts: Partial<Record<PrimaryMailboxId, number | undefined>> = {
+    inbox: inboxData?.pages[0]?.unreadCount,
+    sent: sentData?.pages[0]?.unreadCount,
+    trash: trashData?.pages[0]?.unreadCount,
+  }
+
   return (
     <SidebarGroup>
       <SidebarGroupLabel>메일함</SidebarGroupLabel>
       <SidebarMenu>
-        {PRIMARY_MAILBOX_IDS.map((mailboxId) => (
-          <SidebarMenuItem key={mailboxId}>
-            <SidebarMenuButton
-              tooltip={MAILBOX_LABELS[mailboxId]}
-              isActive={mailbox === mailboxId}
-              onClick={() => onMailboxChange(mailboxId)}
-            >
-              {folderIcons[mailboxId]}
-              <span>{MAILBOX_LABELS[mailboxId]}</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-        ))}
+        {PRIMARY_MAILBOX_IDS.map((mailboxId) => {
+          const unreadCount = unreadCounts[mailboxId] ?? 0
+
+          return (
+            <SidebarMenuItem key={mailboxId}>
+              <SidebarMenuButton
+                tooltip={MAILBOX_LABELS[mailboxId]}
+                isActive={mailbox === mailboxId}
+                onClick={() => onMailboxChange(mailboxId)}
+                className={unreadCount > 0 ? "pr-12" : undefined}
+              >
+                {folderIcons[mailboxId]}
+                <span>{MAILBOX_LABELS[mailboxId]}</span>
+              </SidebarMenuButton>
+              {unreadCount > 0 ? (
+                <SidebarMenuBadge aria-label={`${MAILBOX_LABELS[mailboxId]} 안읽음 ${unreadCount.toLocaleString()}개`}>
+                  <Badge variant="secondary" className="h-5 min-w-5 px-1.5 text-[11px]">
+                    {formatUnreadCount(unreadCount)}
+                  </Badge>
+                </SidebarMenuBadge>
+              ) : null}
+            </SidebarMenuItem>
+          )
+        })}
       </SidebarMenu>
     </SidebarGroup>
   )

--- a/src/components/trash/trash-detail.tsx
+++ b/src/components/trash/trash-detail.tsx
@@ -42,7 +42,7 @@ function getThreadDetailErrorCopy(error: unknown) {
 
 function EmptyState() {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-3">
+    <div className="flex h-full w-full min-w-0 flex-1 flex-col items-center justify-center gap-3">
       <div className="flex size-16 items-center justify-center rounded-full bg-muted">
         <MailOpen className="size-8 text-muted-foreground" />
       </div>
@@ -58,7 +58,7 @@ function EmptyState() {
 
 function LoadingState() {
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full w-full min-w-0 flex-1 flex-col">
       <div className="flex h-11 w-full min-w-0 shrink-0 items-center justify-between gap-2 px-4">
         <Skeleton className="h-4 w-24" />
         <div className="flex items-center gap-1">

--- a/src/components/trash/trash-list.tsx
+++ b/src/components/trash/trash-list.tsx
@@ -188,7 +188,7 @@ export function TrashList({
     )
 
   return (
-    <div className="flex h-full flex-col overflow-hidden rounded-[inherit]">
+    <div className="flex h-full w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[inherit]">
       {header}
 
       <ScrollArea className="min-h-0 flex-1">
@@ -239,7 +239,7 @@ export function TrashList({
             <div ref={loadMoreRef} className="h-1" />
           </>
         ) : (
-          <div className="flex min-h-full flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+          <div className="flex min-h-full w-full flex-col items-center justify-center gap-3 px-6 py-16 text-center">
             <div className="flex size-14 items-center justify-center rounded-full bg-muted">
               <Trash2 className="size-7 text-muted-foreground/60" />
             </div>

--- a/src/components/trash/trash-list.tsx
+++ b/src/components/trash/trash-list.tsx
@@ -33,6 +33,7 @@ function toInboxSummary(thread: TrashThreadSummary): InboxThreadSummary {
 interface TrashListProps {
   mailboxName: string
   threads: TrashThreadSummary[] | undefined
+  totalCount?: number
   isLoading: boolean
   isFetchingNextPage: boolean
   hasNextPage: boolean
@@ -53,6 +54,7 @@ interface TrashListProps {
 export function TrashList({
   mailboxName,
   threads,
+  totalCount,
   isLoading,
   isFetchingNextPage,
   hasNextPage,
@@ -180,7 +182,7 @@ export function TrashList({
       <div className="flex h-11 shrink-0 items-center gap-3 border-b px-4">
         <h2 className="min-w-0 truncate text-sm font-medium">{mailboxName}</h2>
         <span className="hidden rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground sm:inline-flex">
-          {(threads?.length ?? 0).toLocaleString()}개
+          {(totalCount ?? 0).toLocaleString()}개
         </span>
       </div>
     )

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -146,6 +146,24 @@ function Sidebar({
   collapsible?: "offcanvas" | "icon" | "none"
 }) {
   const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+  const handleMobileSidebarClick = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!(event.target instanceof Element)) return
+
+      const closeTarget = event.target.closest('a[href], button[data-sidebar="menu-button"]')
+
+      if (
+        !closeTarget ||
+        closeTarget.hasAttribute("aria-haspopup") ||
+        closeTarget.closest('[data-slot="dropdown-menu-trigger"]')
+      ) {
+        return
+      }
+
+      setOpenMobile(false)
+    },
+    [setOpenMobile]
+  )
 
   if (collapsible === "none") {
     return (
@@ -179,7 +197,9 @@ function Sidebar({
             <SheetTitle>Sidebar</SheetTitle>
             <SheetDescription>Displays the mobile sidebar.</SheetDescription>
           </SheetHeader>
-          <div className="flex h-full w-full flex-col">{children}</div>
+          <div className="flex h-full w-full flex-col" onClick={handleMobileSidebarClick}>
+            {children}
+          </div>
         </SheetContent>
       </Sheet>
     )

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -19,7 +19,6 @@ const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH = "16rem"
 const SIDEBAR_WIDTH_MOBILE = "18rem"
 const SIDEBAR_WIDTH_ICON = "3rem"
-const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 
 type SidebarContextProps = {
   state: "expanded" | "collapsed"
@@ -81,19 +80,6 @@ function SidebarProvider({
   const toggleSidebar = React.useCallback(() => {
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
   }, [isMobile, setOpen, setOpenMobile])
-
-  // Adds a keyboard shortcut to toggle the sidebar.
-  React.useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === SIDEBAR_KEYBOARD_SHORTCUT && (event.metaKey || event.ctrlKey)) {
-        event.preventDefault()
-        toggleSidebar()
-      }
-    }
-
-    window.addEventListener("keydown", handleKeyDown)
-    return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [toggleSidebar])
 
   // We add a state so that we can do data-state="expanded" or "collapsed".
   // This makes it easier to style the sidebar with Tailwind classes.

--- a/src/queries/emails.ts
+++ b/src/queries/emails.ts
@@ -1,12 +1,12 @@
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
 
 import { getMailboxThreads, getThreadDetail } from "@/api/emails"
-import type { SupportedMailboxId } from "@/types/email"
+import type { ListThreadsParams, SupportedMailboxId } from "@/types/email"
 
 export const emailKeys = {
   all: () => ["emails"] as const,
-  mailbox: (mailbox: SupportedMailboxId | null, size: number) =>
-    [...emailKeys.all(), "mailbox", mailbox, size] as const,
+  mailbox: (mailbox: SupportedMailboxId | null, params: Omit<ListThreadsParams, "marker">) =>
+    [...emailKeys.all(), "mailbox", mailbox, params] as const,
   thread: (id: string) => [...emailKeys.all(), "thread", id] as const,
 }
 
@@ -17,18 +17,23 @@ export const emailQueries = {
   }),
 }
 
-export function useMailboxThreads(mailbox: SupportedMailboxId | null, options: { size?: number } = {}) {
+export function useMailboxThreads(mailbox: SupportedMailboxId | null, options: Omit<ListThreadsParams, "marker"> = {}) {
   const size = options.size ?? 50
+  const params = {
+    size,
+    labelId: options.labelId,
+    read: options.read,
+  }
 
   return useInfiniteQuery({
-    queryKey: emailKeys.mailbox(mailbox, size),
+    queryKey: emailKeys.mailbox(mailbox, params),
     initialPageParam: undefined as string | undefined,
     queryFn: ({ pageParam }) => {
       if (!mailbox) {
         throw new Error("Mailbox is required")
       }
 
-      return getMailboxThreads(mailbox, { marker: pageParam, size })
+      return getMailboxThreads(mailbox, { ...params, marker: pageParam })
     },
     getNextPageParam: (lastPage) => lastPage.nextMarker ?? undefined,
     enabled: mailbox != null,

--- a/src/routes/_authenticated/compose.tsx
+++ b/src/routes/_authenticated/compose.tsx
@@ -70,7 +70,7 @@ function ComposePage() {
 
   if (isMobile) {
     return (
-      <div className="flex min-h-0 flex-1 overflow-hidden">
+      <div className="flex min-h-0 w-full min-w-0 flex-1 overflow-hidden">
         <ComposeEmail
           fromAddress={fromAddress}
           onFromAddressChange={handleFromAddressChange}
@@ -84,7 +84,7 @@ function ComposePage() {
   }
 
   return (
-    <div className="flex min-h-0 flex-1 overflow-hidden">
+    <div className="flex min-h-0 w-full min-w-0 flex-1 overflow-hidden">
       <div className="min-h-0 min-w-0 basis-1/2 border-r-0">
         <ComposeReference threadId={replyThreadId ?? null} />
       </div>

--- a/src/routes/_authenticated/mail/$mailbox.tsx
+++ b/src/routes/_authenticated/mail/$mailbox.tsx
@@ -214,7 +214,7 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
 
   if (isMobile) {
     return (
-      <div className="flex min-h-0 flex-1 overflow-hidden">
+      <div className="flex min-h-0 w-full min-w-0 flex-1 overflow-hidden">
         {hasSelection ? (
           <EmailDetail
             threadId={visibleSelectedThreadId}
@@ -236,7 +236,7 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
   }
 
   return (
-    <div className="flex min-h-0 flex-1 overflow-hidden">
+    <div className="flex min-h-0 w-full min-w-0 flex-1 overflow-hidden">
       <div
         className={cn(
           "min-h-0 min-w-0 border-r-0 transition-[flex-basis,width] duration-300 ease-out",
@@ -393,14 +393,14 @@ function TrashMailboxView() {
 
   if (isMobile) {
     return (
-      <div className="flex min-h-0 flex-1 overflow-hidden">
+      <div className="flex min-h-0 w-full min-w-0 flex-1 overflow-hidden">
         {hasSelection ? <TrashDetail threadId={visibleSelectedThreadId} onClose={closeThread} /> : trashList}
       </div>
     )
   }
 
   return (
-    <div className="flex min-h-0 flex-1 overflow-hidden">
+    <div className="flex min-h-0 w-full min-w-0 flex-1 overflow-hidden">
       <div
         className={cn(
           "min-h-0 min-w-0 border-r-0 transition-[flex-basis,width] duration-300 ease-out",

--- a/src/routes/_authenticated/mail/$mailbox.tsx
+++ b/src/routes/_authenticated/mail/$mailbox.tsx
@@ -87,6 +87,7 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
     isError,
     error,
     refetch,
+    isRefetching,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
@@ -168,6 +169,7 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
       isLoading={supportedMailbox != null && isLoading}
       isFetchingNextPage={isFetchingNextPage}
       hasNextPage={!!hasNextPage}
+      isRefreshing={isRefetching}
       selectedThreadId={visibleSelectedThreadId}
       filter={filter}
       onFilterChange={(nextFilter) => {
@@ -197,6 +199,7 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
           void fetchNextPage()
         }
       }}
+      onRefresh={supportedMailbox ? () => void refetch() : undefined}
       getAccount={getAccount}
       emptyTitle={emptyTitle}
       emptyDescription={emptyDescription}

--- a/src/routes/_authenticated/mail/$mailbox.tsx
+++ b/src/routes/_authenticated/mail/$mailbox.tsx
@@ -91,9 +91,12 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
     hasNextPage,
     isFetchingNextPage,
     isFetchNextPageError,
-  } = useMailboxThreads(supportedMailbox)
+  } = useMailboxThreads(supportedMailbox, {
+    read: filter === "unread" ? false : undefined,
+  })
 
   const loadedThreads = data?.pages.flatMap((page) => page.content) ?? []
+  const totalThreadCount = data?.pages[0]?.totalCount ?? loadedThreads.length
   const searchTerms = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
   const selectedAccount = accountId ? (accounts?.find((account) => account.id === accountId) ?? null) : null
 
@@ -116,10 +119,6 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
   const threads = supportedMailbox
     ? loadedThreads.filter((thread) => {
         if (selectedAccount && thread.accountId !== selectedAccount.id) {
-          return false
-        }
-
-        if (filter === "unread" && thread.isRead) {
           return false
         }
 
@@ -165,6 +164,7 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
     <EmailList
       mailboxName={MAILBOX_LABELS[mailbox]}
       threads={threads}
+      totalCount={totalThreadCount}
       isLoading={supportedMailbox != null && isLoading}
       isFetchingNextPage={isFetchingNextPage}
       hasNextPage={!!hasNextPage}
@@ -295,6 +295,7 @@ function TrashMailboxView() {
   } = useTrashThreads()
 
   const loadedThreads = data?.pages.flatMap((page) => page.content) ?? []
+  const totalThreadCount = data?.pages[0]?.totalCount ?? loadedThreads.length
   const searchTerms = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
   const selectedAccount = accountId ? (accounts?.find((account) => account.id === accountId) ?? null) : null
 
@@ -347,6 +348,7 @@ function TrashMailboxView() {
     <TrashList
       mailboxName={MAILBOX_LABELS.trash}
       threads={threads}
+      totalCount={totalThreadCount}
       isLoading={isLoading}
       isFetchingNextPage={isFetchingNextPage}
       hasNextPage={!!hasNextPage}


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#6

### 📌 Task

- Closes #56
- Closes #10

## 💡 작업 내용

- 받은메일함, 보낸메일함, 휴지통 사이드바에 안읽음 카운터를 표시 추가
- 안읽음 필터를 클라이언트 필터링이 아닌 조회 API 기반으로 수정
- 메일 목록 헤더에 API 기반으로 전체 메일 수를 표시하도록 변경
- 인박스 메일 목록 새로고침 버튼 추가
- 기존 이슈 해결
  - 모바일 사이드바 내비게이션에서 메뉴 이동시 자동 닫힘 처리 추가
  - 모바일 인박스에서 발생하는 레이아웃 가로폭 문제 해결
  - 사이드바 토글 단축키(`Ctrl + B`) 제거

## 📝 추가 설명

- 메일 카운터는 99개 초과시 99+로 축약하여 표시
- 멩리함 카운터 조회는 각 메일함별 `size: 1` 요청의 `unreadCount`를 사용

## 🖼️ 스크린샷

<img width="932" height="553" alt="image" src="https://github.com/user-attachments/assets/a1f263b7-8e41-406c-a9f4-62fddef665ba" />

<br>

읽지 않은 메일 수 카운터

| Before | After |
|--------|--------|
| <img width="360" height="780" alt="image" src="https://github.com/user-attachments/assets/36314bb7-4b72-4224-8199-fb0b1fc0ddde" /> | <img width="360" height="780" alt="image" src="https://github.com/user-attachments/assets/ef14db75-9442-4eaf-8865-39524757ecd7" /> | 

모바일 인박스 레이아웃 가로폭 이슈