### PR TITLE
[STORY-402] 라벨 필터링 및 읽지 않음 카운터, 라벨 정렬 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.0.1",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@fontsource-variable/geist": "^5.2.8",
         "@react-email/editor": "^1.3.2",
         "@tailwindcss/vite": "^4.2.1",
@@ -1728,6 +1731,59 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {
@@ -4464,9 +4520,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4479,9 +4532,6 @@
       "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4496,9 +4546,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4511,9 +4558,6 @@
       "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4528,9 +4572,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4543,9 +4584,6 @@
       "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4560,9 +4598,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4575,9 +4610,6 @@
       "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4592,9 +4624,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4607,9 +4636,6 @@
       "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4624,9 +4650,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4640,9 +4663,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4655,9 +4675,6 @@
       "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4905,9 +4922,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4923,9 +4937,6 @@
       "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4943,9 +4954,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4961,9 +4969,6 @@
       "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -10566,9 +10571,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10588,9 +10590,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -10612,9 +10611,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10634,9 +10630,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/geist": "^5.2.8",
     "@react-email/editor": "^1.3.2",
     "@tailwindcss/vite": "^4.2.1",

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -24,15 +24,19 @@ import type { PrimaryMailboxId } from "@/types/email"
 interface AppSidebarProps {
   mailbox: PrimaryMailboxId | null
   activeAccountId?: string
+  activeLabelId?: string
   onMailboxChange: (mailbox: PrimaryMailboxId) => void
   onAccountToggle: (accountId: string) => void
+  onLabelToggle: (labelId: string) => void
 }
 
 export function AppSidebar({
   mailbox,
   activeAccountId,
+  activeLabelId,
   onMailboxChange,
   onAccountToggle,
+  onLabelToggle,
   ...props
 }: AppSidebarProps & React.ComponentProps<typeof Sidebar>) {
   const { data: user } = useUser()
@@ -91,7 +95,7 @@ export function AppSidebar({
         </div>
 
         <NavFolders mailbox={mailbox} onMailboxChange={onMailboxChange} />
-        <NavLabels className="mt-4" />
+        <NavLabels activeLabelId={activeLabelId} onLabelToggle={onLabelToggle} className="mt-4" />
         <NavAccounts activeAccountId={activeAccountId} onAccountToggle={onAccountToggle} className="mt-auto" />
       </SidebarContent>
 

--- a/src/components/inbox/email-detail.tsx
+++ b/src/components/inbox/email-detail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { Archive, ArrowLeft, Forward, MailOpen, Reply, Trash2 } from "lucide-react"
 import { useNavigate } from "@tanstack/react-router"
 import { toast } from "sonner"
@@ -157,6 +157,17 @@ export function EmailDetail({ threadId, onClose }: EmailDetailProps) {
 
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
   const [expandedThreadId, setExpandedThreadId] = useState<string | null>(null)
+  const threadLabels = useMemo(() => {
+    if (!thread) return []
+    const seen = new Set<string>()
+    return thread.messages
+      .flatMap((m) => m.labels)
+      .filter((l) => {
+        if (seen.has(l.labelId)) return false
+        seen.add(l.labelId)
+        return true
+      })
+  }, [thread])
 
   if (thread && thread.threadId !== expandedThreadId) {
     const next = new Set<string>()
@@ -263,7 +274,7 @@ export function EmailDetail({ threadId, onClose }: EmailDetailProps) {
   return (
     <div className="flex h-full w-full min-w-0 flex-1 flex-col">
       <ThreadToolbar onClose={onClose} onDelete={handleDeleteThread} onReply={handleReply} isDeleting={isDeleting} />
-      <ThreadHeader thread={thread} account={account} />
+      <ThreadHeader thread={thread} account={account} labels={threadLabels} />
       <ThreadMessageList
         messages={messages}
         expandedIds={expandedIds}

--- a/src/components/inbox/email-list-item.tsx
+++ b/src/components/inbox/email-list-item.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { Paperclip } from "lucide-react"
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
 
@@ -12,8 +12,11 @@ import { formatFullDateTime, formatRelativeDate } from "@/lib/date"
 import { AccountIcon } from "@/lib/icon-entries"
 import { getMailAddressLabel } from "@/lib/mail-address"
 import { cn } from "@/lib/utils"
-import type { InboxThreadSummary } from "@/types/email"
+import { useLabels } from "@/queries/labels"
+import type { InboxThreadSummary, LabelSummary } from "@/types/email"
 import type { MailAccount } from "@/types/mail-account"
+
+type LabelsColorMap = Map<string, string>
 
 interface EmailListItemProps {
   thread: InboxThreadSummary
@@ -30,12 +33,31 @@ interface EmailListItemCellsProps {
   isChecked: boolean
   account?: MailAccount
   participantLabel: string
+  labelsColorMap: LabelsColorMap
   onToggleCheck: () => void
 }
 
 interface EmailListItemPreviewProps {
   thread: InboxThreadSummary
   participantLabel: string
+  labelsColorMap: LabelsColorMap
+}
+
+function LabelChips({ labels, labelsColorMap }: { labels: LabelSummary[]; labelsColorMap: LabelsColorMap }) {
+  if (labels.length === 0) return null
+  return (
+    <>
+      {labels.map((label) => (
+        <span
+          key={label.labelId}
+          className="inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium text-white"
+          style={{ backgroundColor: labelsColorMap.get(label.labelId) ?? label.colorCode }}
+        >
+          {label.name}
+        </span>
+      ))}
+    </>
+  )
 }
 
 function createCursorAnchor(
@@ -55,6 +77,7 @@ function EmailListItemCells({
   isChecked,
   account,
   participantLabel,
+  labelsColorMap,
   onToggleCheck,
 }: EmailListItemCellsProps) {
   const hasAttachments = thread.attachments.length > 0
@@ -87,6 +110,11 @@ function EmailListItemCells({
       </TableCell>
       <TableCell className="min-w-0">
         <div className="flex min-w-0 items-center gap-2">
+          {thread.labels.length > 0 && (
+            <div className="flex shrink-0 items-center gap-1">
+              <LabelChips labels={thread.labels} labelsColorMap={labelsColorMap} />
+            </div>
+          )}
           <span className={cn("truncate", isUnread ? "text-foreground" : "text-muted-foreground")}>
             {thread.latestSubject || "(제목 없음)"}
           </span>
@@ -103,7 +131,7 @@ function EmailListItemCells({
   )
 }
 
-function EmailListItemPreview({ thread, participantLabel }: EmailListItemPreviewProps) {
+function EmailListItemPreview({ thread, participantLabel, labelsColorMap }: EmailListItemPreviewProps) {
   const hasAttachments = thread.attachments.length > 0
 
   return (
@@ -112,9 +140,10 @@ function EmailListItemPreview({ thread, participantLabel }: EmailListItemPreview
       <p className="line-clamp-3 text-sm leading-relaxed text-muted-foreground">{thread.snippet}</p>
       <Separator />
       <div className="flex flex-wrap items-center gap-1.5">
-        <Badge variant="secondary" className="font-normal">
+        <Badge variant="secondary" className="rounded font-normal">
           {participantLabel}
         </Badge>
+        <LabelChips labels={thread.labels} labelsColorMap={labelsColorMap} />
       </div>
       <div className="flex items-center gap-3 text-xs text-muted-foreground">
         {hasAttachments ? (
@@ -133,6 +162,8 @@ export function EmailListItem({ thread, isSelected, isChecked, account, onSelect
   const isMobile = useIsMobile()
   const [open, setOpen] = useState(false)
   const [anchor, setAnchor] = useState<PopoverPrimitive.Positioner.Props["anchor"]>(null)
+  const { data: labelsList } = useLabels()
+  const labelsColorMap = useMemo(() => new Map(labelsList?.map((l) => [l.id, l.colorCode]) ?? []), [labelsList])
   const isUnread = !thread.isRead
   const participantLabel = getMailAddressLabel(thread.participant)
   const rowClassName = cn(
@@ -175,6 +206,7 @@ export function EmailListItem({ thread, isSelected, isChecked, account, onSelect
           isChecked={isChecked}
           account={account}
           participantLabel={participantLabel}
+          labelsColorMap={labelsColorMap}
           onToggleCheck={onToggleCheck}
         />
       </TableRow>
@@ -201,7 +233,7 @@ export function EmailListItem({ thread, isSelected, isChecked, account, onSelect
         render={(triggerProps) => renderRow(triggerProps)}
       />
       <PopoverContent anchor={anchor} side="bottom" align="start" sideOffset={20} className="w-80 p-4">
-        <EmailListItemPreview thread={thread} participantLabel={participantLabel} />
+        <EmailListItemPreview thread={thread} participantLabel={participantLabel} labelsColorMap={labelsColorMap} />
       </PopoverContent>
     </Popover>
   )

--- a/src/components/inbox/email-list-item.tsx
+++ b/src/components/inbox/email-list-item.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { useState } from "react"
 import { Paperclip } from "lucide-react"
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
 
@@ -12,7 +12,6 @@ import { formatFullDateTime, formatRelativeDate } from "@/lib/date"
 import { AccountIcon } from "@/lib/icon-entries"
 import { getMailAddressLabel } from "@/lib/mail-address"
 import { cn } from "@/lib/utils"
-import { useLabels } from "@/queries/labels"
 import type { InboxThreadSummary, LabelSummary } from "@/types/email"
 import type { MailAccount } from "@/types/mail-account"
 
@@ -23,6 +22,7 @@ interface EmailListItemProps {
   isSelected: boolean
   isChecked: boolean
   account?: MailAccount
+  labelsColorMap: LabelsColorMap
   onSelect: () => void
   onToggleCheck: () => void
 }
@@ -158,12 +158,18 @@ function EmailListItemPreview({ thread, participantLabel, labelsColorMap }: Emai
   )
 }
 
-export function EmailListItem({ thread, isSelected, isChecked, account, onSelect, onToggleCheck }: EmailListItemProps) {
+export function EmailListItem({
+  thread,
+  isSelected,
+  isChecked,
+  account,
+  labelsColorMap,
+  onSelect,
+  onToggleCheck,
+}: EmailListItemProps) {
   const isMobile = useIsMobile()
   const [open, setOpen] = useState(false)
   const [anchor, setAnchor] = useState<PopoverPrimitive.Positioner.Props["anchor"]>(null)
-  const { data: labelsList } = useLabels()
-  const labelsColorMap = useMemo(() => new Map(labelsList?.map((l) => [l.id, l.colorCode]) ?? []), [labelsList])
   const isUnread = !thread.isRead
   const participantLabel = getMailAddressLabel(thread.participant)
   const rowClassName = cn(

--- a/src/components/inbox/email-list.tsx
+++ b/src/components/inbox/email-list.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { InboxIcon } from "lucide-react"
 import { toast } from "sonner"
 
@@ -9,6 +9,7 @@ import { EmailListLoadingRows } from "@/components/inbox/email-list-loading-rows
 import { useDeleteThread, useRestoreTrashThread } from "@/mutations/trash"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Table, TableBody } from "@/components/ui/table"
+import { useLabels } from "@/queries/labels"
 import type { EmailFilter, InboxThreadSummary } from "@/types/email"
 import type { MailAccount } from "@/types/mail-account"
 
@@ -65,6 +66,8 @@ export function EmailList({
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const { mutate: deleteThread } = useDeleteThread()
   const { mutate: restoreThread } = useRestoreTrashThread()
+  const { data: labelsList } = useLabels()
+  const labelsColorMap = useMemo(() => new Map(labelsList?.map((l) => [l.id, l.colorCode]) ?? []), [labelsList])
 
   const toggleSelected = (id: string) => {
     setSelectedIds((prev) => {
@@ -160,6 +163,7 @@ export function EmailList({
                       isSelected={selectedThreadId === thread.threadId}
                       isChecked={selectedIds.has(thread.threadId)}
                       account={getAccount(thread.accountId)}
+                      labelsColorMap={labelsColorMap}
                       onSelect={() => onSelectThread(thread.threadId)}
                       onToggleCheck={() => toggleSelected(thread.threadId)}
                     />

--- a/src/components/label-filter-dialog.tsx
+++ b/src/components/label-filter-dialog.tsx
@@ -140,7 +140,7 @@ export function LabelFilterDialog({
               autoFocus
             />
           </CriteriaRow>
-          <CriteriaRow label="보낸사람">
+          <CriteriaRow label="보낸 주소">
             <Input
               value={criteria.fromAddress}
               onChange={(e) => setCriteria((c) => ({ ...c, fromAddress: e.target.value }))}
@@ -154,7 +154,7 @@ export function LabelFilterDialog({
               className="h-8"
             />
           </CriteriaRow>
-          <CriteriaRow label="받는사람">
+          <CriteriaRow label="받는 주소">
             <Input
               value={criteria.toAddress}
               onChange={(e) => setCriteria((c) => ({ ...c, toAddress: e.target.value }))}

--- a/src/components/nav/nav-labels.tsx
+++ b/src/components/nav/nav-labels.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { Link, useLocation } from "@tanstack/react-router"
+import { Link } from "@tanstack/react-router"
 import { useQuery } from "@tanstack/react-query"
 import { Check, ChevronDown, ListFilter, MoreVertical, Plus } from "lucide-react"
 import { toast } from "sonner"
@@ -27,7 +27,6 @@ import {
 } from "@/components/ui/sidebar"
 import { cn } from "@/lib/utils"
 import { getErrorMessage, getHttpStatus } from "@/lib/http-error"
-import { parseMailRouteSearch } from "@/lib/mail-routing"
 import { useDeleteLabel, useUpdateLabel } from "@/mutations/labels"
 import { useCreateLabel } from "@/mutations/labels"
 import { labelQueries, useLabels } from "@/queries/labels"
@@ -62,7 +61,15 @@ const NOTIFICATION_OPTIONS: { value: NotificationPolicy; label: string }[] = [
   { value: "SILENT", label: "알림 안함" },
 ]
 
-function LabelItem({ label, isActive }: { label: LabelListItem; isActive: boolean }) {
+function LabelItem({
+  label,
+  isActive,
+  onLabelToggle,
+}: {
+  label: LabelListItem
+  isActive: boolean
+  onLabelToggle: (labelId: string) => void
+}) {
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const [renameOpen, setRenameOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -111,11 +118,12 @@ function LabelItem({ label, isActive }: { label: LabelListItem; isActive: boolea
   return (
     <SidebarMenuItem>
       <SidebarMenuButton
+        type="button"
         tooltip={label.name}
         isActive={isActive}
         size="sm"
         className="group-hover/menu-item:bg-sidebar-accent group-hover/menu-item:text-sidebar-accent-foreground"
-        render={<Link to="/mail/$mailbox" params={{ mailbox: "inbox" }} search={{ labelId: label.id }} />}
+        onClick={() => onLabelToggle(label.id)}
       >
         <span className="size-3 shrink-0 rounded-sm" style={{ backgroundColor: label.colorCode }} />
         <span className="truncate">{label.name}</span>
@@ -255,15 +263,19 @@ function LabelItem({ label, isActive }: { label: LabelListItem; isActive: boolea
 
 const LABELS_LIMIT = 4
 
-export function NavLabels({ className }: { className?: string }) {
+interface NavLabelsProps {
+  activeLabelId?: string
+  onLabelToggle: (labelId: string) => void
+  className?: string
+}
+
+export function NavLabels({ activeLabelId, onLabelToggle, className }: NavLabelsProps) {
   const { data: labels = [] } = useLabels()
   const createLabel = useCreateLabel()
   const [open, setOpen] = useState(false)
   const [name, setName] = useState("")
   const [selectedColor, setSelectedColor] = useState(LABEL_COLORS[0])
   const [showAll, setShowAll] = useState(false)
-  const location = useLocation()
-  const { labelId: activeLabelId } = parseMailRouteSearch(location.search)
 
   const visibleLabels = showAll ? labels : labels.slice(0, LABELS_LIMIT)
   const hasMore = labels.length > LABELS_LIMIT
@@ -355,7 +367,12 @@ export function NavLabels({ className }: { className?: string }) {
       {labels.length > 0 && (
         <SidebarMenu>
           {visibleLabels.map((label) => (
-            <LabelItem key={label.id} label={label} isActive={activeLabelId === label.id} />
+            <LabelItem
+              key={label.id}
+              label={label}
+              isActive={activeLabelId === label.id}
+              onLabelToggle={onLabelToggle}
+            />
           ))}
           {hasMore && (
             <SidebarMenuItem>

--- a/src/components/nav/nav-labels.tsx
+++ b/src/components/nav/nav-labels.tsx
@@ -130,7 +130,7 @@ function LabelItem({
     >
       <button
         type="button"
-        className="absolute top-1/2 left-1 z-10 -translate-y-1/2 cursor-grab touch-none rounded p-0.5 opacity-0 group-hover/menu-item:opacity-30 hover:!opacity-60 active:cursor-grabbing"
+        className="absolute top-1/2 left-1 z-10 -translate-y-1/2 cursor-grab touch-none rounded p-0.5 opacity-0 group-hover/menu-item:opacity-30 hover:opacity-60 active:cursor-grabbing"
         aria-label="드래그하여 순서 변경"
         {...attributes}
         {...listeners}

--- a/src/components/nav/nav-labels.tsx
+++ b/src/components/nav/nav-labels.tsx
@@ -1,22 +1,8 @@
-import { useMemo, useState } from "react"
+import { useState } from "react"
 import { Link } from "@tanstack/react-router"
 import { useQuery } from "@tanstack/react-query"
-import {
-  DndContext,
-  KeyboardSensor,
-  PointerSensor,
-  closestCenter,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-} from "@dnd-kit/core"
-import {
-  SortableContext,
-  arrayMove,
-  sortableKeyboardCoordinates,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable"
+import { DndContext, closestCenter } from "@dnd-kit/core"
+import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
 import { Check, ChevronDown, GripVertical, ListFilter, MoreVertical, Plus } from "lucide-react"
 import { toast } from "sonner"
@@ -46,6 +32,7 @@ import { cn } from "@/lib/utils"
 import { getErrorMessage, getHttpStatus } from "@/lib/http-error"
 import { useCreateLabel, useDeleteLabel, useUpdateLabel } from "@/mutations/labels"
 import { labelQueries, useLabels } from "@/queries/labels"
+import { useLabelOrder } from "@/hooks/use-label-order"
 import type { LabelListItem, NotificationPolicy } from "@/types/label"
 
 const LABEL_COLORS = [
@@ -299,48 +286,15 @@ interface NavLabelsProps {
 
 export function NavLabels({ activeLabelId, onLabelToggle, className }: NavLabelsProps) {
   const { data: serverLabels = [] } = useLabels()
-  const updateLabel = useUpdateLabel()
   const createLabel = useCreateLabel()
-  // labelOrder stores the user-defined ID sequence. New labels (not yet in labelOrder)
-  // are appended at the end in server order.
-  const [labelOrder, setLabelOrder] = useState<string[]>([])
+  const { orderedLabels, sensors, handleDragEnd } = useLabelOrder(serverLabels)
   const [open, setOpen] = useState(false)
   const [name, setName] = useState("")
   const [selectedColor, setSelectedColor] = useState(LABEL_COLORS[0])
   const [showAll, setShowAll] = useState(false)
 
-  const orderedLabels = useMemo(() => {
-    const serverMap = new Map(serverLabels.map((l) => [l.id, l]))
-    const existing = labelOrder.filter((id) => serverMap.has(id)).map((id) => serverMap.get(id)!)
-    const newLabels = serverLabels.filter((l) => !labelOrder.includes(l.id))
-    return [...existing, ...newLabels]
-  }, [serverLabels, labelOrder])
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
-  )
-
   const visibleLabels = showAll ? orderedLabels : orderedLabels.slice(0, LABELS_LIMIT)
   const hasMore = orderedLabels.length > LABELS_LIMIT
-
-  function handleDragEnd(event: DragEndEvent) {
-    const { active, over } = event
-    if (!over || active.id === over.id) return
-
-    const oldIndex = orderedLabels.findIndex((l) => l.id === String(active.id))
-    const newIndex = orderedLabels.findIndex((l) => l.id === String(over.id))
-    if (oldIndex === -1 || newIndex === -1) return
-
-    const newLabels = arrayMove(orderedLabels, oldIndex, newIndex)
-    setLabelOrder(newLabels.map((l) => l.id))
-
-    newLabels.forEach((label, i) => {
-      if (orderedLabels[i]?.id !== label.id) {
-        updateLabel.mutate({ labelId: label.id, data: { order: i } })
-      }
-    })
-  }
 
   function handleCreate() {
     if (!name.trim()) return

--- a/src/components/nav/nav-labels.tsx
+++ b/src/components/nav/nav-labels.tsx
@@ -1,7 +1,24 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { Link } from "@tanstack/react-router"
 import { useQuery } from "@tanstack/react-query"
-import { Check, ChevronDown, ListFilter, MoreVertical, Plus } from "lucide-react"
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core"
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import { Check, ChevronDown, GripVertical, ListFilter, MoreVertical, Plus } from "lucide-react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -27,8 +44,7 @@ import {
 } from "@/components/ui/sidebar"
 import { cn } from "@/lib/utils"
 import { getErrorMessage, getHttpStatus } from "@/lib/http-error"
-import { useDeleteLabel, useUpdateLabel } from "@/mutations/labels"
-import { useCreateLabel } from "@/mutations/labels"
+import { useCreateLabel, useDeleteLabel, useUpdateLabel } from "@/mutations/labels"
 import { labelQueries, useLabels } from "@/queries/labels"
 import type { LabelListItem, NotificationPolicy } from "@/types/label"
 
@@ -79,6 +95,8 @@ function LabelItem({
   const deleteLabel = useDeleteLabel()
   const { data: labelDetail } = useQuery({ ...labelQueries.detail(label.id), enabled: dropdownOpen })
 
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: label.id })
+
   function handleColorChange(color: string) {
     updateLabel.mutate({ labelId: label.id, data: { colorCode: color } })
     setDropdownOpen(false)
@@ -116,13 +134,25 @@ function LabelItem({
   }
 
   return (
-    <SidebarMenuItem>
+    <SidebarMenuItem
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.4 : undefined }}
+    >
+      <button
+        type="button"
+        className="absolute top-1/2 left-1 z-10 -translate-y-1/2 cursor-grab touch-none rounded p-0.5 opacity-0 group-hover/menu-item:opacity-30 hover:!opacity-60 active:cursor-grabbing"
+        aria-label="드래그하여 순서 변경"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="size-3.5" />
+      </button>
       <SidebarMenuButton
         type="button"
         tooltip={label.name}
         isActive={isActive}
         size="sm"
-        className="group-hover/menu-item:bg-sidebar-accent group-hover/menu-item:text-sidebar-accent-foreground"
+        className="pl-5 group-hover/menu-item:bg-sidebar-accent group-hover/menu-item:text-sidebar-accent-foreground"
         onClick={() => onLabelToggle(label.id)}
       >
         <span className="size-3 shrink-0 rounded-sm" style={{ backgroundColor: label.colorCode }} />
@@ -270,15 +300,49 @@ interface NavLabelsProps {
 }
 
 export function NavLabels({ activeLabelId, onLabelToggle, className }: NavLabelsProps) {
-  const { data: labels = [] } = useLabels()
+  const { data: serverLabels = [] } = useLabels()
+  const updateLabel = useUpdateLabel()
   const createLabel = useCreateLabel()
+  // labelOrder stores the user-defined ID sequence. New labels (not yet in labelOrder)
+  // are appended at the end in server order.
+  const [labelOrder, setLabelOrder] = useState<string[]>([])
   const [open, setOpen] = useState(false)
   const [name, setName] = useState("")
   const [selectedColor, setSelectedColor] = useState(LABEL_COLORS[0])
   const [showAll, setShowAll] = useState(false)
 
-  const visibleLabels = showAll ? labels : labels.slice(0, LABELS_LIMIT)
-  const hasMore = labels.length > LABELS_LIMIT
+  const orderedLabels = useMemo(() => {
+    const serverMap = new Map(serverLabels.map((l) => [l.id, l]))
+    const existing = labelOrder.filter((id) => serverMap.has(id)).map((id) => serverMap.get(id)!)
+    const newLabels = serverLabels.filter((l) => !labelOrder.includes(l.id))
+    return [...existing, ...newLabels]
+  }, [serverLabels, labelOrder])
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  const visibleLabels = showAll ? orderedLabels : orderedLabels.slice(0, LABELS_LIMIT)
+  const hasMore = orderedLabels.length > LABELS_LIMIT
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const oldIndex = orderedLabels.findIndex((l) => l.id === String(active.id))
+    const newIndex = orderedLabels.findIndex((l) => l.id === String(over.id))
+    if (oldIndex === -1 || newIndex === -1) return
+
+    const newLabels = arrayMove(orderedLabels, oldIndex, newIndex)
+    setLabelOrder(newLabels.map((l) => l.id))
+
+    newLabels.forEach((label, i) => {
+      if (orderedLabels[i]?.id !== label.id) {
+        updateLabel.mutate({ labelId: label.id, data: { order: i } })
+      }
+    })
+  }
 
   function handleCreate() {
     if (!name.trim()) return
@@ -364,16 +428,20 @@ export function NavLabels({ activeLabelId, onLabelToggle, className }: NavLabels
         </div>
       </SidebarGroupLabel>
 
-      {labels.length > 0 && (
+      {orderedLabels.length > 0 && (
         <SidebarMenu>
-          {visibleLabels.map((label) => (
-            <LabelItem
-              key={label.id}
-              label={label}
-              isActive={activeLabelId === label.id}
-              onLabelToggle={onLabelToggle}
-            />
-          ))}
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+            <SortableContext items={visibleLabels.map((l) => l.id)} strategy={verticalListSortingStrategy}>
+              {visibleLabels.map((label) => (
+                <LabelItem
+                  key={label.id}
+                  label={label}
+                  isActive={activeLabelId === label.id}
+                  onLabelToggle={onLabelToggle}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
           {hasMore && (
             <SidebarMenuItem>
               <SidebarMenuButton size="sm" onClick={() => setShowAll((v) => !v)}>

--- a/src/components/nav/nav-labels.tsx
+++ b/src/components/nav/nav-labels.tsx
@@ -130,19 +130,19 @@ function LabelItem({
     >
       <button
         type="button"
-        className="absolute top-1/2 left-1 z-10 -translate-y-1/2 cursor-grab touch-none rounded p-0.5 opacity-0 group-hover/menu-item:opacity-30 hover:opacity-60 active:cursor-grabbing"
+        className="absolute top-1/2 -left-3.5 z-10 -translate-y-1/2 cursor-grab touch-none rounded p-0.5 opacity-0 group-hover/menu-item:opacity-30 hover:opacity-60 active:cursor-grabbing"
         aria-label="드래그하여 순서 변경"
         {...attributes}
         {...listeners}
       >
-        <GripVertical className="size-3.5" />
+        <GripVertical className="size-3" />
       </button>
       <SidebarMenuButton
         type="button"
         tooltip={label.name}
         isActive={isActive}
         size="sm"
-        className="pl-5 group-hover/menu-item:bg-sidebar-accent group-hover/menu-item:text-sidebar-accent-foreground"
+        className="group-hover/menu-item:bg-sidebar-accent group-hover/menu-item:text-sidebar-accent-foreground"
         onClick={() => onLabelToggle(label.id)}
       >
         <span className="size-3 shrink-0 rounded-sm" style={{ backgroundColor: label.colorCode }} />

--- a/src/components/nav/nav-labels.tsx
+++ b/src/components/nav/nav-labels.tsx
@@ -86,6 +86,7 @@ function LabelItem({
   isActive: boolean
   onLabelToggle: (labelId: string) => void
 }) {
+  const [isHovered, setIsHovered] = useState(false)
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const [renameOpen, setRenameOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -137,6 +138,8 @@ function LabelItem({
     <SidebarMenuItem
       ref={setNodeRef}
       style={{ transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.4 : undefined }}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
     >
       <button
         type="button"
@@ -157,24 +160,19 @@ function LabelItem({
       >
         <span className="size-3 shrink-0 rounded-sm" style={{ backgroundColor: label.colorCode }} />
         <span className="truncate">{label.name}</span>
-        {label.unreadThreadCount > 0 && (
-          <span className="ml-auto rounded-full bg-muted px-1.5 py-0.5 text-[10px] leading-none font-medium text-muted-foreground tabular-nums group-hover/menu-item:hidden">
-            {label.unreadThreadCount}
-          </span>
-        )}
       </SidebarMenuButton>
 
       <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
         <DropdownMenuTrigger
-          render={
-            <SidebarMenuAction
-              showOnHover
-              aria-label="라벨 메뉴"
-              className="size-5 hover:bg-sidebar-accent-foreground/15"
-            />
-          }
+          render={<SidebarMenuAction aria-label="라벨 메뉴" className="size-5 hover:bg-sidebar-accent-foreground/15" />}
         >
-          <MoreVertical />
+          {isHovered || dropdownOpen ? (
+            <MoreVertical />
+          ) : label.unreadThreadCount > 0 ? (
+            <span className="px-1.5 py-0.5 text-[10px] leading-none font-medium text-muted-foreground tabular-nums">
+              {label.unreadThreadCount}
+            </span>
+          ) : null}
         </DropdownMenuTrigger>
         <DropdownMenuContent side="right" align="start" className="min-w-44 ring-foreground/6">
           <DropdownMenuSub>

--- a/src/components/thread-header.tsx
+++ b/src/components/thread-header.tsx
@@ -1,5 +1,9 @@
+import { useMemo } from "react"
+
 import { Badge } from "@/components/ui/badge"
 import { AccountIcon } from "@/lib/icon-entries"
+import { useLabels } from "@/queries/labels"
+import type { LabelSummary } from "@/types/email"
 import type { MailAccount } from "@/types/mail-account"
 
 interface ThreadHeaderData {
@@ -10,12 +14,15 @@ interface ThreadHeaderData {
 interface ThreadHeaderProps {
   thread: ThreadHeaderData
   account?: MailAccount
+  labels?: LabelSummary[]
 }
 
-export function ThreadHeader({ thread, account }: ThreadHeaderProps) {
+export function ThreadHeader({ thread, account, labels }: ThreadHeaderProps) {
   const messageCount = thread.messages.length
   const hasInbound = thread.messages.some((m) => m.direction === "INBOUND")
   const hasOutbound = thread.messages.some((m) => m.direction === "OUTBOUND")
+  const { data: labelsList } = useLabels()
+  const labelsColorMap = useMemo(() => new Map(labelsList?.map((l) => [l.id, l.colorCode]) ?? []), [labelsList])
 
   return (
     <div className="shrink-0 border-b px-6 pt-2 pb-5">
@@ -44,6 +51,15 @@ export function ThreadHeader({ thread, account }: ThreadHeaderProps) {
         <Badge variant="secondary" className="font-normal">
           메시지 {messageCount}개
         </Badge>
+        {labels?.map((label) => (
+          <span
+            key={label.labelId}
+            className="inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium text-white"
+            style={{ backgroundColor: labelsColorMap.get(label.labelId) ?? label.colorCode }}
+          >
+            {label.name}
+          </span>
+        ))}
       </div>
     </div>
   )

--- a/src/components/thread-header.tsx
+++ b/src/components/thread-header.tsx
@@ -1,8 +1,5 @@
-import { useMemo } from "react"
-
 import { Badge } from "@/components/ui/badge"
 import { AccountIcon } from "@/lib/icon-entries"
-import { useLabels } from "@/queries/labels"
 import type { LabelSummary } from "@/types/email"
 import type { MailAccount } from "@/types/mail-account"
 
@@ -21,9 +18,6 @@ export function ThreadHeader({ thread, account, labels }: ThreadHeaderProps) {
   const messageCount = thread.messages.length
   const hasInbound = thread.messages.some((m) => m.direction === "INBOUND")
   const hasOutbound = thread.messages.some((m) => m.direction === "OUTBOUND")
-  const { data: labelsList } = useLabels()
-  const labelsColorMap = useMemo(() => new Map(labelsList?.map((l) => [l.id, l.colorCode]) ?? []), [labelsList])
-
   return (
     <div className="shrink-0 border-b px-6 pt-2 pb-5">
       <h2 className="text-xl leading-snug font-semibold wrap-break-word">{thread.latestSubject || "(제목 없음)"}</h2>
@@ -55,7 +49,7 @@ export function ThreadHeader({ thread, account, labels }: ThreadHeaderProps) {
           <span
             key={label.labelId}
             className="inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium text-white"
-            style={{ backgroundColor: labelsColorMap.get(label.labelId) ?? label.colorCode }}
+            style={{ backgroundColor: label.colorCode }}
           >
             {label.name}
           </span>

--- a/src/components/trash/trash-list.tsx
+++ b/src/components/trash/trash-list.tsx
@@ -10,6 +10,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { Table, TableBody } from "@/components/ui/table"
 import { getErrorMessage } from "@/lib/http-error"
 import { useRestoreTrashThread } from "@/mutations/trash"
+import { useLabels } from "@/queries/labels"
 import type { InboxThreadSummary } from "@/types/email"
 import type { MailAccount } from "@/types/mail-account"
 import type { TrashThreadSummary } from "@/types/trash"
@@ -74,6 +75,8 @@ export function TrashList({
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const { mutateAsync: restoreThread } = useRestoreTrashThread()
+  const { data: labelsList } = useLabels()
+  const labelsColorMap = useMemo(() => new Map(labelsList?.map((l) => [l.id, l.colorCode]) ?? []), [labelsList])
 
   const toggleSelected = (id: string) => {
     setSelectedIds((prev) => {
@@ -219,6 +222,7 @@ export function TrashList({
                     isSelected={selectedThreadId === thread.threadId}
                     isChecked={visibleSelectedIds.has(thread.threadId)}
                     account={getAccount(thread.accountId)}
+                    labelsColorMap={labelsColorMap}
                     onSelect={() => onSelectThread(thread.threadId)}
                     onToggleCheck={() => toggleSelected(thread.threadId)}
                   />

--- a/src/hooks/use-label-order.ts
+++ b/src/hooks/use-label-order.ts
@@ -1,0 +1,43 @@
+import { useMemo, useState } from "react"
+import { KeyboardSensor, PointerSensor, useSensor, useSensors, type DragEndEvent } from "@dnd-kit/core"
+import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable"
+
+import { useUpdateLabel } from "@/mutations/labels"
+import type { LabelListItem } from "@/types/label"
+
+export function useLabelOrder(serverLabels: LabelListItem[]) {
+  const [labelOrder, setLabelOrder] = useState<string[]>([])
+  const updateLabel = useUpdateLabel()
+
+  const orderedLabels = useMemo(() => {
+    const serverMap = new Map(serverLabels.map((l) => [l.id, l]))
+    const existing = labelOrder.filter((id) => serverMap.has(id)).map((id) => serverMap.get(id)!)
+    const newLabels = serverLabels.filter((l) => !labelOrder.includes(l.id))
+    return [...existing, ...newLabels]
+  }, [serverLabels, labelOrder])
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const oldIndex = orderedLabels.findIndex((l) => l.id === String(active.id))
+    const newIndex = orderedLabels.findIndex((l) => l.id === String(over.id))
+    if (oldIndex === -1 || newIndex === -1) return
+
+    const newLabels = arrayMove(orderedLabels, oldIndex, newIndex)
+    setLabelOrder(newLabels.map((l) => l.id))
+
+    newLabels.forEach((label, i) => {
+      if (orderedLabels[i]?.id !== label.id) {
+        updateLabel.mutate({ labelId: label.id, data: { order: i } })
+      }
+    })
+  }
+
+  return { orderedLabels, sensors, handleDragEnd }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,25 @@
 
 @custom-variant dark (&:is(.dark *));
 
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  15%,
+  55% {
+    transform: translateX(-5px);
+  }
+  35%,
+  75% {
+    transform: translateX(5px);
+  }
+}
+
+.animate-shake {
+  animation: shake 0.45s ease-in-out;
+}
+
 .compose-email-editor {
   --re-bg: var(--popover);
   --re-bg-active: var(--accent);

--- a/src/mutations/emails.ts
+++ b/src/mutations/emails.ts
@@ -6,6 +6,7 @@ import type { ComposeEmailData } from "@/types/email"
 import { markThreadAsRead, sendMail } from "@/api/emails"
 import { queryClient } from "@/lib/query-client"
 import { emailKeys } from "@/queries/emails"
+import { labelKeys } from "@/queries/labels"
 
 export const emailMutationOptions = {
   sendMail: () => ({
@@ -22,6 +23,7 @@ export function useMarkThreadAsRead() {
     mutationFn: (threadId: string) => markThreadAsRead(threadId),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: emailKeys.all() })
+      void queryClient.invalidateQueries({ queryKey: labelKeys.all() })
     },
     onError: () => {
       toast.error("읽음 처리에 실패했습니다")

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -29,13 +29,14 @@ export const Route = createFileRoute("/_authenticated")({
 
 function getMailRouteState(pathname: string, search: unknown) {
   const [, section, mailbox] = pathname.split("/")
-  const { query = "", filter = "all", accountId } = parseMailRouteSearch(search)
+  const { query = "", filter = "all", accountId, labelId } = parseMailRouteSearch(search)
 
   return {
     mailbox: section === "mail" && mailbox ? parseMailboxId(mailbox) : null,
     query,
     filter,
     accountId,
+    labelId,
   }
 }
 
@@ -60,7 +61,7 @@ function NotificationSettingsLink() {
 function AuthenticatedRouteLayout() {
   const isMobile = useIsMobile()
   const navigate = useNavigate()
-  const { mailbox, query, filter, accountId } = useLocation({
+  const { mailbox, query, filter, accountId, labelId } = useLocation({
     select: (currentLocation) => getMailRouteState(currentLocation.pathname, currentLocation.search),
   })
 
@@ -146,6 +147,7 @@ function AuthenticatedRouteLayout() {
         <AppSidebar
           mailbox={mailbox}
           activeAccountId={accountId}
+          activeLabelId={labelId}
           onMailboxChange={(nextMailbox) => {
             void navigate({
               to: "/mail/$mailbox",
@@ -164,6 +166,18 @@ function AuthenticatedRouteLayout() {
               search: (previous) => ({
                 ...previous,
                 accountId: previous.accountId === nextAccountId ? undefined : nextAccountId,
+                thread: undefined,
+              }),
+              replace: true,
+            })
+          }}
+          onLabelToggle={(nextLabelId) => {
+            void navigate({
+              to: "/mail/$mailbox",
+              params: { mailbox: mailbox ?? "inbox" },
+              search: (previous) => ({
+                ...previous,
+                labelId: previous.labelId === nextLabelId ? undefined : nextLabelId,
                 thread: undefined,
               }),
               replace: true,

--- a/src/routes/_authenticated/mail/$mailbox.tsx
+++ b/src/routes/_authenticated/mail/$mailbox.tsx
@@ -15,6 +15,7 @@ import { cn } from "@/lib/utils"
 import { useMarkThreadAsRead } from "@/mutations/emails"
 import { useMailAccounts } from "@/queries/mail-accounts"
 import { useMailboxThreads } from "@/queries/emails"
+import { useLabels } from "@/queries/labels"
 import { useTrashThreads } from "@/queries/trash"
 import { isSupportedMailboxId, MAILBOX_LABELS, parseMailboxId, type PrimaryMailboxId } from "@/types/email"
 import type { TrashThreadSummary } from "@/types/trash"
@@ -72,12 +73,14 @@ function MailboxPage() {
 }
 
 function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
-  const { query = "", filter = "all", accountId, thread: selectedThreadId = null } = Route.useSearch()
+  const { query = "", filter = "all", accountId, labelId, thread: selectedThreadId = null } = Route.useSearch()
   const navigate = Route.useNavigate()
   const isMobile = useIsMobile()
   const { data: accounts } = useMailAccounts()
+  const { data: labels } = useLabels()
   const { mutate: markAsRead } = useMarkThreadAsRead()
   const supportedMailbox = isSupportedMailboxId(mailbox) ? mailbox : null
+  const selectedLabel = labelId ? (labels?.find((label) => label.id === labelId) ?? null) : null
   const {
     data,
     isLoading,
@@ -91,6 +94,7 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
     isFetchNextPageError,
   } = useMailboxThreads(supportedMailbox, {
     read: filter === "unread" ? false : undefined,
+    labelId: labelId ? [labelId] : undefined,
   })
 
   const loadedThreads = data?.pages.flatMap((page) => page.content) ?? []
@@ -113,6 +117,22 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
       replace: true,
     })
   }, [accounts, navigate, selectedAccount, accountId])
+
+  useEffect(() => {
+    if (!labelId || labels === undefined || selectedLabel) {
+      return
+    }
+
+    toast.error("유효하지 않은 라벨입니다")
+
+    void navigate({
+      search: (previous) => ({
+        ...previous,
+        labelId: undefined,
+      }),
+      replace: true,
+    })
+  }, [labels, navigate, selectedLabel, labelId])
 
   const threads = supportedMailbox
     ? loadedThreads.filter((thread) => {
@@ -153,6 +173,9 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
     emptyDescription = "현재까지 불러온 메일에서 검색 결과를 찾지 못했습니다."
   } else if (filter === "unread") {
     emptyTitle = "안 읽은 메일이 없습니다"
+  } else if (selectedLabel?.id) {
+    emptyTitle = "선택한 라벨의 메일이 없습니다"
+    emptyDescription = `"${selectedLabel.name}" 라벨이 적용된 메일이 없습니다.`
   } else if (selectedAccount?.id) {
     emptyTitle = "선택한 계정의 메일이 없습니다"
     emptyDescription = `${selectedAccount.alias} (${selectedAccount.emailAddress}) 계정에서 불러온 메일이 없습니다.`

--- a/src/routes/_authenticated/mail/$mailbox.tsx
+++ b/src/routes/_authenticated/mail/$mailbox.tsx
@@ -1,5 +1,4 @@
-import { useEffect } from "react"
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, redirect } from "@tanstack/react-router"
 import { toast } from "sonner"
 
 import { EmailDetail } from "@/components/inbox/email-detail"
@@ -13,9 +12,9 @@ import { parseMailRouteSearch } from "@/lib/mail-routing"
 import { getMailAddressSearchText } from "@/lib/mail-address"
 import { cn } from "@/lib/utils"
 import { useMarkThreadAsRead } from "@/mutations/emails"
-import { useMailAccounts } from "@/queries/mail-accounts"
+import { useMailAccounts, mailAccountQueries } from "@/queries/mail-accounts"
 import { useMailboxThreads } from "@/queries/emails"
-import { useLabels } from "@/queries/labels"
+import { useLabels, labelQueries } from "@/queries/labels"
 import { useTrashThreads } from "@/queries/trash"
 import { isSupportedMailboxId, MAILBOX_LABELS, parseMailboxId, type PrimaryMailboxId } from "@/types/email"
 import type { TrashThreadSummary } from "@/types/trash"
@@ -33,6 +32,35 @@ export const Route = createFileRoute("/_authenticated/mail/$mailbox")({
     },
   },
   validateSearch: parseMailRouteSearch,
+  beforeLoad: async ({ context, params, search }) => {
+    const { labelId, accountId } = search
+
+    if (!labelId && !accountId) return
+
+    const [labels, accounts] = await Promise.all([
+      labelId !== undefined ? context.queryClient.ensureQueryData(labelQueries.list()) : null,
+      accountId !== undefined ? context.queryClient.ensureQueryData(mailAccountQueries.list()) : null,
+    ])
+
+    const isLabelInvalid = labels !== null && !labels.some((l) => l.id === labelId)
+    const isAccountInvalid = accounts !== null && !accounts.some((a) => a.id === accountId)
+
+    if (!isLabelInvalid && !isAccountInvalid) return
+
+    if (isLabelInvalid) toast.error("유효하지 않은 라벨입니다")
+    if (isAccountInvalid) toast.error("유효하지 않은 계정입니다")
+
+    throw redirect({
+      to: "/mail/$mailbox",
+      params: { mailbox: params.mailbox },
+      search: {
+        ...search,
+        labelId: isLabelInvalid ? undefined : search.labelId,
+        accountId: isAccountInvalid ? undefined : search.accountId,
+      },
+      replace: true,
+    })
+  },
   component: MailboxPage,
 })
 
@@ -101,38 +129,6 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
   const totalThreadCount = data?.pages[0]?.totalCount ?? loadedThreads.length
   const searchTerms = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
   const selectedAccount = accountId ? (accounts?.find((account) => account.id === accountId) ?? null) : null
-
-  useEffect(() => {
-    if (!accountId || accounts === undefined || selectedAccount) {
-      return
-    }
-
-    toast.error("유효하지 않은 계정입니다")
-
-    void navigate({
-      search: (previous) => ({
-        ...previous,
-        accountId: undefined,
-      }),
-      replace: true,
-    })
-  }, [accounts, navigate, selectedAccount, accountId])
-
-  useEffect(() => {
-    if (!labelId || labels === undefined || selectedLabel) {
-      return
-    }
-
-    toast.error("유효하지 않은 라벨입니다")
-
-    void navigate({
-      search: (previous) => ({
-        ...previous,
-        labelId: undefined,
-      }),
-      replace: true,
-    })
-  }, [labels, navigate, selectedLabel, labelId])
 
   const threads = supportedMailbox
     ? loadedThreads.filter((thread) => {
@@ -321,22 +317,6 @@ function TrashMailboxView() {
   const totalThreadCount = data?.pages[0]?.totalCount ?? loadedThreads.length
   const searchTerms = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
   const selectedAccount = accountId ? (accounts?.find((account) => account.id === accountId) ?? null) : null
-
-  useEffect(() => {
-    if (!accountId || accounts === undefined || selectedAccount) {
-      return
-    }
-
-    toast.error("유효하지 않은 계정입니다")
-
-    void navigate({
-      search: (previous) => ({
-        ...previous,
-        accountId: undefined,
-      }),
-      replace: true,
-    })
-  }, [accounts, navigate, selectedAccount, accountId])
 
   const threads = loadedThreads.filter((thread) => {
     if (selectedAccount && thread.accountId !== selectedAccount.id) {

--- a/src/routes/_authenticated/settings/label/$labelId.tsx
+++ b/src/routes/_authenticated/settings/label/$labelId.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react"
-import { createFileRoute } from "@tanstack/react-router"
-import { Pencil, Plus, Trash2 } from "lucide-react"
+import { Link, createFileRoute } from "@tanstack/react-router"
+import { ArrowLeft, Minus, Plus } from "lucide-react"
 import { toast } from "sonner"
 
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button, buttonVariants } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { LabelFilterDialog } from "@/components/label-filter-dialog"
@@ -41,37 +41,40 @@ function LabelDetailPage() {
   const { data: label, isPending, isError } = useLabelDetail(labelId)
   const updateRule = useUpdateLabelRule()
   const [isEditing, setIsEditing] = useState(false)
-  const [conditions, setConditions] = useState<LabelCondition[] | null>(null)
+  const [editGroups, setEditGroups] = useState<{ conditions: LabelCondition[] }[] | null>(null)
   const [filterDialogOpen, setFilterDialogOpen] = useState(false)
 
-  const savedConditions = label?.rule?.groups[0]?.conditions ?? []
-  const displayConditions = conditions ?? savedConditions
-  const colSpan = isEditing ? 4 : 3
+  const savedGroups = label?.rule?.groups ?? []
+  const displayGroups = editGroups ?? savedGroups
+  const totalConditions = savedGroups.reduce((sum, g) => sum + g.conditions.length, 0)
 
   function startEditing() {
-    setConditions([...savedConditions])
+    setEditGroups(savedGroups.map((g) => ({ conditions: [...g.conditions] })))
     setIsEditing(true)
   }
 
   function cancelEditing() {
-    setConditions(null)
+    setEditGroups(null)
     setIsEditing(false)
   }
 
-  function handleRemove(index: number) {
-    setConditions(displayConditions.filter((_, i) => i !== index))
+  function handleRemove(groupIndex: number, conditionIndex: number) {
+    setEditGroups((prev) =>
+      prev!.map((g, gi) =>
+        gi === groupIndex ? { conditions: g.conditions.filter((_, ci) => ci !== conditionIndex) } : g
+      )
+    )
   }
 
   function handleSave() {
-    const otherGroups = label?.rule?.groups.slice(1) ?? []
     updateRule.mutate(
       {
         labelId,
-        data: { rule: { groups: [{ conditions: displayConditions }, ...otherGroups] } },
+        data: { rule: { groups: editGroups! } },
       },
       {
         onSuccess: () => {
-          setConditions(null)
+          setEditGroups(null)
           setIsEditing(false)
           toast.success("필터 규칙이 저장되었습니다.")
         },
@@ -112,6 +115,12 @@ function LabelDetailPage() {
   return (
     <ScrollArea className="min-h-0 flex-1">
       <div className="flex flex-col gap-6 px-3 pt-1 pb-4">
+        <div>
+          <Link to="/settings/label" className={buttonVariants({ variant: "ghost", size: "sm" })}>
+            <ArrowLeft className="size-4" />
+            라벨 목록
+          </Link>
+        </div>
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -122,14 +131,6 @@ function LabelDetailPage() {
               {label.name}
             </CardTitle>
             <CardDescription>이 라벨에 자동으로 분류될 메일의 조건을 설정합니다.</CardDescription>
-            <CardAction>
-              {!isEditing && (
-                <Button variant="outline" size="sm" onClick={startEditing} disabled={savedConditions.length === 0}>
-                  <Pencil data-icon="inline-start" />
-                  조건 수정
-                </Button>
-              )}
-            </CardAction>
           </CardHeader>
           <CardContent className="px-0">
             <Table>
@@ -138,46 +139,57 @@ function LabelDetailPage() {
                   <TableHead>필드</TableHead>
                   <TableHead>연산자</TableHead>
                   <TableHead>값</TableHead>
-                  {isEditing && <TableHead className="w-10" />}
+                  <TableHead className="w-10" />
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {displayConditions.length === 0 ? (
+                {totalConditions === 0 ? (
                   <TableRow>
-                    <TableCell colSpan={colSpan} className="text-center text-sm text-muted-foreground">
+                    <TableCell colSpan={4} className="text-center text-sm text-muted-foreground">
                       설정된 필터 조건이 없습니다.
                     </TableCell>
                   </TableRow>
                 ) : (
-                  displayConditions.map((condition, index) => (
-                    <TableRow key={index}>
-                      <TableCell>
-                        <Badge variant="secondary" className="font-normal">
-                          {FIELD_LABELS[condition.field]}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-sm text-muted-foreground">
-                        {OPERATOR_LABELS[condition.operator]}
-                      </TableCell>
-                      <TableCell className="font-mono text-sm">{condition.value}</TableCell>
-                      {isEditing && (
+                  displayGroups.flatMap((group, groupIndex) => [
+                    ...(groupIndex > 0
+                      ? [
+                          <TableRow key={`sep-${groupIndex}`} className="hover:bg-transparent">
+                            <TableCell colSpan={4} className="py-1 text-center text-xs text-muted-foreground">
+                              또는
+                            </TableCell>
+                          </TableRow>,
+                        ]
+                      : []),
+                    ...group.conditions.map((condition, conditionIndex) => (
+                      <TableRow key={`${groupIndex}-${conditionIndex}`}>
                         <TableCell>
-                          <Button
-                            variant="ghost"
-                            size="icon-sm"
-                            onClick={() => handleRemove(index)}
-                            aria-label="조건 삭제"
-                          >
-                            <Trash2 className="size-4" />
-                          </Button>
+                          <Badge variant="secondary" className="font-normal">
+                            {FIELD_LABELS[condition.field]}
+                          </Badge>
                         </TableCell>
-                      )}
-                    </TableRow>
-                  ))
+                        <TableCell className="text-sm text-muted-foreground">
+                          {OPERATOR_LABELS[condition.operator]}
+                        </TableCell>
+                        <TableCell className="font-mono text-sm">{condition.value}</TableCell>
+                        <TableCell>
+                          {isEditing && (
+                            <Button
+                              variant="ghost"
+                              size="icon-sm"
+                              onClick={() => handleRemove(groupIndex, conditionIndex)}
+                              aria-label="조건 삭제"
+                            >
+                              <Minus className="size-4" />
+                            </Button>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    )),
+                  ])
                 )}
                 {!isEditing && (
                   <TableRow className="hover:bg-transparent">
-                    <TableCell colSpan={colSpan} className="p-0">
+                    <TableCell colSpan={4} className="p-0">
                       <button
                         type="button"
                         className="flex w-full cursor-pointer items-center justify-center py-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
@@ -191,6 +203,13 @@ function LabelDetailPage() {
                 )}
               </TableBody>
             </Table>
+            {!isEditing && (
+              <div className="flex justify-end px-4 pt-3">
+                <Button variant="outline" size="sm" onClick={startEditing} disabled={totalConditions === 0}>
+                  수정하기
+                </Button>
+              </div>
+            )}
           </CardContent>
           {isEditing && (
             <CardFooter className="justify-end gap-2">

--- a/src/routes/_authenticated/settings/label/$labelId.tsx
+++ b/src/routes/_authenticated/settings/label/$labelId.tsx
@@ -20,12 +20,12 @@ export const Route = createFileRoute("/_authenticated/settings/label/$labelId")(
 
 const FIELD_LABELS: Record<ConditionField, string> = {
   MAIL_ACCOUNT: "메일 계정",
-  FROM_ADDRESS: "보낸 사람 (주소)",
-  FROM_DOMAIN: "보낸 사람 (도메인)",
-  TO_ADDRESS: "받는 사람",
+  FROM_ADDRESS: "보낸 주소",
+  FROM_DOMAIN: "보낸 도메인",
+  TO_ADDRESS: "받는 주소",
   CC_ADDRESS: "참조",
   SUBJECT: "제목",
-  BODY_TEXT: "본문",
+  BODY_TEXT: "포함하는 단어",
   HAS_ATTACHMENT: "첨부파일",
 }
 

--- a/src/routes/_authenticated/settings/label/$labelId.tsx
+++ b/src/routes/_authenticated/settings/label/$labelId.tsx
@@ -46,7 +46,7 @@ function LabelDetailPage() {
 
   const savedGroups = label?.rule?.groups ?? []
   const displayGroups = editGroups ?? savedGroups
-  const totalConditions = savedGroups.reduce((sum, g) => sum + g.conditions.length, 0)
+  const totalConditions = displayGroups.reduce((sum, g) => sum + g.conditions.length, 0)
 
   function startEditing() {
     setEditGroups(savedGroups.map((g) => ({ conditions: [...g.conditions] })))
@@ -60,17 +60,18 @@ function LabelDetailPage() {
 
   function handleRemove(groupIndex: number, conditionIndex: number) {
     setEditGroups((prev) =>
-      prev!.map((g, gi) =>
-        gi === groupIndex ? { conditions: g.conditions.filter((_, ci) => ci !== conditionIndex) } : g
-      )
+      prev!
+        .map((g, gi) => (gi === groupIndex ? { conditions: g.conditions.filter((_, ci) => ci !== conditionIndex) } : g))
+        .filter((g) => g.conditions.length > 0)
     )
   }
 
   function handleSave() {
+    const groups = editGroups!.filter((g) => g.conditions.length > 0)
     updateRule.mutate(
       {
         labelId,
-        data: { rule: { groups: editGroups! } },
+        data: { rule: { groups } },
       },
       {
         onSuccess: () => {

--- a/src/routes/_authenticated/settings/label/index.tsx
+++ b/src/routes/_authenticated/settings/label/index.tsx
@@ -1,6 +1,22 @@
-import { useState, useRef, useEffect } from "react"
+import { useState, useRef, useEffect, useMemo } from "react"
 import { createFileRoute, Link, useLocation } from "@tanstack/react-router"
-import { ChevronRight, Plus } from "lucide-react"
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core"
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable"
+import { ChevronRight, GripVertical, Plus } from "lucide-react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -10,7 +26,7 @@ import { Input } from "@/components/ui/input"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { LabelFilterDialog } from "@/components/label-filter-dialog"
 import { getErrorMessage } from "@/lib/http-error"
-import { useCreateLabel } from "@/mutations/labels"
+import { useCreateLabel, useUpdateLabel } from "@/mutations/labels"
 import { useLabels } from "@/queries/labels"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import type { LabelListItem } from "@/types/label"
@@ -63,9 +79,29 @@ function ColorPicker({ selected, onSelect }: { selected: string; onSelect: (colo
   )
 }
 
-function LabelRow({ label }: { label: LabelListItem }) {
+function SortableLabelRow({ label }: { label: LabelListItem }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: label.id })
+
   return (
-    <TableRow>
+    <TableRow
+      ref={setNodeRef}
+      style={{
+        transform: transform ? `translateY(${transform.y}px)` : undefined,
+        transition,
+        opacity: isDragging ? 0.4 : undefined,
+      }}
+    >
+      <TableCell className="w-8 px-2">
+        <button
+          type="button"
+          className="flex cursor-grab touch-none items-center text-muted-foreground/30 hover:text-muted-foreground active:cursor-grabbing"
+          aria-label="드래그하여 순서 변경"
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="size-4" />
+        </button>
+      </TableCell>
       <TableCell className="text-center">
         <span className="inline-block size-4 rounded-sm" style={{ backgroundColor: label.colorCode }} />
       </TableCell>
@@ -139,15 +175,47 @@ function CreateLabelDialog() {
 }
 
 function SettingsLabelPage() {
-  const { data: labels = [], isPending, isError } = useLabels()
+  const { data: serverLabels = [], isPending, isError } = useLabels()
+  const updateLabel = useUpdateLabel()
   const location = useLocation()
   const createFilterRef = useRef<HTMLDivElement>(null)
+  const [labelOrder, setLabelOrder] = useState<string[]>([])
+
+  const orderedLabels = useMemo(() => {
+    const serverMap = new Map(serverLabels.map((l) => [l.id, l]))
+    const existing = labelOrder.filter((id) => serverMap.has(id)).map((id) => serverMap.get(id)!)
+    const newLabels = serverLabels.filter((l) => !labelOrder.includes(l.id))
+    return [...existing, ...newLabels]
+  }, [serverLabels, labelOrder])
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
 
   useEffect(() => {
     if (location.hash === "create-filter") {
       createFilterRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
     }
   }, [location.hash])
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const oldIndex = orderedLabels.findIndex((l) => l.id === String(active.id))
+    const newIndex = orderedLabels.findIndex((l) => l.id === String(over.id))
+    if (oldIndex === -1 || newIndex === -1) return
+
+    const newLabels = arrayMove(orderedLabels, oldIndex, newIndex)
+    setLabelOrder(newLabels.map((l) => l.id))
+
+    newLabels.forEach((label, i) => {
+      if (orderedLabels[i]?.id !== label.id) {
+        updateLabel.mutate({ labelId: label.id, data: { order: i } })
+      }
+    })
+  }
 
   return (
     <ScrollArea className="min-h-0 flex-1">
@@ -158,41 +226,46 @@ function SettingsLabelPage() {
             <CardDescription>라벨 규칙 등 전반적인 설정을 관리합니다.</CardDescription>
           </CardHeader>
           <CardContent className="px-0">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="w-10 text-center">색상</TableHead>
-                  <TableHead className="w-full">이름</TableHead>
-                  <TableHead className="w-16 pr-6 text-right">관리</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {isPending && (
+            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+              <Table>
+                <TableHeader>
                   <TableRow>
-                    <TableCell colSpan={3} className="text-center text-sm text-muted-foreground">
-                      라벨 목록을 불러오는 중입니다.
-                    </TableCell>
+                    <TableHead className="w-8" />
+                    <TableHead className="w-10 text-center">색상</TableHead>
+                    <TableHead className="w-full">이름</TableHead>
+                    <TableHead className="w-16 pr-6 text-right">관리</TableHead>
                   </TableRow>
-                )}
-                {isError && (
-                  <TableRow>
-                    <TableCell colSpan={3} className="text-center text-sm text-destructive">
-                      라벨 목록을 불러오지 못했습니다.
-                    </TableCell>
-                  </TableRow>
-                )}
-                {!isPending && !isError && labels.length === 0 && (
-                  <TableRow>
-                    <TableCell colSpan={3} className="text-center text-sm text-muted-foreground">
-                      등록된 라벨이 없습니다.
-                    </TableCell>
-                  </TableRow>
-                )}
-                {labels.map((label) => (
-                  <LabelRow key={label.id} label={label} />
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {isPending && (
+                    <TableRow>
+                      <TableCell colSpan={4} className="text-center text-sm text-muted-foreground">
+                        라벨 목록을 불러오는 중입니다.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  {isError && (
+                    <TableRow>
+                      <TableCell colSpan={4} className="text-center text-sm text-destructive">
+                        라벨 목록을 불러오지 못했습니다.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  {!isPending && !isError && orderedLabels.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={4} className="text-center text-sm text-muted-foreground">
+                        등록된 라벨이 없습니다.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  <SortableContext items={orderedLabels.map((l) => l.id)} strategy={verticalListSortingStrategy}>
+                    {orderedLabels.map((label) => (
+                      <SortableLabelRow key={label.id} label={label} />
+                    ))}
+                  </SortableContext>
+                </TableBody>
+              </Table>
+            </DndContext>
           </CardContent>
         </Card>
 

--- a/src/routes/_authenticated/settings/label/index.tsx
+++ b/src/routes/_authenticated/settings/label/index.tsx
@@ -1,21 +1,7 @@
-import { useState, useRef, useEffect, useMemo } from "react"
+import { useState, useRef, useEffect } from "react"
 import { createFileRoute, Link, useLocation } from "@tanstack/react-router"
-import {
-  DndContext,
-  KeyboardSensor,
-  PointerSensor,
-  closestCenter,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-} from "@dnd-kit/core"
-import {
-  SortableContext,
-  arrayMove,
-  sortableKeyboardCoordinates,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable"
+import { DndContext, closestCenter } from "@dnd-kit/core"
+import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable"
 import { ChevronRight, GripVertical, Plus } from "lucide-react"
 import { toast } from "sonner"
 
@@ -26,8 +12,9 @@ import { Input } from "@/components/ui/input"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { LabelFilterDialog } from "@/components/label-filter-dialog"
 import { getErrorMessage } from "@/lib/http-error"
-import { useCreateLabel, useUpdateLabel } from "@/mutations/labels"
+import { useCreateLabel } from "@/mutations/labels"
 import { useLabels } from "@/queries/labels"
+import { useLabelOrder } from "@/hooks/use-label-order"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import type { LabelListItem } from "@/types/label"
 
@@ -176,46 +163,19 @@ function CreateLabelDialog() {
 
 function SettingsLabelPage() {
   const { data: serverLabels = [], isPending, isError } = useLabels()
-  const updateLabel = useUpdateLabel()
+  const { orderedLabels, sensors, handleDragEnd } = useLabelOrder(serverLabels)
   const location = useLocation()
   const createFilterRef = useRef<HTMLDivElement>(null)
-  const [labelOrder, setLabelOrder] = useState<string[]>([])
-
-  const orderedLabels = useMemo(() => {
-    const serverMap = new Map(serverLabels.map((l) => [l.id, l]))
-    const existing = labelOrder.filter((id) => serverMap.has(id)).map((id) => serverMap.get(id)!)
-    const newLabels = serverLabels.filter((l) => !labelOrder.includes(l.id))
-    return [...existing, ...newLabels]
-  }, [serverLabels, labelOrder])
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
-  )
 
   useEffect(() => {
     if (location.hash === "create-filter") {
-      createFilterRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
+      const el = createFilterRef.current
+      if (!el) return
+      el.scrollIntoView({ behavior: "smooth", block: "start" })
+      el.classList.add("animate-shake")
+      el.addEventListener("animationend", () => el.classList.remove("animate-shake"), { once: true })
     }
   }, [location.hash])
-
-  function handleDragEnd(event: DragEndEvent) {
-    const { active, over } = event
-    if (!over || active.id === over.id) return
-
-    const oldIndex = orderedLabels.findIndex((l) => l.id === String(active.id))
-    const newIndex = orderedLabels.findIndex((l) => l.id === String(over.id))
-    if (oldIndex === -1 || newIndex === -1) return
-
-    const newLabels = arrayMove(orderedLabels, oldIndex, newIndex)
-    setLabelOrder(newLabels.map((l) => l.id))
-
-    newLabels.forEach((label, i) => {
-      if (orderedLabels[i]?.id !== label.id) {
-        updateLabel.mutate({ labelId: label.id, data: { order: i } })
-      }
-    })
-  }
 
   return (
     <ScrollArea className="min-h-0 flex-1">


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#17

### 📌 Task

- Closes #47 
- Closes #48 

## 💡 작업 내용

- 라벨 사이드바 구현
- 라벨 필터링 구현
- 라벨별 안읽은 메일 수 UI 구현
- Drag & Drop 을 이용한 라벨 순서 변경 구현
- email-list 및 thread-header에 라벨 표시

## 📝 추가 설명

### 라벨 목록 및 필터링

- `accountId` 필터와 동일하게 URL search param으로 관리
- 토글 형식으로 구현 -> 클릭으로 필터 on/off 가능

### 라벨 unread 표시 및 정렬

- Drag & Drop 정렬을 위해 `dnd-kit` 패키지 설치 
- 사이드바(`nav-label`) 및 라벨 설정(`/settings/label/index`) 페이지에 적용 (사이드바에만 구현할까 했는데, 모바일 환경의 경우 설정 페이지에서도 순서를 바꿀 수 있도록 설정 페이지에도 적용하였습니다.)

### 기타

-  `useMemo` 사용하여 라벨 색상을 변경했을 때, list에 있는 라벨 색상 즉시 동시화
- 라벨 설정 상세페이지에 조건 모두 보이게끔 UI 수정함 (전체적인 UI나 동작은 #60 에서 진행하면 될 것 같습니다)
- **라벨 설정 페이지에서 group과 conditions에 대해 UX를 어떻게 풀어나가야 할지 회의 필요**
- 라벨 규칙 생성 시, 응답으로 오는 key 이름에 맞춰 수정 (ex.  `FROM_ADDRESS`: 보낸사람 -> 보낸 주소)

## 🖼️ 스크린샷

- 라벨 사이드바 및 list에 표시

<img width="1918" height="863" alt="image" src="https://github.com/user-attachments/assets/c76b2233-63f8-4b4a-ad70-92a97534ba2f" />

- 라벨 필터링

<img width="1919" height="866" alt="image" src="https://github.com/user-attachments/assets/11d560ee-c01f-4ec0-9192-319568cb72ba" />

- 라벨 순서 변경

<img width="1918" height="865" alt="image" src="https://github.com/user-attachments/assets/905aba73-f6fb-4926-b9ec-8ea32a27c72c" />

- 라벨 수정 상세페이지

<img width="1568" height="772" alt="image" src="https://github.com/user-attachments/assets/bb4ff51b-ada0-4d1f-99df-0974ba15cc80" />
