### PR TITLE
[STROY-408] 라벨 그룹 구현

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -6,6 +6,7 @@ import { buttonVariants } from "@/components/ui/button"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { NavAccounts } from "@/components/nav/nav-accounts"
 import { NavFolders } from "@/components/nav/nav-folders"
+import { NavLabelGroups } from "@/components/nav/nav-label-groups"
 import { NavLabels } from "@/components/nav/nav-labels"
 import { NavUser } from "@/components/nav/nav-user"
 import {
@@ -25,18 +26,22 @@ interface AppSidebarProps {
   mailbox: PrimaryMailboxId | null
   activeAccountId?: string
   activeLabelId?: string
+  activeLabelGroupId?: string
   onMailboxChange: (mailbox: PrimaryMailboxId) => void
   onAccountToggle: (accountId: string) => void
   onLabelToggle: (labelId: string) => void
+  onLabelGroupToggle: (groupId: string) => void
 }
 
 export function AppSidebar({
   mailbox,
   activeAccountId,
   activeLabelId,
+  activeLabelGroupId,
   onMailboxChange,
   onAccountToggle,
   onLabelToggle,
+  onLabelGroupToggle,
   ...props
 }: AppSidebarProps & React.ComponentProps<typeof Sidebar>) {
   const { data: user } = useUser()
@@ -95,7 +100,12 @@ export function AppSidebar({
         </div>
 
         <NavFolders mailbox={mailbox} onMailboxChange={onMailboxChange} />
-        <NavLabels activeLabelId={activeLabelId} onLabelToggle={onLabelToggle} className="mt-4" />
+        <NavLabelGroups
+          activeLabelGroupId={activeLabelGroupId}
+          onLabelGroupToggle={onLabelGroupToggle}
+          className="mt-2"
+        />
+        <NavLabels activeLabelId={activeLabelId} onLabelToggle={onLabelToggle} className="mt-2" />
         <NavAccounts activeAccountId={activeAccountId} onAccountToggle={onAccountToggle} className="mt-auto" />
       </SidebarContent>
 

--- a/src/components/nav/nav-label-groups.tsx
+++ b/src/components/nav/nav-label-groups.tsx
@@ -1,0 +1,391 @@
+import { useState } from "react"
+import { MoreVertical, Plus } from "lucide-react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Input } from "@/components/ui/input"
+import {
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar"
+import { getErrorMessage, getHttpStatus } from "@/lib/http-error"
+import { useCreateLabelGroup, useDeleteLabelGroup, useUpdateLabelGroup } from "@/mutations/labels"
+import { useLabelGroups, useLabels } from "@/queries/labels"
+import type { LabelGroupItem, LabelListItem } from "@/types/label"
+
+function LabelPickerList({
+  labels,
+  selectedIds,
+  onToggle,
+}: {
+  labels: LabelListItem[]
+  selectedIds: string[]
+  onToggle: (id: string) => void
+}) {
+  if (labels.length === 0) {
+    return <div className="rounded-md border px-3 py-4 text-center text-xs text-muted-foreground">라벨이 없습니다</div>
+  }
+  return (
+    <div className="max-h-48 space-y-0.5 overflow-y-auto rounded-md border p-1">
+      {labels.map((label) => (
+        <label key={label.id} className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 hover:bg-muted">
+          <Checkbox checked={selectedIds.includes(label.id)} onCheckedChange={() => onToggle(label.id)} />
+          <span className="size-3 shrink-0 rounded-sm" style={{ backgroundColor: label.colorCode }} />
+          <span className="truncate text-sm">{label.name}</span>
+        </label>
+      ))}
+    </div>
+  )
+}
+
+function LabelGroupFormDialog({
+  open,
+  onOpenChange,
+  title,
+  submitLabel,
+  name,
+  onNameChange,
+  selectedLabelIds,
+  onToggle,
+  labels,
+  onSubmit,
+  isPending,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  submitLabel: string
+  name: string
+  onNameChange: (name: string) => void
+  selectedLabelIds: string[]
+  onToggle: (id: string) => void
+  labels: LabelListItem[]
+  onSubmit: () => void
+  isPending: boolean
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-4 py-2">
+          <Input
+            placeholder="그룹 이름"
+            value={name}
+            onChange={(e) => onNameChange(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && onSubmit()}
+            autoFocus
+          />
+          <div>
+            <p className="mb-2 text-xs text-muted-foreground">라벨 선택</p>
+            <LabelPickerList labels={labels} selectedIds={selectedLabelIds} onToggle={onToggle} />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            취소
+          </Button>
+          <Button onClick={onSubmit} disabled={!name.trim() || isPending}>
+            {submitLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CreateGroupDialog({
+  open,
+  onOpenChange,
+  labels,
+  groups,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  labels: LabelListItem[]
+  groups: LabelGroupItem[]
+}) {
+  const [name, setName] = useState("")
+  const [selectedLabelIds, setSelectedLabelIds] = useState<string[]>([])
+  const createLabelGroup = useCreateLabelGroup()
+
+  function handleCreate() {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    const maxOrder = groups.length > 0 ? Math.max(...groups.map((g) => g.order)) : 0
+    createLabelGroup.mutate(
+      { name: trimmed, labelIds: selectedLabelIds, order: maxOrder + 1 },
+      {
+        onSuccess: () => {
+          onOpenChange(false)
+          setName("")
+          setSelectedLabelIds([])
+          toast.success(`${trimmed} 그룹이 생성되었습니다`)
+        },
+        onError: (e) => {
+          if (getHttpStatus(e) === 409) {
+            toast.error("이미 존재하는 라벨 그룹입니다.")
+          } else {
+            toast.error(getErrorMessage(e, "라벨 그룹 생성에 실패했습니다."))
+          }
+        },
+      }
+    )
+  }
+
+  function toggleLabel(id: string) {
+    setSelectedLabelIds((prev) => (prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]))
+  }
+
+  return (
+    <LabelGroupFormDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="새 라벨 그룹 만들기"
+      submitLabel="만들기"
+      name={name}
+      onNameChange={setName}
+      selectedLabelIds={selectedLabelIds}
+      onToggle={toggleLabel}
+      labels={labels}
+      onSubmit={handleCreate}
+      isPending={createLabelGroup.isPending}
+    />
+  )
+}
+
+function EditGroupDialog({
+  open,
+  onOpenChange,
+  group,
+  allLabels,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  group: LabelGroupItem
+  allLabels: LabelListItem[]
+}) {
+  const [name, setName] = useState(group.name)
+  const [selectedLabelIds, setSelectedLabelIds] = useState<string[]>(group.labelIds)
+  const updateLabelGroup = useUpdateLabelGroup()
+
+  function handleUpdate() {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    updateLabelGroup.mutate(
+      { labelGroupId: group.id, data: { name: trimmed, labelIds: selectedLabelIds } },
+      {
+        onSuccess: () => {
+          onOpenChange(false)
+          toast.success(`${trimmed} 그룹이 수정되었습니다`)
+        },
+        onError: (e) => {
+          if (getHttpStatus(e) === 409) {
+            toast.error("이미 존재하는 라벨 그룹입니다.")
+          } else {
+            toast.error(getErrorMessage(e, "라벨 그룹 수정에 실패했습니다."))
+          }
+        },
+      }
+    )
+  }
+
+  function toggleLabel(id: string) {
+    setSelectedLabelIds((prev) => (prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]))
+  }
+
+  return (
+    <LabelGroupFormDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="라벨 그룹 수정"
+      submitLabel="수정"
+      name={name}
+      onNameChange={setName}
+      selectedLabelIds={selectedLabelIds}
+      onToggle={toggleLabel}
+      labels={allLabels}
+      onSubmit={handleUpdate}
+      isPending={updateLabelGroup.isPending}
+    />
+  )
+}
+
+function GroupDeleteDialog({
+  open,
+  onOpenChange,
+  group,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  group: LabelGroupItem
+}) {
+  const deleteLabelGroup = useDeleteLabelGroup()
+
+  function handleDelete() {
+    deleteLabelGroup.mutate(group.id, {
+      onSuccess: () => {
+        onOpenChange(false)
+        toast.success(`${group.name} 그룹이 삭제되었습니다`)
+      },
+      onError: (e) => toast.error(getErrorMessage(e, "라벨 그룹 삭제에 실패했습니다.")),
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>삭제</DialogTitle>
+        </DialogHeader>
+        <p className="text-base text-muted-foreground">
+          {group.name} 그룹을 삭제하시겠습니까? 라벨 자체는 삭제되지 않습니다.
+        </p>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            취소
+          </Button>
+          <Button variant="destructive" onClick={handleDelete} disabled={deleteLabelGroup.isPending}>
+            삭제
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function GroupItem({
+  group,
+  allLabels,
+  isActive,
+  onGroupToggle,
+}: {
+  group: LabelGroupItem
+  allLabels: LabelListItem[]
+  isActive: boolean
+  onGroupToggle: (groupId: string) => void
+}) {
+  const [isHovered, setIsHovered] = useState(false)
+  const [dropdownOpen, setDropdownOpen] = useState(false)
+  const [editOpen, setEditOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+
+  const groupLabels = allLabels.filter((l) => group.labelIds.includes(l.id))
+
+  return (
+    <SidebarMenuItem onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+      <SidebarMenuButton
+        type="button"
+        tooltip={group.name}
+        isActive={isActive}
+        size="sm"
+        className="group-hover/menu-item:bg-sidebar-accent group-hover/menu-item:text-sidebar-accent-foreground"
+        onClick={() => onGroupToggle(group.id)}
+      >
+        <div className="flex shrink-0 items-center">
+          {groupLabels.slice(0, 3).map((label, i) => (
+            <span
+              key={label.id}
+              className="size-2.5 rounded-full"
+              style={{ backgroundColor: label.colorCode, marginLeft: i === 0 ? 0 : -4 }}
+            />
+          ))}
+          {groupLabels.length === 0 && <span className="size-2.5 rounded-full bg-muted-foreground/30" />}
+        </div>
+        <span className="truncate">{group.name}</span>
+      </SidebarMenuButton>
+
+      <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
+        <DropdownMenuTrigger
+          render={<SidebarMenuAction aria-label="그룹 메뉴" className="size-5 hover:bg-sidebar-accent-foreground/15" />}
+        >
+          {(isHovered || dropdownOpen) && <MoreVertical />}
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="right" align="start" className="min-w-44 ring-foreground/6">
+          <DropdownMenuItem
+            onClick={() => {
+              setEditOpen(true)
+              setDropdownOpen(false)
+            }}
+          >
+            라벨 그룹 수정
+          </DropdownMenuItem>
+          <DropdownMenuSeparator className="my-0.5" />
+          <DropdownMenuItem
+            variant="destructive"
+            onClick={() => {
+              setDeleteOpen(true)
+              setDropdownOpen(false)
+            }}
+          >
+            삭제
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <EditGroupDialog
+        key={String(editOpen)}
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        group={group}
+        allLabels={allLabels}
+      />
+
+      <GroupDeleteDialog open={deleteOpen} onOpenChange={setDeleteOpen} group={group} />
+    </SidebarMenuItem>
+  )
+}
+
+interface NavLabelGroupsProps {
+  activeLabelGroupId?: string
+  onLabelGroupToggle: (groupId: string) => void
+  className?: string
+}
+
+export function NavLabelGroups({ activeLabelGroupId, onLabelGroupToggle, className }: NavLabelGroupsProps) {
+  const { data: groups = [] } = useLabelGroups()
+  const { data: labels = [] } = useLabels()
+  const [createOpen, setCreateOpen] = useState(false)
+
+  return (
+    <SidebarGroup className={className}>
+      <SidebarGroupLabel className="flex items-center justify-between pr-1">
+        <span>라벨 그룹</span>
+        <Button variant="ghost" size="icon-xs" title="라벨 그룹 추가" onClick={() => setCreateOpen(true)}>
+          <Plus />
+          <span className="sr-only">라벨 그룹 추가</span>
+        </Button>
+      </SidebarGroupLabel>
+
+      {groups.length > 0 && (
+        <SidebarMenu>
+          {groups.map((group) => (
+            <GroupItem
+              key={group.id}
+              group={group}
+              allLabels={labels}
+              isActive={activeLabelGroupId === group.id}
+              onGroupToggle={onLabelGroupToggle}
+            />
+          ))}
+        </SidebarMenu>
+      )}
+
+      <CreateGroupDialog open={createOpen} onOpenChange={setCreateOpen} labels={labels} groups={groups} />
+    </SidebarGroup>
+  )
+}

--- a/src/components/nav/nav-labels.tsx
+++ b/src/components/nav/nav-labels.tsx
@@ -474,11 +474,21 @@ export function NavLabels({ activeLabelId, onLabelToggle, className }: NavLabels
           <button
             type="button"
             title="AI 라벨 추천 받기"
-            className={buttonVariants({ variant: "ghost", size: "icon-xs" })}
-            onClick={() => createSuggestions.mutate()}
+            className={cn(
+              buttonVariants({ variant: "ghost", size: "icon-xs" }),
+              "text-primary hover:bg-primary/10 hover:text-primary",
+              createSuggestions.isPending && "animate-pulse"
+            )}
+            onClick={() => {
+              const toastId = toast.loading("AI 추천 라벨을 생성 중입니다...")
+              createSuggestions.mutate(undefined, {
+                onSuccess: () => toast.success("AI 추천 라벨 생성이 완료되었습니다!", { id: toastId }),
+                onError: (e) => toast.error(getErrorMessage(e, "AI 추천 라벨 생성에 실패했습니다."), { id: toastId }),
+              })
+            }}
             disabled={createSuggestions.isPending}
           >
-            <Sparkles className="size-3.5" />
+            <Sparkles className="ai-sparkle-icon size-3.5" />
             <span className="sr-only">AI 라벨 추천 받기</span>
           </button>
           <Button variant="ghost" size="icon-xs" title="라벨 추가" onClick={() => setOpen(true)}>

--- a/src/components/nav/nav-labels.tsx
+++ b/src/components/nav/nav-labels.tsx
@@ -1,10 +1,10 @@
-import { useMemo, useState } from "react"
+import { useState } from "react"
 import { Link, useNavigate, useSearch } from "@tanstack/react-router"
 import { useQuery } from "@tanstack/react-query"
 import { DndContext, closestCenter } from "@dnd-kit/core"
 import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
-import { Check, ChevronDown, GripVertical, MoreVertical, Plus, Sparkles, X } from "lucide-react"
+import { Check, GripVertical, MoreVertical, Plus, Sparkles, X } from "lucide-react"
 import { toast } from "sonner"
 
 import { Button, buttonVariants } from "@/components/ui/button"
@@ -357,7 +357,7 @@ function SuggestionItem({ suggestion }: { suggestion: LabelSuggestion }) {
   const navigate = useNavigate()
   const approveLabelSuggestion = useApproveLabelSuggestion()
   const { data: detail } = useLabelSuggestionDetail(suggestion.id, approveOpen)
-  const groups = useMemo(() => detail?.rule?.groups ?? [], [detail])
+  const groups = detail?.rule?.groups ?? []
 
   function handleReject() {
     deleteSuggestion.mutate(suggestion.id, {
@@ -435,8 +435,6 @@ function SuggestionItem({ suggestion }: { suggestion: LabelSuggestion }) {
   )
 }
 
-const LABELS_LIMIT = 4
-
 interface NavLabelsProps {
   activeLabelId?: string
   onLabelToggle: (labelId: string) => void
@@ -450,10 +448,6 @@ export function NavLabels({ activeLabelId, onLabelToggle, className }: NavLabels
   const createSuggestions = useCreateLabelSuggestions()
   const { orderedLabels, sensors, handleDragEnd } = useLabelOrder(serverLabels)
   const [open, setOpen] = useState(false)
-  const [showAll, setShowAll] = useState(false)
-
-  const visibleLabels = showAll ? orderedLabels : orderedLabels.slice(0, LABELS_LIMIT)
-  const hasMore = orderedLabels.length > LABELS_LIMIT
 
   function handleCreate({ name, colorCode, notificationPolicy }: LabelFormData) {
     const maxOrder = serverLabels.length > 0 ? Math.max(...serverLabels.map((l) => l.order)) : 0
@@ -497,8 +491,8 @@ export function NavLabels({ activeLabelId, onLabelToggle, className }: NavLabels
       {orderedLabels.length > 0 && (
         <SidebarMenu>
           <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-            <SortableContext items={visibleLabels.map((l) => l.id)} strategy={verticalListSortingStrategy}>
-              {visibleLabels.map((label) => (
+            <SortableContext items={orderedLabels.map((l) => l.id)} strategy={verticalListSortingStrategy}>
+              {orderedLabels.map((label) => (
                 <LabelItem
                   key={label.id}
                   label={label}
@@ -508,14 +502,6 @@ export function NavLabels({ activeLabelId, onLabelToggle, className }: NavLabels
               ))}
             </SortableContext>
           </DndContext>
-          {hasMore && (
-            <SidebarMenuItem>
-              <SidebarMenuButton size="sm" onClick={() => setShowAll((v) => !v)}>
-                <ChevronDown className={cn("size-4 transition-transform", showAll && "rotate-180")} />
-                <span>{showAll ? "접기" : "더보기"}</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          )}
         </SidebarMenu>
       )}
 

--- a/src/components/thread/list-item.tsx
+++ b/src/components/thread/list-item.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils"
 import type { InboxThreadSummary, LabelSummary } from "@/types/email"
 import type { MailAccount } from "@/types/mail-account"
 
-type LabelsColorMap = Map<string, string>
+type LabelsColorMap = Map<string, { colorCode: string; name: string }>
 
 interface ThreadListItemProps {
   thread: InboxThreadSummary
@@ -29,15 +29,18 @@ function LabelChips({ labels, labelsColorMap }: { labels: LabelSummary[]; labels
   if (visibleLabels.length === 0) return null
   return (
     <>
-      {visibleLabels.map((label) => (
-        <span
-          key={label.labelId}
-          className="inline-flex max-w-24 shrink-0 items-center truncate rounded-full px-1.5 py-0.5 text-xs font-medium text-white"
-          style={{ backgroundColor: labelsColorMap?.get(label.labelId) ?? label.colorCode }}
-        >
-          {label.name}
-        </span>
-      ))}
+      {visibleLabels.map((label) => {
+        const entry = labelsColorMap.get(label.labelId)
+        return (
+          <span
+            key={label.labelId}
+            className="inline-flex max-w-48 shrink-0 items-center truncate rounded-full px-1.5 py-0.5 text-xs font-medium text-white"
+            style={{ backgroundColor: entry?.colorCode ?? label.colorCode }}
+          >
+            {entry?.name ?? label.name}
+          </span>
+        )
+      })}
     </>
   )
 }

--- a/src/components/thread/list.tsx
+++ b/src/components/thread/list.tsx
@@ -66,7 +66,10 @@ export function ThreadList({
   const { mutate: deleteThread } = useDeleteThread()
   const { mutate: restoreThread } = useRestoreTrashThread()
   const { data: labelsList } = useSuspenseLabels()
-  const labelsColorMap = useMemo(() => new Map(labelsList.map((l) => [l.id, l.colorCode])), [labelsList])
+  const labelsColorMap = useMemo(
+    () => new Map(labelsList.map((l) => [l.id, { colorCode: l.colorCode, name: l.name }])),
+    [labelsList]
+  )
   const isSelectionMode = selectedIds.size > 0
 
   const toggleSelected = (id: string) => {

--- a/src/components/trash/thread-list.tsx
+++ b/src/components/trash/thread-list.tsx
@@ -75,7 +75,10 @@ export function TrashThreadList({
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const { mutateAsync: restoreThread } = useRestoreTrashThread()
   const { data: labelsList } = useLabels()
-  const labelsColorMap = useMemo(() => new Map(labelsList?.map((l) => [l.id, l.colorCode]) ?? []), [labelsList])
+  const labelsColorMap = useMemo(
+    () => new Map(labelsList?.map((l) => [l.id, { colorCode: l.colorCode, name: l.name }]) ?? []),
+    [labelsList]
+  )
 
   const toggleSelected = (id: string) => {
     setSelectedIds((prev) => {

--- a/src/index.css
+++ b/src/index.css
@@ -132,6 +132,29 @@
   }
 }
 
+@keyframes ai-sparkle-glow {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scale(0.92);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1.08);
+  }
+}
+
+.ai-sparkle-icon {
+  animation: ai-sparkle-glow 2.5s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ai-sparkle-icon {
+    animation: none;
+  }
+}
+
 .compose-email-editor {
   --re-bg: var(--popover);
   --re-bg-active: var(--accent);

--- a/src/lib/mail-routing.ts
+++ b/src/lib/mail-routing.ts
@@ -6,6 +6,7 @@ export interface MailRouteSearch {
   accountId?: string
   thread?: string
   labelId?: string
+  labelGroupId?: string
 }
 
 export function parseMailRouteSearch(search: unknown): MailRouteSearch {
@@ -19,6 +20,7 @@ export function parseMailRouteSearch(search: unknown): MailRouteSearch {
   const accountId = typeof values.accountId === "string" ? values.accountId.trim() : undefined
   const thread = typeof values.thread === "string" ? values.thread.trim() : undefined
   const labelId = typeof values.labelId === "string" ? values.labelId.trim() : undefined
+  const labelGroupId = typeof values.labelGroupId === "string" ? values.labelGroupId.trim() : undefined
 
   return {
     ...(query ? { query } : {}),
@@ -26,5 +28,6 @@ export function parseMailRouteSearch(search: unknown): MailRouteSearch {
     ...(accountId ? { accountId } : {}),
     ...(thread ? { thread } : {}),
     ...(labelId ? { labelId } : {}),
+    ...(labelGroupId ? { labelGroupId } : {}),
   }
 }

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -29,7 +29,7 @@ export const Route = createFileRoute("/_authenticated")({
 
 function getMailRouteState(pathname: string, search: unknown) {
   const [, section, mailbox] = pathname.split("/")
-  const { query = "", filter = "all", accountId, labelId } = parseMailRouteSearch(search)
+  const { query = "", filter = "all", accountId, labelId, labelGroupId } = parseMailRouteSearch(search)
 
   return {
     mailbox: section === "mail" && mailbox ? parseMailboxId(mailbox) : null,
@@ -37,6 +37,7 @@ function getMailRouteState(pathname: string, search: unknown) {
     filter,
     accountId,
     labelId,
+    labelGroupId,
   }
 }
 
@@ -61,7 +62,7 @@ function NotificationSettingsLink() {
 function AuthenticatedRouteLayout() {
   const isMobile = useIsMobile()
   const navigate = useNavigate()
-  const { mailbox, query, filter, accountId, labelId } = useLocation({
+  const { mailbox, query, filter, accountId, labelId, labelGroupId } = useLocation({
     select: (currentLocation) => getMailRouteState(currentLocation.pathname, currentLocation.search),
   })
 
@@ -148,6 +149,7 @@ function AuthenticatedRouteLayout() {
           mailbox={mailbox}
           activeAccountId={accountId}
           activeLabelId={labelId}
+          activeLabelGroupId={labelGroupId}
           onMailboxChange={(nextMailbox) => {
             void navigate({
               to: "/mail/$mailbox",
@@ -178,6 +180,20 @@ function AuthenticatedRouteLayout() {
               search: (previous) => ({
                 ...previous,
                 labelId: previous.labelId === nextLabelId ? undefined : nextLabelId,
+                labelGroupId: undefined,
+                thread: undefined,
+              }),
+              replace: true,
+            })
+          }}
+          onLabelGroupToggle={(nextGroupId) => {
+            void navigate({
+              to: "/mail/$mailbox",
+              params: { mailbox: mailbox ?? "inbox" },
+              search: (previous) => ({
+                ...previous,
+                labelGroupId: previous.labelGroupId === nextGroupId ? undefined : nextGroupId,
+                labelId: undefined,
                 thread: undefined,
               }),
               replace: true,

--- a/src/routes/_authenticated/mail/$mailbox.tsx
+++ b/src/routes/_authenticated/mail/$mailbox.tsx
@@ -14,7 +14,7 @@ import { cn } from "@/lib/utils"
 import { useMarkThreadAsRead } from "@/mutations/emails"
 import { useMailAccounts, mailAccountQueries } from "@/queries/mail-accounts"
 import { useMailboxThreads } from "@/queries/emails"
-import { useLabels, labelQueries } from "@/queries/labels"
+import { useLabels, labelQueries, useLabelGroups, labelGroupQueries } from "@/queries/labels"
 import { useTrashThreads } from "@/queries/trash"
 import { isSupportedMailboxId, MAILBOX_LABELS, parseMailboxId, type PrimaryMailboxId } from "@/types/email"
 import type { TrashThreadSummary } from "@/types/trash"
@@ -33,22 +33,25 @@ export const Route = createFileRoute("/_authenticated/mail/$mailbox")({
   },
   validateSearch: parseMailRouteSearch,
   beforeLoad: async ({ context, params, search }) => {
-    const { labelId, accountId } = search
+    const { labelId, accountId, labelGroupId } = search
 
-    const [labels, accounts] = await Promise.all([
+    const [labels, accounts, groups] = await Promise.all([
       context.queryClient.ensureQueryData(labelQueries.list()),
       accountId !== undefined ? context.queryClient.ensureQueryData(mailAccountQueries.list()) : null,
+      labelGroupId !== undefined ? context.queryClient.ensureQueryData(labelGroupQueries.list()) : null,
     ])
 
-    if (!labelId && !accountId) return
+    if (!labelId && !accountId && !labelGroupId) return
 
     const isLabelInvalid = labelId !== undefined && !labels.some((l) => l.id === labelId)
     const isAccountInvalid = accounts !== null && !accounts.some((a) => a.id === accountId)
+    const isGroupInvalid = groups !== null && !groups.some((g) => g.id === labelGroupId)
 
-    if (!isLabelInvalid && !isAccountInvalid) return
+    if (!isLabelInvalid && !isAccountInvalid && !isGroupInvalid) return
 
     if (isLabelInvalid) toast.error("유효하지 않은 라벨입니다")
     if (isAccountInvalid) toast.error("유효하지 않은 계정입니다")
+    if (isGroupInvalid) toast.error("유효하지 않은 라벨 그룹입니다")
 
     throw redirect({
       to: "/mail/$mailbox",
@@ -57,6 +60,7 @@ export const Route = createFileRoute("/_authenticated/mail/$mailbox")({
         ...search,
         labelId: isLabelInvalid ? undefined : search.labelId,
         accountId: isAccountInvalid ? undefined : search.accountId,
+        labelGroupId: isGroupInvalid ? undefined : search.labelGroupId,
       },
       replace: true,
     })
@@ -101,14 +105,24 @@ function MailboxPage() {
 }
 
 function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
-  const { query = "", filter = "all", accountId, labelId, thread: selectedThreadId = null } = Route.useSearch()
+  const {
+    query = "",
+    filter = "all",
+    accountId,
+    labelId,
+    labelGroupId,
+    thread: selectedThreadId = null,
+  } = Route.useSearch()
   const navigate = Route.useNavigate()
   const isMobile = useIsMobile()
   const { data: accounts } = useMailAccounts()
   const { data: labels } = useLabels()
+  const { data: groups } = useLabelGroups()
   const { mutate: markAsRead } = useMarkThreadAsRead()
   const supportedMailbox = isSupportedMailboxId(mailbox) ? mailbox : null
   const selectedLabel = labelId ? (labels?.find((label) => label.id === labelId) ?? null) : null
+  const selectedGroup = labelGroupId ? (groups?.find((g) => g.id === labelGroupId) ?? null) : null
+  const effectiveLabelIds = selectedGroup ? selectedGroup.labelIds : labelId ? [labelId] : undefined
   const {
     data,
     isLoading,
@@ -122,7 +136,7 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
     isFetchNextPageError,
   } = useMailboxThreads(supportedMailbox, {
     read: filter === "unread" ? false : undefined,
-    labelId: labelId ? [labelId] : undefined,
+    labelId: effectiveLabelIds,
   })
 
   const loadedThreads = data?.pages.flatMap((page) => page.content) ?? []
@@ -169,6 +183,9 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
     emptyDescription = "현재까지 불러온 메일에서 검색 결과를 찾지 못했습니다."
   } else if (filter === "unread") {
     emptyTitle = "안 읽은 메일이 없습니다"
+  } else if (selectedGroup?.id) {
+    emptyTitle = "선택한 그룹의 메일이 없습니다"
+    emptyDescription = `"${selectedGroup.name}" 그룹에 속한 라벨이 적용된 메일이 없습니다.`
   } else if (selectedLabel?.id) {
     emptyTitle = "선택한 라벨의 메일이 없습니다"
     emptyDescription = `"${selectedLabel.name}" 라벨이 적용된 메일이 없습니다.`


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#23

### 📌 Task

- Closes #63 
- Closes #64 

## 💡 작업 내용

- 라벨 그룹 생성, 수정, 삭제 기능 구현
- 라벨 그룹 사이드바 뷰 구현
- 라벨 더보기 버튼 제거
- 메일 리스트에 라벨 실시간 동기화
- AI 라벨 추천 버튼 CSS 수정

## 📝 추가 설명

### 라벨 그룹

- `effectiveLabelIds`를 그룹 선택 여부에 따라 동적으로 결정, `labelGroupId`를 search params로 받아 필터링
- 라벨 그룹 생성, 라벨 그룹 수정을 `nav-label-group` 안에서 하나의 컴포넌트로 묶어 관리

### 기타

- 라벨 색상 수정에만 즉시 동기화되던 로직을 라벨 이름을 수정해도 즉시 동기화 되도록 수정
- AI 라벨 추천 버튼에 기본 css를 추가하고, 버튼을 클릭했을 때 toast를 추가하여 작업이 진행중임을 표시
- 라벨 최대 너비 `max-w-24` -> `max-w-48` 수정

## 🖼️ 스크린샷

- 라벨 그룹 사이드바
<img width="1919" height="862" alt="image" src="https://github.com/user-attachments/assets/b158cd24-e6fa-41d7-8971-a5d2ed0edb3a" />

- 라벨 그룹 생성 및 수정 다이얼로그

| 생성 | 수정 |
| -- | -- |
| <img width="508" height="519" alt="image" src="https://github.com/user-attachments/assets/e35dc67c-40da-4677-981d-a42330138901" /> | <img width="542" height="548" alt="image" src="https://github.com/user-attachments/assets/f14c337c-a087-4de3-bd0b-ee84721466f8" /> |
