### PR TITLE
[STORY-501] AI 메일 초안 생성

### DIFF
--- a/src/api/emails.ts
+++ b/src/api/emails.ts
@@ -7,6 +7,9 @@ import type {
   InboxThreadDetail,
   InboxThreadSummary,
   ListThreadsParams,
+  MailDraftStreamEvent,
+  MailDraftStreamRequest,
+  MailDraftUsage,
   MarkerSliceResponse,
   SupportedMailboxId,
   UnreadCountResponse,
@@ -47,6 +50,123 @@ function appendFormDataValues(formData: FormData, key: string, values?: readonly
   }
 }
 
+export class MailDraftStreamError extends Error {
+  code?: string
+
+  constructor(message: string, code?: string) {
+    super(message)
+    this.name = "MailDraftStreamError"
+    this.code = code
+  }
+}
+
+interface SseFrame {
+  event: string
+  data: string
+}
+
+function parseSseFrame(frame: string): SseFrame | null {
+  let event = "message"
+  const dataLines: string[] = []
+
+  for (const rawLine of frame.split(/\r?\n/)) {
+    const line = rawLine.trimEnd()
+
+    if (!line || line.startsWith(":")) {
+      continue
+    }
+
+    const separatorIndex = line.indexOf(":")
+    const field = separatorIndex === -1 ? line : line.slice(0, separatorIndex)
+    const rawValue = separatorIndex === -1 ? "" : line.slice(separatorIndex + 1)
+    const value = rawValue.startsWith(" ") ? rawValue.slice(1) : rawValue
+
+    if (field === "event") {
+      event = value
+    }
+
+    if (field === "data") {
+      dataLines.push(value)
+    }
+  }
+
+  if (dataLines.length === 0 && event !== "done") {
+    return null
+  }
+
+  return {
+    event,
+    data: dataLines.join("\n"),
+  }
+}
+
+function parseMailDraftStreamEvent(frame: SseFrame): MailDraftStreamEvent | null {
+  if (frame.event === "done") {
+    return { type: "done" }
+  }
+
+  if (!["subject", "body", "usage", "error"].includes(frame.event)) {
+    return null
+  }
+
+  const data = JSON.parse(frame.data) as unknown
+
+  if (frame.event === "subject") {
+    const delta =
+      typeof data === "object" && data !== null && "delta" in data && typeof data.delta === "string" ? data.delta : ""
+
+    return { type: "subject", delta }
+  }
+
+  if (frame.event === "body") {
+    const delta =
+      typeof data === "object" && data !== null && "delta" in data && typeof data.delta === "string" ? data.delta : ""
+
+    return { type: "body", delta }
+  }
+
+  if (frame.event === "usage") {
+    const usage = data as MailDraftUsage
+
+    return { type: "usage", usage }
+  }
+
+  if (frame.event === "error") {
+    const code =
+      typeof data === "object" && data !== null && "code" in data && typeof data.code === "string"
+        ? data.code
+        : undefined
+    const message =
+      typeof data === "object" && data !== null && "message" in data && typeof data.message === "string"
+        ? data.message
+        : "메일 초안 생성에 실패했습니다."
+
+    return { type: "error", code, message }
+  }
+
+  return null
+}
+
+async function parseErrorResponseMessage(response: Response) {
+  const text = await response.text()
+
+  if (!text) {
+    return response.statusText || "메일 초안 생성 요청에 실패했습니다."
+  }
+
+  try {
+    const data = JSON.parse(text) as unknown
+
+    if (typeof data === "object" && data !== null && "message" in data && typeof data.message === "string") {
+      return data.message
+    }
+  } catch {
+    return text
+  }
+
+  return response.statusText || "메일 초안 생성 요청에 실패했습니다."
+}
+
 export async function getMailboxThreads(
   mailbox: SupportedMailboxId,
   params: ListThreadsParams = {}
@@ -79,6 +199,87 @@ export async function getUnreadCount(): Promise<UnreadCountResponse> {
 
 export function getAttachmentDownloadUrl(attachmentId: string) {
   return buildApiUrl(`/api/v1/mail/attachments/${attachmentId}`)
+}
+
+export async function streamMailDraft(
+  request: MailDraftStreamRequest,
+  options: {
+    signal?: AbortSignal
+    onEvent: (event: MailDraftStreamEvent) => void
+  }
+) {
+  const response = await fetch(buildApiUrl("/api/v1/mail/drafts/stream"), {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      Accept: "text/event-stream",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(request),
+    signal: options.signal,
+  })
+
+  if (!response.ok) {
+    throw new MailDraftStreamError(await parseErrorResponseMessage(response))
+  }
+
+  if (!response.body) {
+    throw new MailDraftStreamError("메일 초안 생성 응답을 읽을 수 없습니다.")
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ""
+  let shouldCancelReader = true
+
+  const emitFrameEvent = (frameText: string) => {
+    const frame = parseSseFrame(frameText)
+    if (!frame) return false
+
+    const event = parseMailDraftStreamEvent(frame)
+    if (!event) return false
+
+    options.onEvent(event)
+
+    if (event.type === "error") {
+      throw new MailDraftStreamError(event.message, event.code)
+    }
+
+    return event.type === "done"
+  }
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read()
+      buffer += decoder.decode(value, { stream: !done })
+
+      const frames = buffer.split(/\r?\n\r?\n/)
+      buffer = frames.pop() ?? ""
+
+      for (const frameText of frames) {
+        if (emitFrameEvent(frameText)) {
+          return
+        }
+      }
+
+      if (done) {
+        shouldCancelReader = false
+        break
+      }
+    }
+
+    if (emitFrameEvent(buffer)) {
+      return
+    }
+
+    throw new MailDraftStreamError("메일 초안 생성이 완료되기 전에 연결이 종료되었습니다.")
+  } finally {
+    if (shouldCancelReader) {
+      await reader.cancel().catch(() => undefined)
+    }
+
+    reader.releaseLock()
+  }
 }
 
 export async function sendMail(data: ComposeEmailData): Promise<void> {

--- a/src/components/compose/compose-ai-draft-panel.tsx
+++ b/src/components/compose/compose-ai-draft-panel.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useRef, useState } from "react"
+import { ArrowUp, Loader2, Sparkles, Square, WandSparkles, X } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { cn } from "@/lib/utils"
+import type { MailDraftStreamPhase, MailDraftUsage } from "@/types/email"
+
+interface ComposeAiDraftPanelProps {
+  prompt: string
+  onPromptChange: (value: string) => void
+  isDraftContentEmpty: boolean
+  isStreaming: boolean
+  phase: MailDraftStreamPhase
+  usage: MailDraftUsage | null
+  onGenerate: () => void
+  onStop: () => void
+}
+
+const MODEL_OPTIONS = ["Auto"] as const
+
+function getPhaseLabel(phase: MailDraftStreamPhase) {
+  if (phase === "subject") return "제목 생성 중..."
+  if (phase === "body") return "본문 생성 중..."
+  if (phase === "done") return "초안 생성 완료"
+  if (phase === "aborted") return "초안 생성을 중지했습니다"
+  if (phase === "error") return "초안 생성 실패"
+
+  return ""
+}
+
+function formatUsage(usage: MailDraftUsage | null) {
+  if (!usage) return null
+
+  return `${usage.totalTokens.toLocaleString()} tokens`
+}
+
+export function ComposeAiDraftPanel({
+  prompt,
+  onPromptChange,
+  isDraftContentEmpty,
+  isStreaming,
+  phase,
+  usage,
+  onGenerate,
+  onStop,
+}: ComposeAiDraftPanelProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [model, setModel] = useState<string>("Auto")
+  const inputRef = useRef<HTMLInputElement>(null)
+  const wasDraftContentEmptyRef = useRef(isDraftContentEmpty)
+  const wasStreamingRef = useRef(false)
+
+  useEffect(() => {
+    if (isOpen && !isStreaming) {
+      inputRef.current?.focus()
+    }
+  }, [isOpen, isStreaming])
+
+  useEffect(() => {
+    const didFinishStreaming = wasStreamingRef.current && !isStreaming && phase === "done"
+    const didStartWriting = wasDraftContentEmptyRef.current && !isDraftContentEmpty && !isStreaming
+
+    if (didFinishStreaming || didStartWriting) {
+      setIsOpen(false)
+    }
+
+    wasDraftContentEmptyRef.current = isDraftContentEmpty
+    wasStreamingRef.current = isStreaming
+  }, [isDraftContentEmpty, isStreaming, phase])
+
+  const promptText = prompt.trim()
+  const usageText = formatUsage(usage)
+  const isPanelVisible = isOpen || isStreaming
+  const isFloatingEntryVisible = isPanelVisible || isDraftContentEmpty
+  const phaseLabel = getPhaseLabel(phase)
+  const actionLabel = isStreaming
+    ? "AI 초안 생성 중지"
+    : !isPanelVisible
+      ? "AI 초안 생성 열기"
+      : promptText
+        ? "AI 초안 생성"
+        : "AI 초안 생성 닫기"
+
+  const handleActionClick = () => {
+    if (isStreaming) {
+      onStop()
+      return
+    }
+
+    if (!isPanelVisible) {
+      setIsOpen(true)
+      return
+    }
+
+    if (!promptText) {
+      setIsOpen(false)
+      return
+    }
+
+    onGenerate()
+  }
+
+  return (
+    <>
+      <div
+        className={cn(
+          "pointer-events-none absolute z-40 flex justify-end transition-all duration-150 ease-out",
+          isPanelVisible ? "right-3.5 bottom-4" : "right-3.5 bottom-4 sm:right-7 sm:bottom-8",
+          isFloatingEntryVisible ? "scale-100 opacity-100" : "scale-75 opacity-0"
+        )}
+        aria-hidden={!isFloatingEntryVisible}
+        inert={!isFloatingEntryVisible}
+      >
+        <div className="group pointer-events-auto relative">
+          {!isPanelVisible && (
+            <span
+              aria-hidden
+              className="absolute -inset-1.5 -z-10 rounded-full bg-[conic-gradient(from_0deg,var(--primary),var(--chart-1),var(--ring),var(--primary))] opacity-0 blur-md transition-opacity duration-300 group-hover:[animation:spin_3s_linear_infinite] group-hover:opacity-70"
+            />
+          )}
+          <Button
+            type="button"
+            size="icon-lg"
+            onClick={handleActionClick}
+            aria-label={actionLabel}
+            aria-expanded={isPanelVisible}
+            className={cn(
+              "rounded-full border-transparent shadow-lg shadow-primary/25 transition-all duration-150 ease-out group-active:scale-95 focus-visible:border-transparent focus-visible:ring-0",
+              isPanelVisible ? "size-9" : "size-12",
+              !isPanelVisible &&
+                !isStreaming &&
+                "bg-linear-to-br from-primary to-primary/80 group-hover:scale-110 group-hover:shadow-xl group-hover:shadow-primary/40",
+              isPanelVisible && !promptText && "bg-muted text-muted-foreground hover:bg-muted/80",
+              isPanelVisible && promptText && "bg-primary text-primary-foreground hover:bg-primary/90",
+              isStreaming && "bg-background text-foreground hover:bg-background"
+            )}
+          >
+            {isStreaming ? (
+              <Square className="size-4 fill-current" />
+            ) : isPanelVisible && !promptText ? (
+              <X className="size-4" />
+            ) : isPanelVisible ? (
+              <ArrowUp className="size-4" />
+            ) : (
+              <WandSparkles className="size-6 transition-transform duration-300 group-hover:rotate-360" />
+            )}
+          </Button>
+        </div>
+      </div>
+
+      <section
+        className={cn(
+          "pointer-events-auto absolute right-2 bottom-2 z-30 w-[calc(100%-1rem)] max-w-3xl origin-bottom-right transition-all duration-150 ease-out",
+          isPanelVisible
+            ? "translate-x-0 translate-y-0 scale-100 opacity-100"
+            : "pointer-events-none translate-x-3 translate-y-6 scale-75 opacity-0"
+        )}
+        aria-label="AI 초안 생성"
+        aria-hidden={!isPanelVisible}
+        inert={!isPanelVisible}
+      >
+        <div className="w-full overflow-hidden rounded-lg border bg-muted/60 shadow-xl ring-1 shadow-foreground/10 ring-foreground/5">
+          <div className="relative h-9 px-3">
+            <div
+              className={cn(
+                "absolute inset-y-0 left-3 flex items-center transition-all duration-300 ease-out",
+                isStreaming ? "pointer-events-none -translate-y-1 opacity-0" : "translate-y-0 opacity-100"
+              )}
+            >
+              <Select value={model} onValueChange={(value) => setModel(value ?? "Auto")} disabled={isStreaming}>
+                <SelectTrigger
+                  size="sm"
+                  className="-ml-2 h-8 gap-1.5 border-transparent bg-transparent text-muted-foreground hover:bg-foreground/5 hover:text-foreground focus-visible:ring-0 dark:bg-transparent"
+                  aria-label="AI 모델 선택"
+                >
+                  <Sparkles className="size-4 text-primary" />
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent align="start">
+                  {MODEL_OPTIONS.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      {option}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div
+              className={cn(
+                "absolute inset-y-0 left-3 flex items-center gap-2 transition-all duration-300 ease-out",
+                isStreaming ? "translate-y-0 opacity-100" : "pointer-events-none translate-y-1 opacity-0"
+              )}
+              aria-live="polite"
+            >
+              <Loader2 className="size-4 shrink-0 animate-spin text-primary" />
+              <span className="truncate text-sm font-medium text-foreground">{phaseLabel}</span>
+            </div>
+
+            {!isStreaming && usageText ? (
+              <span className="absolute inset-y-0 right-3 hidden items-center text-xs text-muted-foreground sm:flex">
+                {usageText}
+              </span>
+            ) : null}
+          </div>
+
+          <Input
+            ref={inputRef}
+            value={prompt}
+            onChange={(event) => onPromptChange(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.nativeEvent.isComposing && promptText) {
+                event.preventDefault()
+                onGenerate()
+              }
+            }}
+            placeholder="어떤 메일을 작성할까요?"
+            aria-label="AI 초안 생성 프롬프트"
+            disabled={isStreaming}
+            className="h-13 border-0 bg-popover px-4 text-base shadow-none focus-visible:ring-0"
+          />
+        </div>
+      </section>
+    </>
+  )
+}

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -13,18 +13,21 @@ import { useNavigate } from "@tanstack/react-router"
 import { toast } from "sonner"
 
 import { FileAttachmentChip } from "@/components/attachment-chip"
+import { ComposeAiDraftPanel } from "@/components/compose/compose-ai-draft-panel"
 import { ComposeEditorToolbar, type ComposeEditor } from "@/components/compose/compose-editor-toolbar"
 import { ComposeSendPreviewDialog, type ComposeSendPreviewData } from "@/components/compose/compose-send-preview-dialog"
 import { RecipientInput } from "@/components/compose/recipient-input"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { MailDraftStreamError, streamMailDraft } from "@/api/emails"
 import { getErrorMessage } from "@/lib/http-error"
 import { formatMailAddressesForSend, parseMailRecipients } from "@/lib/mail-address"
+import { cn } from "@/lib/utils"
 import { useSendMail } from "@/mutations/emails"
 import { useActiveMailAccounts } from "@/queries/mail-accounts"
 import { useUser } from "@/queries/user"
-import type { ComposeInlineImage, MailAddress } from "@/types/email"
+import type { ComposeInlineImage, MailAddress, MailDraftStreamPhase, MailDraftUsage } from "@/types/email"
 
 interface ComposeEmailProps {
   fromAddress: string | null
@@ -50,6 +53,7 @@ interface RecipientFieldProps {
   label: string
   recipients: MailAddress[]
   onRecipientsChange: (recipients: MailAddress[]) => void
+  disabled?: boolean
   children?: ReactNode
 }
 
@@ -201,6 +205,40 @@ function applyListIndentation(document: Document) {
   }
 }
 
+function textToEditorContent(text: string): JSONContent {
+  const lines = text.replace(/\r\n/g, "\n").split("\n")
+
+  return {
+    type: "doc",
+    content: lines.map((line) => ({
+      type: "paragraph",
+      content: line ? [{ type: "text", text: line }] : undefined,
+    })),
+  }
+}
+
+const CONTENTFUL_EDITOR_NODE_TYPES = new Set(["button", "horizontalRule", "image", "section", "table"])
+
+function hasVisibleEditorContent(node: JSONContent): boolean {
+  if (node.type === "globalContent" || node.type === "hardBreak") {
+    return false
+  }
+
+  if (typeof node.text === "string") {
+    return node.text.trim().length > 0
+  }
+
+  if (node.type && CONTENTFUL_EDITOR_NODE_TYPES.has(node.type)) {
+    return true
+  }
+
+  return (node.content ?? []).some(hasVisibleEditorContent)
+}
+
+function isEditorContentEmpty(content: JSONContent) {
+  return !hasVisibleEditorContent(content)
+}
+
 function buildMailContentWithImages(
   html: string,
   inlineImages: readonly PendingInlineImage[],
@@ -245,7 +283,14 @@ function buildMailContentWithImages(
   }
 }
 
-function RecipientField({ id, label, recipients, onRecipientsChange, children }: RecipientFieldProps) {
+function RecipientField({
+  id,
+  label,
+  recipients,
+  onRecipientsChange,
+  disabled = false,
+  children,
+}: RecipientFieldProps) {
   return (
     <div className="flex min-h-10 items-start border-b px-4 py-2">
       <label htmlFor={id} className="w-20 shrink-0 pt-1 text-sm text-muted-foreground">
@@ -257,6 +302,7 @@ function RecipientField({ id, label, recipients, onRecipientsChange, children }:
           recipients={recipients}
           onRecipientsChange={onRecipientsChange}
           placeholder="이름 또는 이메일 입력"
+          disabled={disabled}
         />
       </div>
       {children ? <div className="ml-2 flex shrink-0 items-center gap-1">{children}</div> : null}
@@ -277,6 +323,8 @@ export function ComposeEmail({
   const attachmentInputRef = useRef<HTMLInputElement>(null)
   const attachmentsRef = useRef<File[]>([])
   const inlineImagesRef = useRef<PendingInlineImage[]>([])
+  const draftAbortControllerRef = useRef<AbortController | null>(null)
+  const isMountedRef = useRef(true)
   const { data: user, isPending: isUserPending } = useUser()
   const { data: activeMailAccounts, isPending: isMailAccountsPending } = useActiveMailAccounts()
   const sendMailMutation = useSendMail()
@@ -285,6 +333,7 @@ export function ComposeEmail({
   const [cc, setCc] = useState<MailAddress[]>(() => parseMailRecipients(initialCc ?? ""))
   const [bcc, setBcc] = useState<MailAddress[]>([])
   const [subject, setSubject] = useState(initialSubject ?? "")
+  const [initialSubjectValue] = useState(() => initialSubject ?? "")
   const [isEditorReady, setIsEditorReady] = useState(false)
   const [isEditorEmpty, setIsEditorEmpty] = useState(true)
   const [isPreparingPreview, setIsPreparingPreview] = useState(false)
@@ -293,6 +342,10 @@ export function ComposeEmail({
   const [showBcc, setShowBcc] = useState(false)
   const [attachments, setAttachments] = useState<File[]>([])
   const [inlineImages, setInlineImages] = useState<PendingInlineImage[]>([])
+  const [draftPrompt, setDraftPrompt] = useState("")
+  const [isDraftStreaming, setIsDraftStreaming] = useState(false)
+  const [draftStreamPhase, setDraftStreamPhase] = useState<MailDraftStreamPhase>("idle")
+  const [draftUsage, setDraftUsage] = useState<MailDraftUsage | null>(null)
 
   const activeFromAddressSet = useMemo(
     () => new Set((activeMailAccounts ?? []).map((mailAccount) => mailAccount.emailAddress)),
@@ -315,8 +368,15 @@ export function ComposeEmail({
   const isFromAddressPending = isUserPending || isMailAccountsPending
   const isSendPreviewOpen = sendPreview !== null
   const cannotSend =
-    sendMailMutation.isPending || isPreparingPreview || isFromAddressPending || !selectedFromAddress || !isEditorReady
-
+    sendMailMutation.isPending ||
+    isPreparingPreview ||
+    isDraftStreaming ||
+    isFromAddressPending ||
+    !selectedFromAddress ||
+    !isEditorReady
+  const isDraftSubjectEmpty = !subject.trim() || (!!initialSubjectValue && subject === initialSubjectValue)
+  const isDraftContentEmpty = isDraftSubjectEmpty && isEditorEmpty
+  const draftPromptText = draftPrompt.trim()
   useEffect(() => {
     attachmentsRef.current = attachments
   }, [attachments])
@@ -332,6 +392,37 @@ export function ComposeEmail({
       }
     }
   }, [])
+
+  useEffect(() => {
+    isMountedRef.current = true
+
+    return () => {
+      isMountedRef.current = false
+      draftAbortControllerRef.current?.abort()
+    }
+  }, [])
+
+  const replaceEditorBodyText = (text: string) => {
+    const currentEditor = editorRef.current?.editor
+
+    if (!currentEditor) {
+      return
+    }
+
+    currentEditor.commands.setContent(textToEditorContent(text))
+    setIsEditorEmpty(isEditorContentEmpty(currentEditor.getJSON()))
+  }
+
+  const getCurrentEditorContent = () => editorRef.current?.getJSON() ?? null
+  const isCurrentEditorContentEmpty = () => {
+    const content = getCurrentEditorContent()
+
+    return !content || isEditorContentEmpty(content)
+  }
+
+  const isCurrentDraftContentEmpty = () => {
+    return isDraftSubjectEmpty && isCurrentEditorContentEmpty()
+  }
 
   const showUploadLimitError = () => {
     toast.error("첨부 용량은 본문 이미지를 포함해 20MB 이하만 가능합니다")
@@ -423,6 +514,116 @@ export function ComposeEmail({
     setInlineImages(nextInlineImages)
   }
 
+  const handleGenerateDraft = async () => {
+    if (draftAbortControllerRef.current) {
+      return
+    }
+
+    if (!selectedFromAddress) {
+      toast.error("발신 계정을 선택해주세요")
+      return
+    }
+
+    if (!editorRef.current?.editor || !isEditorReady) {
+      toast.error("메일 에디터를 불러오는 중입니다")
+      return
+    }
+
+    if (!draftPromptText) {
+      toast.error("AI 초안 요청을 입력해주세요")
+      return
+    }
+
+    if (!isCurrentDraftContentEmpty()) {
+      toast.error("작성 중인 내용을 비운 뒤 다시 시도해주세요")
+      return
+    }
+
+    const abortController = new AbortController()
+    let draftSubject = ""
+    let draftBody = ""
+
+    draftAbortControllerRef.current = abortController
+    setSubject("")
+    replaceEditorBodyText("")
+    setDraftUsage(null)
+    setDraftStreamPhase("subject")
+    setIsDraftStreaming(true)
+
+    try {
+      await streamMailDraft(
+        {
+          mailAddress: selectedFromAddress,
+          query: draftPromptText,
+          replyMessageId: messageId ?? null,
+          to: formatMailAddressesForSend(to),
+          cc: formatMailAddressesForSend(cc),
+        },
+        {
+          signal: abortController.signal,
+          onEvent: (event) => {
+            if (!isMountedRef.current || draftAbortControllerRef.current !== abortController) {
+              return
+            }
+
+            if (event.type === "subject") {
+              draftSubject += event.delta
+              setSubject(draftSubject)
+              setDraftStreamPhase("subject")
+              return
+            }
+
+            if (event.type === "body") {
+              draftBody += event.delta
+              replaceEditorBodyText(draftBody)
+              setDraftStreamPhase("body")
+              return
+            }
+
+            if (event.type === "usage") {
+              setDraftUsage(event.usage)
+              return
+            }
+          },
+        }
+      )
+
+      if (isMountedRef.current && draftAbortControllerRef.current === abortController) {
+        setDraftStreamPhase("done")
+      }
+    } catch (error) {
+      if (abortController.signal.aborted) {
+        if (isMountedRef.current && draftAbortControllerRef.current === abortController) {
+          setDraftStreamPhase("aborted")
+        }
+
+        return
+      }
+
+      if (!isMountedRef.current || draftAbortControllerRef.current !== abortController) {
+        return
+      }
+
+      setDraftStreamPhase("error")
+      toast.error("메일 초안 생성에 실패했습니다", {
+        description:
+          error instanceof MailDraftStreamError ? error.message : getErrorMessage(error, "잠시 후 다시 시도해주세요."),
+      })
+    } finally {
+      if (draftAbortControllerRef.current === abortController) {
+        draftAbortControllerRef.current = null
+
+        if (isMountedRef.current) {
+          setIsDraftStreaming(false)
+        }
+      }
+    }
+  }
+
+  const handleStopDraft = () => {
+    draftAbortControllerRef.current?.abort()
+  }
+
   const createSendPreview = async () => {
     if (isFromAddressPending) {
       toast.error("발신 계정을 불러오는 중입니다")
@@ -449,13 +650,15 @@ export function ComposeEmail({
       return null
     }
 
-    if (isEditorEmpty || editorRef.current.editor?.isEmpty) {
+    const editorContent = editorRef.current.getJSON()
+
+    if (isEditorEmpty || isEditorContentEmpty(editorContent)) {
       toast.error("메일 내용을 입력해주세요")
       return null
     }
 
     const emailContent = await editorRef.current.getEmail()
-    const imageMetadata = collectImageMetadata(editorRef.current.getJSON())
+    const imageMetadata = collectImageMetadata(editorContent)
 
     if (!emailContent.text.trim() && !emailContent.html.trim()) {
       toast.error("메일 내용을 입력해주세요")
@@ -520,34 +723,67 @@ export function ComposeEmail({
   }
 
   const handleClose = () => {
+    if (isDraftStreaming) {
+      return
+    }
+
     navigate({ to: "/mail/$mailbox", params: { mailbox: "inbox" } })
   }
 
   return (
-    <div className="flex h-full w-full min-w-0 flex-1 flex-col">
+    <div className="relative flex h-full w-full min-w-0 flex-1 flex-col">
       <div className="flex h-11 shrink-0 items-center justify-between border-b px-4">
         <h1 className="text-sm font-medium">{messageId ? "답장" : "새 메일 작성"}</h1>
-        <Button variant="ghost" size="icon-sm" onClick={handleClose} className="-mr-2" aria-label="메일 작성 닫기">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={handleClose}
+          className="-mr-2"
+          aria-label="메일 작성 닫기"
+          disabled={isDraftStreaming}
+        >
           <X className="size-4" />
         </Button>
       </div>
 
-      <RecipientField id="compose-to" label="받는 사람" recipients={to} onRecipientsChange={setTo}>
+      <RecipientField
+        id="compose-to"
+        label="받는 사람"
+        recipients={to}
+        onRecipientsChange={setTo}
+        disabled={isDraftStreaming}
+      >
         {!showCc && (
-          <Button variant="ghost" size="xs" onClick={() => setShowCc(true)}>
+          <Button variant="ghost" size="xs" onClick={() => setShowCc(true)} disabled={isDraftStreaming}>
             참조
           </Button>
         )}
         {!showBcc && (
-          <Button variant="ghost" size="xs" onClick={() => setShowBcc(true)}>
+          <Button variant="ghost" size="xs" onClick={() => setShowBcc(true)} disabled={isDraftStreaming}>
             숨은참조
           </Button>
         )}
       </RecipientField>
 
-      {showCc && <RecipientField id="compose-cc" label="참조" recipients={cc} onRecipientsChange={setCc} />}
+      {showCc && (
+        <RecipientField
+          id="compose-cc"
+          label="참조"
+          recipients={cc}
+          onRecipientsChange={setCc}
+          disabled={isDraftStreaming}
+        />
+      )}
 
-      {showBcc && <RecipientField id="compose-bcc" label="숨은 참조" recipients={bcc} onRecipientsChange={setBcc} />}
+      {showBcc && (
+        <RecipientField
+          id="compose-bcc"
+          label="숨은 참조"
+          recipients={bcc}
+          onRecipientsChange={setBcc}
+          disabled={isDraftStreaming}
+        />
+      )}
 
       <div className="flex h-10 items-center border-b px-4 py-2">
         <label htmlFor="compose-subject" className="w-20 shrink-0 text-sm text-muted-foreground">
@@ -559,7 +795,8 @@ export function ComposeEmail({
           value={subject}
           onChange={(e) => setSubject(e.target.value)}
           placeholder="메일 제목 입력"
-          className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          disabled={isDraftStreaming}
+          className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-60"
         />
       </div>
 
@@ -571,7 +808,7 @@ export function ComposeEmail({
           value={selectedFromAddress}
           onValueChange={onFromAddressChange}
           items={fromAddressItems}
-          disabled={isFromAddressPending || fromAddressItems.length === 0}
+          disabled={isDraftStreaming || isFromAddressPending || fromAddressItems.length === 0}
         >
           <SelectTrigger
             aria-labelledby="compose-from-label"
@@ -592,29 +829,49 @@ export function ComposeEmail({
         </Select>
       </div>
 
-      <ComposeEditorToolbar editor={editor} disabled={!isEditorReady} />
+      <ComposeEditorToolbar editor={editor} disabled={!isEditorReady || isDraftStreaming} />
 
-      <div className="flex-1 overflow-hidden" aria-label="메일 본문">
+      <div
+        className={cn("relative flex-1 overflow-hidden", isDraftStreaming && "compose-email-editor-ai-streaming")}
+        aria-label="메일 본문"
+      >
         <EmailEditor
           ref={editorRef}
           theme={EDITOR_THEME}
           placeholder="메일 내용을 입력하세요. / 로 블록을 추가할 수 있습니다."
           bubbleMenu={{ hideWhenActiveNodes: ["button", "image"] }}
           className="compose-email-editor h-full overflow-auto text-sm outline-none"
+          editable={!isDraftStreaming}
           onUploadImage={uploadInlineImage}
           onReady={(ref) => {
             applyEditorTheme(ref.editor)
             setIsEditorReady(true)
-            setIsEditorEmpty(ref.editor?.isEmpty ?? true)
+            setIsEditorEmpty(isEditorContentEmpty(ref.getJSON()))
             setEditor(ref.editor)
           }}
           onUpdate={(ref) => {
             const content = ref.getJSON()
 
             applyEditorTheme(ref.editor, content)
-            setIsEditorEmpty(ref.editor?.isEmpty ?? true)
+            setIsEditorEmpty(isEditorContentEmpty(content))
             pruneUnusedInlineImages(content)
           }}
+        />
+        {isDraftStreaming && (
+          <>
+            <div className="compose-email-editor-ai-sweep" aria-hidden />
+          </>
+        )}
+
+        <ComposeAiDraftPanel
+          prompt={draftPrompt}
+          onPromptChange={setDraftPrompt}
+          isDraftContentEmpty={isDraftContentEmpty}
+          isStreaming={isDraftStreaming}
+          phase={draftStreamPhase}
+          usage={draftUsage}
+          onGenerate={() => void handleGenerateDraft()}
+          onStop={handleStopDraft}
         />
       </div>
 
@@ -634,7 +891,7 @@ export function ComposeEmail({
                 <FileAttachmentChip
                   key={`${file.name}-${file.lastModified}-${index}`}
                   file={file}
-                  onRemove={() => removeAttachment(index)}
+                  onRemove={isDraftStreaming ? undefined : () => removeAttachment(index)}
                 />
               ))}
             </div>
@@ -647,7 +904,7 @@ export function ComposeEmail({
             variant="outline"
             size="lg"
             onClick={() => attachmentInputRef.current?.click()}
-            disabled={sendMailMutation.isPending || isPreparingPreview}
+            disabled={isDraftStreaming || sendMailMutation.isPending || isPreparingPreview}
             aria-label="첨부파일 추가"
           >
             <Paperclip className="size-4" />

--- a/src/components/compose/recipient-input.tsx
+++ b/src/components/compose/recipient-input.tsx
@@ -31,6 +31,7 @@ interface RecipientInputProps {
   recipients: MailAddress[]
   onRecipientsChange: (recipients: MailAddress[]) => void
   placeholder?: string
+  disabled?: boolean
 }
 
 interface RecipientOption extends MailAddress {
@@ -60,6 +61,7 @@ export function RecipientInput({
   recipients,
   onRecipientsChange,
   placeholder = "이름 또는 이메일 입력",
+  disabled = false,
 }: RecipientInputProps) {
   const anchorRef = useComboboxAnchor()
   const [draft, setDraft] = useState("")
@@ -68,7 +70,7 @@ export function RecipientInput({
   const keyword = draft.trim()
   const debouncedKeyword = useDebounce(keyword)
   const isDebouncing = keyword !== debouncedKeyword
-  const contactsQuery = useContacts({ keyword: debouncedKeyword }, isFocused || isOpen)
+  const contactsQuery = useContacts({ keyword: debouncedKeyword }, !disabled && (isFocused || isOpen))
   const selectedEmails = useMemo(
     () => new Set(recipients.map((recipient) => recipient.email.toLowerCase())),
     [recipients]
@@ -105,10 +107,18 @@ export function RecipientInput({
           : "empty"
 
   const updateRecipients = (nextRecipients: readonly MailAddress[]) => {
+    if (disabled) {
+      return
+    }
+
     onRecipientsChange(getUniqueMailAddresses(nextRecipients))
   }
 
   const commitDraft = () => {
+    if (disabled) {
+      return false
+    }
+
     const nextRecipients = parseMailRecipients(draft)
 
     if (nextRecipients.length === 0) {
@@ -121,6 +131,10 @@ export function RecipientInput({
   }
 
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (disabled) {
+      return
+    }
+
     if (event.key === "Tab" || event.key === "," || event.key === ";") {
       if (!draft.trim()) {
         return
@@ -133,6 +147,10 @@ export function RecipientInput({
   }
 
   const handlePaste = (event: ClipboardEvent<HTMLInputElement>) => {
+    if (disabled) {
+      return
+    }
+
     const pastedText = event.clipboardData.getData("text")
 
     if (!hasRecipientSeparator(pastedText)) {
@@ -151,16 +169,25 @@ export function RecipientInput({
       filteredItems={recipientOptions}
       multiple
       value={recipients}
+      open={disabled ? false : isOpen}
       inputValue={draft}
       autoHighlight="always"
       itemToStringLabel={getMailAddressSearchText}
       itemToStringValue={(recipient) => recipient.email}
       isItemEqualToValue={(item, value) => item.email.toLowerCase() === value.email.toLowerCase()}
-      onInputValueChange={(value) => setDraft(value)}
-      onOpenChange={setIsOpen}
+      onInputValueChange={(value) => {
+        if (!disabled) {
+          setDraft(value)
+        }
+      }}
+      onOpenChange={(open) => {
+        setIsOpen(disabled ? false : open)
+      }}
       onValueChange={(value) => {
         updateRecipients(value)
-        setDraft("")
+        if (!disabled) {
+          setDraft("")
+        }
       }}
     >
       <ComboboxChips
@@ -170,7 +197,7 @@ export function RecipientInput({
         <ComboboxValue>
           {recipients.map((recipient) => (
             <Tooltip key={recipient.email}>
-              <TooltipTrigger render={<ComboboxChip className="max-w-full font-normal" />}>
+              <TooltipTrigger render={<ComboboxChip className="max-w-full font-normal" showRemove={!disabled} />}>
                 <span className="truncate">{getMailAddressDisplayName(recipient)}</span>
               </TooltipTrigger>
               <TooltipContent>{recipient.email}</TooltipContent>
@@ -180,7 +207,8 @@ export function RecipientInput({
         <ComboboxChipsInput
           id={id}
           placeholder={recipients.length === 0 ? placeholder : undefined}
-          className="h-6 min-w-36 bg-transparent text-sm placeholder:text-muted-foreground"
+          disabled={disabled}
+          className="h-6 min-w-36 bg-transparent text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-60"
           onFocus={() => setIsFocused(true)}
           onBlur={() => {
             commitDraft()

--- a/src/index.css
+++ b/src/index.css
@@ -24,6 +24,58 @@
   animation: shake 0.45s ease-in-out;
 }
 
+@keyframes ai-editor-sweep {
+  0% {
+    opacity: 0.14;
+    transform: translateX(-110%);
+  }
+
+  45% {
+    opacity: 0.62;
+  }
+
+  100% {
+    opacity: 0.14;
+    transform: translateX(110%);
+  }
+}
+
+@keyframes ai-editor-glow {
+  0%,
+  100% {
+    box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--primary) 26%, transparent);
+  }
+
+  50% {
+    box-shadow:
+      inset 0 0 0 1px color-mix(in oklch, var(--primary) 58%, transparent),
+      0 0 38px color-mix(in oklch, var(--primary) 34%, transparent);
+  }
+}
+
+.compose-email-editor-ai-streaming {
+  animation: ai-editor-glow 1.6s ease-in-out infinite;
+}
+
+.compose-email-editor-ai-sweep {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, color-mix(in oklch, var(--primary) 30%, transparent), transparent);
+  pointer-events: none;
+  animation: ai-editor-sweep 1.7s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .compose-email-editor-ai-streaming,
+  .compose-email-editor-ai-sweep {
+    animation: none;
+  }
+
+  .compose-email-editor-ai-sweep {
+    display: none;
+  }
+}
+
 .compose-email-editor {
   --re-bg: var(--popover);
   --re-bg-active: var(--accent);

--- a/src/types/email.ts
+++ b/src/types/email.ts
@@ -121,3 +121,27 @@ export interface ComposeEmailData {
   attachments?: File[]
   inlineImages?: ComposeInlineImage[]
 }
+
+export interface MailDraftStreamRequest {
+  mailAddress: string
+  query: string
+  replyMessageId: string | null
+  to: string[]
+  cc: string[]
+}
+
+export interface MailDraftUsage {
+  model: string
+  inputTokens: number
+  outputTokens: number
+  totalTokens: number
+}
+
+export type MailDraftStreamPhase = "idle" | "subject" | "body" | "done" | "error" | "aborted"
+
+export type MailDraftStreamEvent =
+  | { type: "subject"; delta: string }
+  | { type: "body"; delta: string }
+  | { type: "usage"; usage: MailDraftUsage }
+  | { type: "done" }
+  | { type: "error"; code?: string; message: string }


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#24

### 📌 Task

- Closes #73 
- Closes #74 

## 💡 작업 내용

- 메일 작성 화면 프롬프트 UI 구현
- SSE 기반 LLM API 연동 구현
- 프롬프트 기반 메일 초안 생성 UX 구현

## 📝 추가 설명

- 메일 작성 화면에 AI 초안 생성용 플로팅 패널을 추가했습니다.
- 사용자 프롬프트를 입력해 메일 제목과 본문 초안을 스트리밍으로 생성할 수 있도록 연동했습니다.
- `/api/v1/mail/drafts/stream` SSE 응답을 `subject`, `body`, `usage`, `error`, `done` 이벤트로 파싱하는 API 클라이언트를 추가했습니다.
- 스트리밍 중에는 발신 계정, 수신자, 제목, 에디터, 첨부, 전송 동작을 잠가 중복 입력과 충돌을 방지했습니다.
- 생성된 본문 텍스트를 에디터 문서 구조로 변환하고, 실제 표시 내용 기준으로 빈 본문 여부를 판정하도록 보강했습니다.
- 수신자 입력 컴포넌트에 `disabled` 상태를 추가해 AI 초안 생성 중 검색, 수정, 삭제를 막도록 했습니다.
- 초안 생성 진행 상태, 중지, 완료, 실패, 토큰 사용량 표시와 에디터 스트리밍 시각 효과를 추가했습니다.

## 🖼️ 스크린샷

https://github.com/user-attachments/assets/4539296e-8bca-4881-8bd9-447cae58f18f
