### PR TITLE
[STORY-402] 인박스 스레드 목록 라벨 UI 구현

### DIFF
--- a/src/components/inbox/email-detail.tsx
+++ b/src/components/inbox/email-detail.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { useState } from "react"
 import { Archive, ArrowLeft, Forward, MailOpen, Reply, Trash2 } from "lucide-react"
 import { useNavigate } from "@tanstack/react-router"
 import { toast } from "sonner"
@@ -157,18 +157,6 @@ export function EmailDetail({ threadId, onClose }: EmailDetailProps) {
 
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
   const [expandedThreadId, setExpandedThreadId] = useState<string | null>(null)
-  const threadLabels = useMemo(() => {
-    if (!thread) return []
-    const seen = new Set<string>()
-    return thread.messages
-      .flatMap((m) => m.labels)
-      .filter((l) => {
-        if (seen.has(l.labelId)) return false
-        seen.add(l.labelId)
-        return true
-      })
-  }, [thread])
-
   if (thread && thread.threadId !== expandedThreadId) {
     const next = new Set<string>()
     const last = thread.messages.at(-1)
@@ -274,7 +262,7 @@ export function EmailDetail({ threadId, onClose }: EmailDetailProps) {
   return (
     <div className="flex h-full w-full min-w-0 flex-1 flex-col">
       <ThreadToolbar onClose={onClose} onDelete={handleDeleteThread} onReply={handleReply} isDeleting={isDeleting} />
-      <ThreadHeader thread={thread} account={account} labels={threadLabels} />
+      <ThreadHeader thread={thread} account={account} labels={thread.labels} />
       <ThreadMessageList
         messages={messages}
         expandedIds={expandedIds}

--- a/src/components/inbox/email-list-header.tsx
+++ b/src/components/inbox/email-list-header.tsx
@@ -13,7 +13,7 @@ const filterOptions: Array<{ value: EmailFilter; label: string }> = [
 interface EmailListHeaderProps {
   mailboxName: string
   currentCount: number
-  totalCount?: number
+  totalCount: number
   filter: EmailFilter
   onFilterChange: (filter: EmailFilter) => void
   isRefreshing?: boolean
@@ -59,7 +59,7 @@ export function EmailListHeader({
     <div className="flex h-11 shrink-0 items-center gap-3 border-b px-4">
       <h2 className="min-w-0 truncate text-sm font-medium">{mailboxName}</h2>
       <span className="hidden rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground sm:inline-flex">
-        {(totalCount ?? 0).toLocaleString()}개
+        {totalCount.toLocaleString()}개
       </span>
       <div className="ml-auto flex shrink-0 items-center gap-1">
         {onRefresh ? (

--- a/src/components/inbox/email-list.tsx
+++ b/src/components/inbox/email-list.tsx
@@ -15,7 +15,7 @@ import type { MailAccount } from "@/types/mail-account"
 interface EmailListProps {
   mailboxName: string
   threads: InboxThreadSummary[] | undefined
-  totalCount?: number
+  totalCount: number
   isLoading: boolean
   isFetchingNextPage: boolean
   hasNextPage: boolean

--- a/src/components/trash/trash-detail.tsx
+++ b/src/components/trash/trash-detail.tsx
@@ -204,7 +204,7 @@ export function TrashDetail({ threadId, onClose }: TrashDetailProps) {
   return (
     <div className="flex h-full w-full min-w-0 flex-1 flex-col">
       <TrashToolbar onClose={onClose} onRestore={handleRestoreThread} isRestoring={isRestoringThread} />
-      <ThreadHeader thread={thread} account={account} />
+      <ThreadHeader thread={thread} account={account} labels={thread.labels} />
       <ThreadMessageList
         messages={messages}
         expandedIds={expandedIds}

--- a/src/components/trash/trash-list.tsx
+++ b/src/components/trash/trash-list.tsx
@@ -33,7 +33,7 @@ function toInboxSummary(thread: TrashThreadSummary): InboxThreadSummary {
 interface TrashListProps {
   mailboxName: string
   threads: TrashThreadSummary[] | undefined
-  totalCount?: number
+  totalCount: number
   isLoading: boolean
   isFetchingNextPage: boolean
   hasNextPage: boolean
@@ -185,7 +185,7 @@ export function TrashList({
       <div className="flex h-11 shrink-0 items-center gap-3 border-b px-4">
         <h2 className="min-w-0 truncate text-sm font-medium">{mailboxName}</h2>
         <span className="hidden rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground sm:inline-flex">
-          {(totalCount ?? 0).toLocaleString()}개
+          {totalCount.toLocaleString()}개
         </span>
       </div>
     )

--- a/src/routes/_authenticated/mail/$mailbox.tsx
+++ b/src/routes/_authenticated/mail/$mailbox.tsx
@@ -126,7 +126,7 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
   })
 
   const loadedThreads = data?.pages.flatMap((page) => page.content) ?? []
-  const totalThreadCount = data?.pages[0]?.totalCount ?? loadedThreads.length
+  const totalThreadCount = data?.pages[0]?.totalCount ?? 0
   const searchTerms = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
   const selectedAccount = accountId ? (accounts?.find((account) => account.id === accountId) ?? null) : null
 
@@ -314,7 +314,7 @@ function TrashMailboxView() {
   } = useTrashThreads()
 
   const loadedThreads = data?.pages.flatMap((page) => page.content) ?? []
-  const totalThreadCount = data?.pages[0]?.totalCount ?? loadedThreads.length
+  const totalThreadCount = data?.pages[0]?.totalCount ?? 0
   const searchTerms = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
   const selectedAccount = accountId ? (accounts?.find((account) => account.id === accountId) ?? null) : null
 

--- a/src/types/email.ts
+++ b/src/types/email.ts
@@ -58,7 +58,6 @@ export interface InboxMessage {
   bodyText: string
   bodyHtml: string
   attachments: Attachment[]
-  labels: LabelSummary[]
 }
 
 export interface InboxThreadSummary {
@@ -82,6 +81,7 @@ export interface InboxThreadDetail {
   latestSubject: string
   isRead: boolean
   lastMessageAt: string
+  labels: LabelSummary[]
   messages: InboxMessage[]
 }
 
@@ -89,8 +89,8 @@ export interface MarkerSliceResponse<T> {
   content: T[]
   nextMarker: string | null
   hasNext: boolean
-  unreadCount?: number
-  totalCount?: number
+  unreadCount: number
+  totalCount: number
 }
 
 export interface ListThreadsParams {

--- a/src/types/trash.ts
+++ b/src/types/trash.ts
@@ -23,5 +23,6 @@ export interface TrashThreadDetail {
   latestSubject: string
   isRead: boolean
   lastMessageAt: string
+  labels: LabelSummary[]
   messages: InboxMessage[]
 }


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#17

### 📌 Task

- Closes #75 

## 💡 작업 내용

- 메시지 단위 라벨 제거, 스레드 단위 라벨 제공으로 변경된 백엔드 응답 형식에 대응하였습니다.

## 📝 추가 설명

- 백엔드 inbox/trash 스레드 응답 계약 변경에 맞춰 프론트 타입을 수정했습니다.
- `MarkerSliceResponse`의 `unreadCount`, `totalCount`를 required 필드로 변경했습니다.
- 메시지 단위 `labels`를 제거하고, 스레드 상세 응답의 `labels`를 사용하도록 변경했습니다.
- 메일 상세 및 휴지통 상세 화면에서 `thread.labels`를 헤더에 전달하도록 수정했습니다.
- 목록, 헤더 컴포넌트의 `totalCount` prop을 required로 좁히고 fallback 표시를 제거했습니다.