### PR TITLE
[STORY-502] AI 메일 검토 구현

### DIFF
--- a/src/api/emails.ts
+++ b/src/api/emails.ts
@@ -10,6 +10,8 @@ import type {
   MailDraftStreamEvent,
   MailDraftStreamRequest,
   MailDraftUsage,
+  MailReviewRequest,
+  MailReviewResult,
   MarkerSliceResponse,
   SupportedMailboxId,
   UnreadCountResponse,
@@ -331,4 +333,8 @@ export async function sendMail(data: ComposeEmailData): Promise<void> {
       messageId: data.messageId,
     },
   })
+}
+
+export async function reviewMail(request: MailReviewRequest): Promise<MailReviewResult> {
+  return apiClient.post<MailReviewResult>("/api/v1/mail/reviews", request)
 }

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -25,7 +25,7 @@ import { MailDraftStreamError, streamMailDraft } from "@/api/emails"
 import { getErrorMessage } from "@/lib/http-error"
 import { formatMailAddressesForSend, parseMailRecipients } from "@/lib/mail-address"
 import { cn } from "@/lib/utils"
-import { useSendMail } from "@/mutations/emails"
+import { useReviewMail, useSendMail } from "@/mutations/emails"
 import { useActiveMailAccounts } from "@/queries/mail-accounts"
 import { useUser } from "@/queries/user"
 import type { ComposeInlineImage, MailAddress, MailDraftStreamPhase, MailDraftUsage } from "@/types/email"
@@ -329,6 +329,7 @@ export function ComposeEmail({
   const { data: user, isPending: isUserPending } = useUser()
   const { data: activeMailAccounts, isPending: isMailAccountsPending } = useActiveMailAccounts()
   const sendMailMutation = useSendMail()
+  const reviewMutation = useReviewMail()
   const [editor, setEditor] = useState<ComposeEditor | null>(null)
   const [to, setTo] = useState<MailAddress[]>(() => parseMailRecipients(initialTo ?? ""))
   const [cc, setCc] = useState<MailAddress[]>(() => parseMailRecipients(initialCc ?? ""))
@@ -698,6 +699,12 @@ export function ComposeEmail({
 
       if (preview) {
         setSendPreview(preview)
+        reviewMutation.mutate({
+          subject: preview.mail.subject,
+          body: preview.text,
+          attachmentCount: preview.mail.attachments?.length ?? 0,
+          attachmentNames: preview.mail.attachments?.map((f) => f.name) ?? [],
+        })
       }
     } catch (error) {
       toast.error("메일 미리보기를 생성하지 못했습니다", {
@@ -925,8 +932,14 @@ export function ComposeEmail({
         open={isSendPreviewOpen}
         preview={sendPreview}
         isSending={sendMailMutation.isPending}
+        isReviewing={reviewMutation.isPending}
+        reviewResult={reviewMutation.data ?? null}
+        reviewError={reviewMutation.isError}
         onOpenChange={(open) => {
-          if (!open) setSendPreview(null)
+          if (!open) {
+            setSendPreview(null)
+            reviewMutation.reset()
+          }
         }}
         onConfirm={handleConfirmSend}
       />

--- a/src/components/compose/compose-send-preview-dialog.tsx
+++ b/src/components/compose/compose-send-preview-dialog.tsx
@@ -4,14 +4,8 @@ import { LocalAttachmentChip } from "@/components/attachment/local-chip"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { cn } from "@/lib/utils"
-import type {
-  ComposeEmailData,
-  MailReviewIssue,
-  MailReviewIssueField,
-  MailReviewIssueSeverity,
-  MailReviewIssueType,
-  MailReviewResult,
-} from "@/types/email"
+import { MAIL_REVIEW_ISSUE_FIELD_LABELS, MAIL_REVIEW_ISSUE_TYPE_LABELS } from "@/types/email"
+import type { ComposeEmailData, MailReviewIssue, MailReviewIssueSeverity, MailReviewResult } from "@/types/email"
 
 export interface ComposeSendPreviewData {
   mail: ComposeEmailData
@@ -28,21 +22,6 @@ interface ComposeSendPreviewDialogProps {
   reviewError: boolean
   onOpenChange: (open: boolean) => void
   onConfirm: () => void
-}
-
-const ISSUE_TYPE_LABELS: Record<MailReviewIssueType, string> = {
-  SPELLING: "맞춤법",
-  SPACING: "띄어쓰기",
-  GRAMMAR: "문법",
-  CONTEXT: "문맥",
-  TONE: "어조",
-  CLARITY: "명확성",
-  ATTACHMENT_MISSING: "첨부파일 누락",
-}
-
-const ISSUE_FIELD_LABELS: Record<MailReviewIssueField, string> = {
-  SUBJECT: "제목",
-  BODY: "본문",
 }
 
 function getSeverityClass(severity: MailReviewIssueSeverity) {
@@ -108,8 +87,8 @@ function ReviewIssueItem({ issue }: { issue: MailReviewIssue }) {
       <AlertTriangle className={cn("mt-0.5 size-4 shrink-0", severityClass)} />
       <div className="min-w-0 flex-1 space-y-1">
         <div className="flex flex-wrap items-center gap-1.5 text-xs">
-          <span className={cn("font-medium", severityClass)}>{ISSUE_TYPE_LABELS[issue.type]}</span>
-          <span className="text-muted-foreground">{ISSUE_FIELD_LABELS[issue.field]}</span>
+          <span className={cn("font-medium", severityClass)}>{MAIL_REVIEW_ISSUE_TYPE_LABELS[issue.type]}</span>
+          <span className="text-muted-foreground">{MAIL_REVIEW_ISSUE_FIELD_LABELS[issue.field]}</span>
         </div>
         <p className="text-sm">{issue.reason}</p>
         {issue.originalText && issue.replacementText && (

--- a/src/components/compose/compose-send-preview-dialog.tsx
+++ b/src/components/compose/compose-send-preview-dialog.tsx
@@ -1,9 +1,17 @@
-import { Loader2, Send } from "lucide-react"
+import { AlertCircle, AlertTriangle, CheckCircle2, Loader2, Send, Sparkles } from "lucide-react"
 
 import { LocalAttachmentChip } from "@/components/attachment/local-chip"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import type { ComposeEmailData } from "@/types/email"
+import { cn } from "@/lib/utils"
+import type {
+  ComposeEmailData,
+  MailReviewIssue,
+  MailReviewIssueField,
+  MailReviewIssueSeverity,
+  MailReviewIssueType,
+  MailReviewResult,
+} from "@/types/email"
 
 export interface ComposeSendPreviewData {
   mail: ComposeEmailData
@@ -15,8 +23,32 @@ interface ComposeSendPreviewDialogProps {
   open: boolean
   preview: ComposeSendPreviewData | null
   isSending: boolean
+  isReviewing: boolean
+  reviewResult: MailReviewResult | null
+  reviewError: boolean
   onOpenChange: (open: boolean) => void
   onConfirm: () => void
+}
+
+const ISSUE_TYPE_LABELS: Record<MailReviewIssueType, string> = {
+  SPELLING: "맞춤법",
+  SPACING: "띄어쓰기",
+  GRAMMAR: "문법",
+  CONTEXT: "문맥",
+  TONE: "어조",
+  CLARITY: "명확성",
+  ATTACHMENT_MISSING: "첨부파일 누락",
+}
+
+const ISSUE_FIELD_LABELS: Record<MailReviewIssueField, string> = {
+  SUBJECT: "제목",
+  BODY: "본문",
+}
+
+function getSeverityClass(severity: MailReviewIssueSeverity) {
+  if (severity === "HIGH") return "text-destructive"
+  if (severity === "MEDIUM") return "text-amber-600 dark:text-amber-400"
+  return "text-muted-foreground"
 }
 
 function PreviewField({ label, value }: { label: string; value: string }) {
@@ -68,10 +100,85 @@ function EmailPreviewFrame({ html, text }: { html: string; text: string }) {
   )
 }
 
+function ReviewIssueItem({ issue }: { issue: MailReviewIssue }) {
+  const severityClass = getSeverityClass(issue.severity)
+
+  return (
+    <li className="flex gap-3 border-b px-4 py-3 last:border-b-0">
+      <AlertTriangle className={cn("mt-0.5 size-4 shrink-0", severityClass)} />
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex flex-wrap items-center gap-1.5 text-xs">
+          <span className={cn("font-medium", severityClass)}>{ISSUE_TYPE_LABELS[issue.type]}</span>
+          <span className="text-muted-foreground">{ISSUE_FIELD_LABELS[issue.field]}</span>
+        </div>
+        <p className="text-sm">{issue.reason}</p>
+        {issue.originalText && issue.replacementText && (
+          <p className="text-xs text-muted-foreground">
+            <span className="line-through">{issue.originalText}</span>
+            {" → "}
+            <span className="font-medium text-foreground">{issue.replacementText}</span>
+          </p>
+        )}
+      </div>
+    </li>
+  )
+}
+
+function ReviewSection({
+  isReviewing,
+  reviewResult,
+  reviewError,
+}: {
+  isReviewing: boolean
+  reviewResult: MailReviewResult | null
+  reviewError: boolean
+}) {
+  return (
+    <div className="rounded-lg border text-sm md:self-start">
+      <div className="flex items-center gap-2 border-b px-4 py-2.5 font-medium text-primary">
+        <Sparkles className="size-4" />
+        AI 검토 결과
+      </div>
+
+      {isReviewing && (
+        <div className="flex items-center gap-2 px-4 py-3 text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" />
+          AI가 메일을 검토하는 중입니다...
+        </div>
+      )}
+
+      {!isReviewing && reviewError && (
+        <div className="flex items-center gap-2 px-4 py-3 text-muted-foreground">
+          <AlertCircle className="size-4" />
+          AI 검토에 실패했습니다. 메일을 수정하거나 바로 발송할 수 있습니다.
+        </div>
+      )}
+
+      {!isReviewing && reviewResult && !reviewResult.hasIssues && (
+        <div className="flex items-center gap-2 px-4 py-3 text-green-600 dark:text-green-400">
+          <CheckCircle2 className="size-4" />
+          수정 권장 사항이 없습니다.
+        </div>
+      )}
+
+      {!isReviewing && reviewResult?.hasIssues && reviewResult.issues.length > 0 && (
+        <ul className="md:max-h-90 md:overflow-y-auto">
+          {reviewResult.issues.map((issue, index) => (
+            <ReviewIssueItem key={issue.segmentId || index} issue={issue} />
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
 export function ComposeSendPreviewDialog({
   open,
   preview,
   isSending,
+  isReviewing,
+  reviewResult,
+  reviewError,
   onOpenChange,
   onConfirm,
 }: ComposeSendPreviewDialogProps) {
@@ -79,33 +186,37 @@ export function ComposeSendPreviewDialog({
 
   return (
     <Dialog open={open} onOpenChange={(nextOpen) => !isSending && onOpenChange(nextOpen)}>
-      <DialogContent className="sm:max-w-3xl">
+      <DialogContent className="flex max-h-[90dvh] flex-col sm:max-w-5xl">
         <DialogHeader>
           <DialogTitle>메일 미리보기</DialogTitle>
         </DialogHeader>
 
         {mail && (
-          <div className="grid gap-4 overflow-y-auto">
-            <dl className="overflow-hidden rounded-lg border text-sm">
-              <PreviewField label="보내는 사람" value={mail.from ?? ""} />
-              <PreviewField label="받는 사람" value={mail.to.join(", ")} />
-              {mail.cc && mail.cc.length > 0 && <PreviewField label="참조" value={mail.cc.join(", ")} />}
-              {mail.bcc && mail.bcc.length > 0 && <PreviewField label="숨은참조" value={mail.bcc.join(", ")} />}
-              <PreviewField label="제목" value={mail.subject} />
-            </dl>
+          <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto md:grid-cols-[1fr_22rem]">
+            <div className="grid gap-4">
+              <dl className="overflow-hidden rounded-lg border text-sm">
+                <PreviewField label="보내는 사람" value={mail.from ?? ""} />
+                <PreviewField label="받는 사람" value={mail.to.join(", ")} />
+                {mail.cc && mail.cc.length > 0 && <PreviewField label="참조" value={mail.cc.join(", ")} />}
+                {mail.bcc && mail.bcc.length > 0 && <PreviewField label="숨은참조" value={mail.bcc.join(", ")} />}
+                <PreviewField label="제목" value={mail.subject} />
+              </dl>
 
-            <EmailPreviewFrame html={preview.html} text={preview.text} />
+              <EmailPreviewFrame html={preview.html} text={preview.text} />
 
-            {mail.attachments && mail.attachments.length > 0 && (
-              <div className="rounded-lg border px-4 py-3 text-sm">
-                <div className="mb-2 font-medium">첨부파일</div>
-                <div className="flex max-h-20 flex-wrap gap-2 overflow-y-auto pr-1">
-                  {mail.attachments.map((file, index) => (
-                    <LocalAttachmentChip key={`${file.name}-${file.lastModified}-${index}`} file={file} />
-                  ))}
+              {mail.attachments && mail.attachments.length > 0 && (
+                <div className="rounded-lg border px-4 py-3 text-sm">
+                  <div className="mb-2 font-medium">첨부파일</div>
+                  <div className="flex flex-wrap gap-2 pr-1 md:max-h-20 md:overflow-y-auto">
+                    {mail.attachments.map((file, index) => (
+                      <LocalAttachmentChip key={`${file.name}-${file.lastModified}-${index}`} file={file} />
+                    ))}
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
+            </div>
+
+            <ReviewSection isReviewing={isReviewing} reviewResult={reviewResult} reviewError={reviewError} />
           </div>
         )}
 

--- a/src/mutations/emails.ts
+++ b/src/mutations/emails.ts
@@ -1,9 +1,16 @@
 import { useMutation } from "@tanstack/react-query"
 import { toast } from "sonner"
 
-import type { ComposeEmailData } from "@/types/email"
+import type { ComposeEmailData, MailReviewRequest } from "@/types/email"
 
-import { markMessageAsRead, markMessageAsUnread, markThreadAsRead, markThreadAsUnread, sendMail } from "@/api/emails"
+import {
+  markMessageAsRead,
+  markMessageAsUnread,
+  markThreadAsRead,
+  markThreadAsUnread,
+  reviewMail,
+  sendMail,
+} from "@/api/emails"
 import { queryClient } from "@/lib/query-client"
 import { emailKeys } from "@/queries/emails"
 import { labelKeys } from "@/queries/labels"
@@ -65,4 +72,10 @@ export function useMarkMessageAsUnread() {
 
 export function useSendMail() {
   return useMutation(emailMutationOptions.sendMail())
+}
+
+export function useReviewMail() {
+  return useMutation({
+    mutationFn: (request: MailReviewRequest) => reviewMail(request),
+  })
 }

--- a/src/types/email.ts
+++ b/src/types/email.ts
@@ -142,3 +142,41 @@ export type MailDraftStreamEvent =
   | { type: "usage"; usage: MailDraftUsage }
   | { type: "done" }
   | { type: "error"; code?: string; message: string }
+
+export interface MailReviewRequest {
+  subject: string
+  body: string
+  attachmentCount?: number
+  attachmentNames?: string[]
+}
+
+export type MailReviewIssueField = "SUBJECT" | "BODY"
+export type MailReviewIssueType =
+  | "SPELLING"
+  | "SPACING"
+  | "GRAMMAR"
+  | "CONTEXT"
+  | "TONE"
+  | "CLARITY"
+  | "ATTACHMENT_MISSING"
+export type MailReviewIssueSeverity = "LOW" | "MEDIUM" | "HIGH"
+
+export interface MailReviewIssue {
+  segmentId: string
+  field: MailReviewIssueField
+  type: MailReviewIssueType
+  severity: MailReviewIssueSeverity
+  segmentText: string
+  originalText: string
+  replacementText: string
+  localStartOffset: number
+  localEndOffset: number
+  globalStartOffset: number
+  globalEndOffset: number
+  reason: string
+}
+
+export interface MailReviewResult {
+  hasIssues: boolean
+  issues: MailReviewIssue[]
+}

--- a/src/types/email.ts
+++ b/src/types/email.ts
@@ -161,6 +161,21 @@ export type MailReviewIssueType =
   | "ATTACHMENT_MISSING"
 export type MailReviewIssueSeverity = "LOW" | "MEDIUM" | "HIGH"
 
+export const MAIL_REVIEW_ISSUE_TYPE_LABELS: Record<MailReviewIssueType, string> = {
+  SPELLING: "맞춤법",
+  SPACING: "띄어쓰기",
+  GRAMMAR: "문법",
+  CONTEXT: "문맥",
+  TONE: "어조",
+  CLARITY: "명확성",
+  ATTACHMENT_MISSING: "첨부파일 누락",
+}
+
+export const MAIL_REVIEW_ISSUE_FIELD_LABELS: Record<MailReviewIssueField, string> = {
+  SUBJECT: "제목",
+  BODY: "본문",
+}
+
 export interface MailReviewIssue {
   segmentId: string
   field: MailReviewIssueField


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#25

### 📌 Task

- Closes #84 
- Closes #85 

## 💡 작업 내용

- AI 메일 검토 API 구현
- AI 메일 검토 UI 구현# 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#25

### 📌 Task

- Closes #84 
- Closes #85 

## 💡 작업 내용

- AI 메일 검토 API 구현
- AI 메일 검토 UI 구현

## 📝 추가 설명

- 기존에 있던 '마크다운 확인 다이얼로그'를 이용하여 구현
- 발송 미리보기 오른쪽에 AI 메일 검토 영역 생성
- AI 검토 패널 추가에 따라 다이얼로그가 2컬럼 레이아웃으로 변경
- 최대 너비 `sm:max-w-3xl` → `sm:max-w-5xl`로 확장

## 🖼️ 스크린샷

- 데스크톱 환경

<img width="1918" height="870" alt="image" src="https://github.com/user-attachments/assets/1b12ed39-c3eb-41f9-be29-bf3cd4a1dfe3" />

- 모바일 환경

| | |
| -- | -- |
| <img width="441" height="758" alt="image" src="https://github.com/user-attachments/assets/3210d810-0cf1-473a-9606-b5ff8208efe4" /> | <img width="438" height="756" alt="image" src="https://github.com/user-attachments/assets/03a9e742-f88a-4707-a9d8-773f7e83646a" /> |


