### PR TITLE
[STORY-601] AI 추천 답장

### DIFF
--- a/src/api/emails.ts
+++ b/src/api/emails.ts
@@ -13,6 +13,8 @@ import type {
   MailReviewRequest,
   MailReviewResult,
   MarkerSliceResponse,
+  ReplyDraftSuggestion,
+  ReplyDraftSuggestionListResponse,
   SupportedMailboxId,
   UnreadCountResponse,
 } from "@/types/email"
@@ -209,6 +211,14 @@ export async function markMessageAsUnread(messageId: string): Promise<void> {
 
 export async function getUnreadCount(): Promise<UnreadCountResponse> {
   return apiClient.get<UnreadCountResponse>("/api/v1/threads/inbox/unread-count")
+}
+
+export async function getReplyDraftSuggestions(messageId: string): Promise<ReplyDraftSuggestionListResponse> {
+  return apiClient.get<ReplyDraftSuggestionListResponse>(`/api/v1/mail/messages/${messageId}/reply-draft-suggestions`)
+}
+
+export async function selectReplyDraftSuggestion(suggestionId: string): Promise<ReplyDraftSuggestion> {
+  return apiClient.post<ReplyDraftSuggestion>(`/api/v1/mail/reply-draft-suggestions/${suggestionId}/select`)
 }
 
 export function getAttachmentDownloadUrl(attachmentId: string) {

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -351,6 +351,7 @@ export function ComposeEmail({
   const [draftStreamPhase, setDraftStreamPhase] = useState<MailDraftStreamPhase>("idle")
   const [draftUsage, setDraftUsage] = useState<MailDraftUsage | null>(null)
 
+  const isReplyMode = !!messageId
   const activeFromAddressSet = useMemo(
     () => new Set((activeMailAccounts ?? []).map((mailAccount) => mailAccount.emailAddress)),
     [activeMailAccounts]
@@ -544,14 +545,16 @@ export function ComposeEmail({
     }
 
     const abortController = new AbortController()
-    let draftSubject = ""
+    let draftSubject = isReplyMode ? subject : ""
     let draftBody = ""
 
     draftAbortControllerRef.current = abortController
-    setSubject("")
+    if (!isReplyMode) {
+      setSubject("")
+    }
     replaceEditorBodyText("")
     setDraftUsage(null)
-    setDraftStreamPhase("subject")
+    setDraftStreamPhase(isReplyMode ? "body" : "subject")
     setIsDraftStreaming(true)
 
     try {
@@ -571,6 +574,10 @@ export function ComposeEmail({
             }
 
             if (event.type === "subject") {
+              if (isReplyMode) {
+                return
+              }
+
               draftSubject += event.delta
               setSubject(draftSubject)
               setDraftStreamPhase("subject")
@@ -805,7 +812,7 @@ export function ComposeEmail({
           value={subject}
           onChange={(e) => setSubject(e.target.value)}
           placeholder="메일 제목 입력"
-          disabled={isDraftStreaming}
+          disabled={isReplyMode || isDraftStreaming}
           className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-60"
         />
       </div>

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -37,6 +37,7 @@ interface ComposeEmailProps {
   initialTo?: string
   initialSubject?: string
   initialCc?: string
+  initialBody?: string
 }
 
 interface PendingInlineImage extends ComposeInlineImage {
@@ -318,6 +319,7 @@ export function ComposeEmail({
   initialTo,
   initialSubject,
   initialCc,
+  initialBody,
 }: ComposeEmailProps) {
   const navigate = useNavigate()
   const editorRef = useRef<EmailEditorRef>(null)
@@ -856,10 +858,15 @@ export function ComposeEmail({
           editable={!isDraftStreaming}
           onUploadImage={uploadInlineImage}
           onReady={(ref) => {
-            applyEditorTheme(ref.editor)
+            const readyEditor = ref.editor
+
+            applyEditorTheme(readyEditor)
+            if (initialBody && readyEditor) {
+              readyEditor.commands.setContent(textToEditorContent(initialBody))
+            }
             setIsEditorReady(true)
             setIsEditorEmpty(isEditorContentEmpty(ref.getJSON()))
-            setEditor(ref.editor)
+            setEditor(readyEditor)
           }}
           onUpdate={(ref) => {
             const content = ref.getJSON()

--- a/src/components/compose/compose-reference-thread-panel.tsx
+++ b/src/components/compose/compose-reference-thread-panel.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react"
 import { Mail } from "lucide-react"
 
 import { MailErrorState } from "@/components/mail-error-state"
@@ -6,6 +5,7 @@ import { ThreadHeader } from "@/components/thread/header"
 import { ThreadMessageList } from "@/components/thread/message-list"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useThreadMessageExpansion } from "@/hooks/use-thread-message-expansion"
 import { getErrorMessage, getHttpStatus } from "@/lib/http-error"
 import { useThread } from "@/queries/emails"
 import { useMailAccounts } from "@/queries/mail-accounts"
@@ -68,31 +68,17 @@ function LoadingState() {
 
 interface ComposeReferenceThreadPanelProps {
   threadId: string | null
+  messageId?: string | null
 }
 
-export function ComposeReferenceThreadPanel({ threadId }: ComposeReferenceThreadPanelProps) {
+export function ComposeReferenceThreadPanel({ threadId, messageId = null }: ComposeReferenceThreadPanelProps) {
   const { data: thread, isLoading, isError, error, refetch } = useThread(threadId)
   const { data: accounts } = useMailAccounts()
-
-  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
-  const [expandedThreadId, setExpandedThreadId] = useState<string | null>(null)
-
-  if (thread && thread.threadId !== expandedThreadId) {
-    const next = new Set<string>()
-    const last = thread.messages.at(-1)
-    if (last) next.add(last.id)
-    setExpandedIds(next)
-    setExpandedThreadId(thread.threadId)
-  }
-
-  const toggleExpanded = (id: string) => {
-    setExpandedIds((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }
+  const { expandedIds, toggleExpanded } = useThreadMessageExpansion({
+    threadId,
+    messages: thread?.messages ?? [],
+    messageId,
+  })
 
   const errorCopy = isError ? getThreadDetailErrorCopy(error) : null
   const account = thread ? accounts?.find((item) => item.id === thread.accountId) : undefined

--- a/src/components/thread/detail.tsx
+++ b/src/components/thread/detail.tsx
@@ -263,8 +263,8 @@ export function ThreadDetail({ threadId, onClose }: ThreadDetailProps) {
     void navigate({
       to: "/compose",
       search: {
-        replyThreadId: thread.threadId,
-        ...(message ? { replyMessageId: message.id } : {}),
+        thread: thread.threadId,
+        ...(message ? { message: message.id } : {}),
       },
     })
   }

--- a/src/components/thread/detail.tsx
+++ b/src/components/thread/detail.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react"
 import { Archive, ArrowLeft, Copy, Forward, MailOpen, Mail, Reply, Trash2 } from "lucide-react"
 import { useNavigate } from "@tanstack/react-router"
 import { toast } from "sonner"
@@ -11,6 +10,7 @@ import { Button } from "@/components/ui/button"
 import { DropdownMenuItem, DropdownMenuSeparator } from "@/components/ui/dropdown-menu"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useThreadMessageExpansion } from "@/hooks/use-thread-message-expansion"
 import { copyTextToClipboard } from "@/lib/clipboard"
 import { getErrorMessage, getHttpStatus } from "@/lib/http-error"
 import {
@@ -189,10 +189,11 @@ function ThreadFooter({
 
 interface ThreadDetailProps {
   threadId: string | null
+  messageId?: string | null
   onClose?: () => void
 }
 
-export function ThreadDetail({ threadId, onClose }: ThreadDetailProps) {
+export function ThreadDetail({ threadId, messageId = null, onClose }: ThreadDetailProps) {
   const navigate = useNavigate()
   const { data: thread, isLoading, isError, error, refetch } = useThread(threadId)
   const { data: accounts } = useMailAccounts()
@@ -204,29 +205,11 @@ export function ThreadDetail({ threadId, onClose }: ThreadDetailProps) {
   const { mutate: markThreadUnread, isPending: isMarkingThreadUnread } = useMarkThreadAsUnread()
   const { mutate: markMessageRead } = useMarkMessageAsRead()
   const { mutate: markMessageUnread } = useMarkMessageAsUnread()
-
-  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
-  const [expandedThreadId, setExpandedThreadId] = useState<string | null>(null)
-
-  if (thread && thread.threadId !== expandedThreadId) {
-    const next = new Set<string>()
-    const last = thread.messages.at(-1)
-    if (last) next.add(last.id)
-    for (const message of thread.messages) {
-      if (!message.isRead) next.add(message.id)
-    }
-    setExpandedIds(next)
-    setExpandedThreadId(thread.threadId)
-  }
-
-  const toggleExpanded = (id: string) => {
-    setExpandedIds((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }
+  const { expandedIds, toggleExpanded } = useThreadMessageExpansion({
+    threadId,
+    messages: thread?.messages ?? [],
+    messageId,
+  })
 
   const handleDeleteMessage = (message: InboxMessage, isLast: boolean) => {
     deleteMessage(message.id, {

--- a/src/components/thread/detail.tsx
+++ b/src/components/thread/detail.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner"
 import { MailErrorState } from "@/components/mail-error-state"
 import { ThreadHeader } from "@/components/thread/header"
 import { ThreadMessageList } from "@/components/thread/message-list"
+import { ReplyDraftSuggestionAction } from "@/components/thread/reply-draft-suggestion-action"
 import { Button } from "@/components/ui/button"
 import { DropdownMenuItem, DropdownMenuSeparator } from "@/components/ui/dropdown-menu"
 import { Separator } from "@/components/ui/separator"
@@ -89,6 +90,18 @@ function LoadingState() {
   )
 }
 
+function getLatestInboundMessage(messages: readonly InboxMessage[]) {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+
+    if (message?.direction === "INBOUND") {
+      return message
+    }
+  }
+
+  return null
+}
+
 interface ThreadToolbarProps {
   isRead: boolean
   onClose?: () => void
@@ -152,18 +165,23 @@ function ThreadToolbar({
   )
 }
 
-function ThreadFooter({ onReply }: { onReply: () => void }) {
+function ThreadFooter({
+  onReply,
+  replyDraftMessage,
+  threadId,
+}: {
+  onReply: () => void
+  replyDraftMessage: InboxMessage | null
+  threadId: string
+}) {
   return (
     <div className="shrink-0 border-t px-6 py-2">
-      <div className="flex flex-wrap gap-2">
+      <div className="flex min-w-0 items-center gap-2 overflow-x-auto">
         <Button variant="outline" size="sm" onClick={onReply}>
           <Reply />
           답장
         </Button>
-        <Button variant="outline" size="sm" disabled title="전달 기능은 아직 지원되지 않습니다.">
-          <Forward />
-          전달
-        </Button>
+        {replyDraftMessage ? <ReplyDraftSuggestionAction threadId={threadId} message={replyDraftMessage} /> : null}
       </div>
     </div>
   )
@@ -309,6 +327,7 @@ export function ThreadDetail({ threadId, onClose }: ThreadDetailProps) {
 
   const messages = thread.messages
   const account = accounts?.find((item) => item.id === thread.accountId)
+  const replyDraftMessage = getLatestInboundMessage(messages)
 
   return (
     <div className="flex h-full w-full min-w-0 flex-1 flex-col">
@@ -354,7 +373,7 @@ export function ThreadDetail({ threadId, onClose }: ThreadDetailProps) {
           </>
         )}
       />
-      <ThreadFooter onReply={() => handleReply()} />
+      <ThreadFooter onReply={() => handleReply()} threadId={thread.threadId} replyDraftMessage={replyDraftMessage} />
     </div>
   )
 }

--- a/src/components/thread/reply-draft-suggestion-action.tsx
+++ b/src/components/thread/reply-draft-suggestion-action.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react"
+import { Reply, Sparkles, Mail } from "lucide-react"
+import { useNavigate } from "@tanstack/react-router"
+
+import { Button } from "@/components/ui/button"
+import { Popover, PopoverContent, PopoverTitle, PopoverTrigger } from "@/components/ui/popover"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
+import { useIsMobile } from "@/hooks/use-mobile"
+import { useReplyDraftSuggestions } from "@/queries/emails"
+import type { InboxMessage, ReplyDraftSuggestion } from "@/types/email"
+
+interface ReplyDraftSuggestionActionProps {
+  threadId: string
+  message: InboxMessage
+}
+
+interface SuggestionPreviewProps {
+  suggestion: ReplyDraftSuggestion
+  onSelect: (suggestion: ReplyDraftSuggestion) => void
+}
+
+function SuggestionPreview({ suggestion, onSelect }: SuggestionPreviewProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="rounded-lg border bg-background p-4">
+        <p className="max-h-72 overflow-hidden text-sm leading-relaxed whitespace-pre-wrap text-foreground">
+          {suggestion.body}
+        </p>
+      </div>
+      <Button onClick={() => onSelect(suggestion)}>
+        <Reply />이 내용으로 답장 작성
+      </Button>
+    </div>
+  )
+}
+
+function getSuggestionAriaLabel(suggestion: ReplyDraftSuggestion) {
+  return `${suggestion.type} 추천 답장`
+}
+
+export function ReplyDraftSuggestionAction({ threadId, message }: ReplyDraftSuggestionActionProps) {
+  const navigate = useNavigate()
+  const isMobile = useIsMobile()
+  const [mobileSuggestion, setMobileSuggestion] = useState<ReplyDraftSuggestion | null>(null)
+  const { data, isPending, isError } = useReplyDraftSuggestions(message.id)
+  const suggestions = data?.suggestions ?? []
+
+  if (isPending || isError || suggestions.length === 0) {
+    return null
+  }
+
+  const handleSelect = (suggestion: ReplyDraftSuggestion) => {
+    setMobileSuggestion(null)
+    void navigate({
+      to: "/compose",
+      search: {
+        replyThreadId: threadId,
+        replyMessageId: message.id,
+        replySuggestionId: suggestion.id,
+      },
+    })
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={mobileSuggestion != null} onOpenChange={(open) => !open && setMobileSuggestion(null)}>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <span className="mx-1 h-5 w-px bg-border" aria-hidden />
+          <div className="mr-1 flex shrink-0 items-center gap-1.5 text-xs font-medium text-muted-foreground">
+            <Sparkles className="size-3.5" />
+            AI 답장
+          </div>
+          {suggestions.map((suggestion) => (
+            <SheetTrigger
+              key={suggestion.id}
+              render={
+                <Button
+                  variant="outline"
+                  size="sm"
+                  aria-label={getSuggestionAriaLabel(suggestion)}
+                  onClick={() => setMobileSuggestion(suggestion)}
+                >
+                  <Mail />
+                  {suggestion.type}
+                </Button>
+              }
+            />
+          ))}
+        </div>
+        <SheetContent side="bottom" className="max-h-[85vh] rounded-t-lg">
+          <SheetHeader>
+            <SheetTitle className="flex flex-row items-center gap-2">
+              <Sparkles className="size-4" />
+              <span>{mobileSuggestion ? `${mobileSuggestion.type} 답장 미리보기` : "추천 답장"}</span>
+            </SheetTitle>
+          </SheetHeader>
+          <ScrollArea className="min-h-0 flex-1 px-4 pb-4">
+            {mobileSuggestion ? <SuggestionPreview suggestion={mobileSuggestion} onSelect={handleSelect} /> : null}
+          </ScrollArea>
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <div className="flex shrink-0 items-center gap-1.5">
+      <span className="mx-1 h-5 w-px bg-border" aria-hidden />
+      <div className="mr-1 flex shrink-0 items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <Sparkles className="size-3.5" />
+        AI 답장 제안
+      </div>
+      {suggestions.map((suggestion) => (
+        <Popover key={suggestion.id}>
+          <PopoverTrigger
+            openOnHover
+            delay={80}
+            closeDelay={120}
+            render={
+              <Button variant="outline" size="sm" aria-label={getSuggestionAriaLabel(suggestion)}>
+                <Mail />
+                {suggestion.type}
+              </Button>
+            }
+          />
+          <PopoverContent side="top" sideOffset={8} className="w-88 max-w-[calc(100vw-2rem)] p-3">
+            <PopoverTitle className="flex flex-row items-center gap-2">
+              <Sparkles className="size-4" />
+              {suggestion.type} 답장 미리보기
+            </PopoverTitle>
+            <SuggestionPreview suggestion={suggestion} onSelect={handleSelect} />
+          </PopoverContent>
+        </Popover>
+      ))}
+    </div>
+  )
+}

--- a/src/components/thread/reply-draft-suggestion-action.tsx
+++ b/src/components/thread/reply-draft-suggestion-action.tsx
@@ -1,14 +1,18 @@
 import { useState } from "react"
-import { Reply, Sparkles, Mail } from "lucide-react"
+import { Loader2, Mail, Reply, Sparkles } from "lucide-react"
+import { useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
+import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import { Popover, PopoverContent, PopoverTitle, PopoverTrigger } from "@/components/ui/popover"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
 import { useIsMobile } from "@/hooks/use-mobile"
-import { useReplyDraftSuggestions } from "@/queries/emails"
-import type { InboxMessage, ReplyDraftSuggestion } from "@/types/email"
+import { getErrorMessage } from "@/lib/http-error"
+import { useSelectReplyDraftSuggestion } from "@/mutations/emails"
+import { emailKeys, useReplyDraftSuggestions } from "@/queries/emails"
+import type { InboxMessage, ReplyDraftSuggestion, ReplyDraftSuggestionListResponse } from "@/types/email"
 
 interface ReplyDraftSuggestionActionProps {
   threadId: string
@@ -18,9 +22,10 @@ interface ReplyDraftSuggestionActionProps {
 interface SuggestionPreviewProps {
   suggestion: ReplyDraftSuggestion
   onSelect: (suggestion: ReplyDraftSuggestion) => void
+  isSelecting?: boolean
 }
 
-function SuggestionPreview({ suggestion, onSelect }: SuggestionPreviewProps) {
+function SuggestionPreview({ suggestion, onSelect, isSelecting = false }: SuggestionPreviewProps) {
   return (
     <div className="flex flex-col gap-3">
       <div className="rounded-lg border bg-background p-4">
@@ -28,8 +33,8 @@ function SuggestionPreview({ suggestion, onSelect }: SuggestionPreviewProps) {
           {suggestion.body}
         </p>
       </div>
-      <Button onClick={() => onSelect(suggestion)}>
-        <Reply />이 내용으로 답장 작성
+      <Button onClick={() => onSelect(suggestion)} disabled={isSelecting}>
+        {isSelecting ? <Loader2 className="animate-spin" /> : <Reply />}이 내용으로 답장 작성
       </Button>
     </div>
   )
@@ -41,25 +46,41 @@ function getSuggestionAriaLabel(suggestion: ReplyDraftSuggestion) {
 
 export function ReplyDraftSuggestionAction({ threadId, message }: ReplyDraftSuggestionActionProps) {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const isMobile = useIsMobile()
   const [mobileSuggestion, setMobileSuggestion] = useState<ReplyDraftSuggestion | null>(null)
   const { data, isPending, isError } = useReplyDraftSuggestions(message.id)
+  const selectSuggestion = useSelectReplyDraftSuggestion()
   const suggestions = data?.suggestions ?? []
 
   if (isPending || isError || suggestions.length === 0) {
     return null
   }
 
-  const handleSelect = (suggestion: ReplyDraftSuggestion) => {
-    setMobileSuggestion(null)
-    void navigate({
-      to: "/compose",
-      search: {
-        thread: threadId,
-        message: message.id,
-        suggestion: suggestion.id,
-      },
-    })
+  const handleSelect = async (suggestion: ReplyDraftSuggestion) => {
+    try {
+      const replyDraftSuggestion = await selectSuggestion.mutateAsync(suggestion.id)
+
+      queryClient.setQueryData<ReplyDraftSuggestionListResponse>(emailKeys.replyDraftSuggestions(message.id), {
+        suggestions: [],
+      })
+      setMobileSuggestion(null)
+      void navigate({
+        to: "/compose",
+        search: {
+          thread: threadId,
+          message: message.id,
+        },
+        state: (prev) => ({
+          ...prev,
+          replyDraftSuggestion,
+        }),
+      })
+    } catch (error) {
+      toast.error("추천 답장 선택에 실패했습니다", {
+        description: getErrorMessage(error, "잠시 후 다시 시도해주세요."),
+      })
+    }
   }
 
   if (isMobile) {
@@ -96,7 +117,13 @@ export function ReplyDraftSuggestionAction({ threadId, message }: ReplyDraftSugg
             </SheetTitle>
           </SheetHeader>
           <ScrollArea className="min-h-0 flex-1 px-4 pb-4">
-            {mobileSuggestion ? <SuggestionPreview suggestion={mobileSuggestion} onSelect={handleSelect} /> : null}
+            {mobileSuggestion ? (
+              <SuggestionPreview
+                suggestion={mobileSuggestion}
+                onSelect={handleSelect}
+                isSelecting={selectSuggestion.isPending}
+              />
+            ) : null}
           </ScrollArea>
         </SheetContent>
       </Sheet>
@@ -128,7 +155,11 @@ export function ReplyDraftSuggestionAction({ threadId, message }: ReplyDraftSugg
               <Sparkles className="size-4" />
               {suggestion.type} 답장 미리보기
             </PopoverTitle>
-            <SuggestionPreview suggestion={suggestion} onSelect={handleSelect} />
+            <SuggestionPreview
+              suggestion={suggestion}
+              onSelect={handleSelect}
+              isSelecting={selectSuggestion.isPending}
+            />
           </PopoverContent>
         </Popover>
       ))}

--- a/src/components/thread/reply-draft-suggestion-action.tsx
+++ b/src/components/thread/reply-draft-suggestion-action.tsx
@@ -55,9 +55,9 @@ export function ReplyDraftSuggestionAction({ threadId, message }: ReplyDraftSugg
     void navigate({
       to: "/compose",
       search: {
-        replyThreadId: threadId,
-        replyMessageId: message.id,
-        replySuggestionId: suggestion.id,
+        thread: threadId,
+        message: message.id,
+        suggestion: suggestion.id,
       },
     })
   }
@@ -108,7 +108,7 @@ export function ReplyDraftSuggestionAction({ threadId, message }: ReplyDraftSugg
       <span className="mx-1 h-5 w-px bg-border" aria-hidden />
       <div className="mr-1 flex shrink-0 items-center gap-1.5 text-xs font-medium text-muted-foreground">
         <Sparkles className="size-3.5" />
-        AI 답장 제안
+        AI 답장
       </div>
       {suggestions.map((suggestion) => (
         <Popover key={suggestion.id}>

--- a/src/hooks/use-thread-message-expansion.ts
+++ b/src/hooks/use-thread-message-expansion.ts
@@ -1,0 +1,65 @@
+import { useState } from "react"
+
+import type { InboxMessage } from "@/types/email"
+
+function getDefaultExpandedIds({
+  messages,
+  messageId,
+}: {
+  messages: readonly InboxMessage[]
+  messageId?: string | null
+}) {
+  const next = new Set<string>()
+  const hasMessageId = messageId != null
+  const last = messages.at(-1)
+
+  if (!hasMessageId && last) {
+    next.add(last.id)
+  }
+
+  for (const message of messages) {
+    if (!message.isRead || message.id === messageId) {
+      next.add(message.id)
+    }
+  }
+
+  return next
+}
+
+export function useThreadMessageExpansion({
+  threadId,
+  messages,
+  messageId = null,
+}: {
+  threadId: string | null
+  messages: readonly InboxMessage[]
+  messageId?: string | null
+}) {
+  const messageKey = messages.map((message) => `${message.id}:${message.isRead ? "1" : "0"}`).join("\u0000")
+  const resetKey = `${threadId ?? ""}\u0000${messageId ?? ""}\u0000${messageKey}`
+  const [expandedState, setExpandedState] = useState(() => ({
+    resetKey,
+    ids: getDefaultExpandedIds({ messages, messageId }),
+  }))
+
+  let expandedIds = expandedState.ids
+
+  if (expandedState.resetKey !== resetKey) {
+    expandedIds = getDefaultExpandedIds({ messages, messageId })
+    setExpandedState({ resetKey, ids: expandedIds })
+  }
+
+  const toggleExpanded = (id: string) => {
+    setExpandedState((prev) => {
+      const next = new Set(prev.ids)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return { ...prev, ids: next }
+    })
+  }
+
+  return {
+    expandedIds,
+    toggleExpanded,
+  }
+}

--- a/src/lib/mail-routing.ts
+++ b/src/lib/mail-routing.ts
@@ -5,6 +5,7 @@ export interface MailRouteSearch {
   filter?: EmailFilter
   accountId?: string
   thread?: string
+  message?: string
   labelId?: string
   labelGroupId?: string
 }
@@ -19,6 +20,7 @@ export function parseMailRouteSearch(search: unknown): MailRouteSearch {
   const filter = values.filter === "unread" ? "unread" : values.filter === "all" ? "all" : undefined
   const accountId = typeof values.accountId === "string" ? values.accountId.trim() : undefined
   const thread = typeof values.thread === "string" ? values.thread.trim() : undefined
+  const message = typeof values.message === "string" ? values.message.trim() : undefined
   const labelId = typeof values.labelId === "string" ? values.labelId.trim() : undefined
   const labelGroupId = typeof values.labelGroupId === "string" ? values.labelGroupId.trim() : undefined
 
@@ -27,6 +29,7 @@ export function parseMailRouteSearch(search: unknown): MailRouteSearch {
     ...(filter && filter !== "all" ? { filter } : {}),
     ...(accountId ? { accountId } : {}),
     ...(thread ? { thread } : {}),
+    ...(message ? { message } : {}),
     ...(labelId ? { labelId } : {}),
     ...(labelGroupId ? { labelGroupId } : {}),
   }

--- a/src/mutations/emails.ts
+++ b/src/mutations/emails.ts
@@ -1,12 +1,7 @@
 import { useMutation } from "@tanstack/react-query"
 import { toast } from "sonner"
 
-import type {
-  ComposeEmailData,
-  MailReviewRequest,
-  ReplyDraftSuggestion,
-  ReplyDraftSuggestionListResponse,
-} from "@/types/email"
+import type { ComposeEmailData, MailReviewRequest } from "@/types/email"
 
 import {
   markMessageAsRead,
@@ -14,17 +9,11 @@ import {
   markThreadAsRead,
   markThreadAsUnread,
   reviewMail,
-  selectReplyDraftSuggestion,
   sendMail,
 } from "@/api/emails"
 import { queryClient } from "@/lib/query-client"
 import { emailKeys } from "@/queries/emails"
 import { labelKeys } from "@/queries/labels"
-
-interface SelectReplyDraftSuggestionVariables {
-  messageId: string
-  suggestionId: string
-}
 
 function invalidateEmailAndLabelQueries() {
   void queryClient.invalidateQueries({ queryKey: emailKeys.all() })
@@ -37,16 +26,6 @@ export const emailMutationOptions = {
     mutationFn: (data: ComposeEmailData) => sendMail(data),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: emailKeys.all() })
-    },
-  }),
-  selectReplyDraftSuggestion: () => ({
-    mutationKey: [...emailKeys.all(), "reply-draft-suggestions", "select"] as const,
-    mutationFn: ({ suggestionId }: SelectReplyDraftSuggestionVariables) => selectReplyDraftSuggestion(suggestionId),
-    onSuccess: (_selectedSuggestion: ReplyDraftSuggestion, { messageId }: SelectReplyDraftSuggestionVariables) => {
-      queryClient.setQueryData<ReplyDraftSuggestionListResponse>(emailKeys.replyDraftSuggestions(messageId), {
-        suggestions: [],
-      })
-      void queryClient.invalidateQueries({ queryKey: emailKeys.replyDraftSuggestions(messageId) })
     },
   }),
 }
@@ -99,8 +78,4 @@ export function useReviewMail() {
   return useMutation({
     mutationFn: (request: MailReviewRequest) => reviewMail(request),
   })
-}
-
-export function useSelectReplyDraftSuggestion() {
-  return useMutation(emailMutationOptions.selectReplyDraftSuggestion())
 }

--- a/src/mutations/emails.ts
+++ b/src/mutations/emails.ts
@@ -9,6 +9,7 @@ import {
   markThreadAsRead,
   markThreadAsUnread,
   reviewMail,
+  selectReplyDraftSuggestion,
   sendMail,
 } from "@/api/emails"
 import { queryClient } from "@/lib/query-client"
@@ -77,5 +78,11 @@ export function useSendMail() {
 export function useReviewMail() {
   return useMutation({
     mutationFn: (request: MailReviewRequest) => reviewMail(request),
+  })
+}
+
+export function useSelectReplyDraftSuggestion() {
+  return useMutation({
+    mutationFn: (suggestionId: string) => selectReplyDraftSuggestion(suggestionId),
   })
 }

--- a/src/mutations/emails.ts
+++ b/src/mutations/emails.ts
@@ -1,7 +1,12 @@
 import { useMutation } from "@tanstack/react-query"
 import { toast } from "sonner"
 
-import type { ComposeEmailData, MailReviewRequest } from "@/types/email"
+import type {
+  ComposeEmailData,
+  MailReviewRequest,
+  ReplyDraftSuggestion,
+  ReplyDraftSuggestionListResponse,
+} from "@/types/email"
 
 import {
   markMessageAsRead,
@@ -9,11 +14,17 @@ import {
   markThreadAsRead,
   markThreadAsUnread,
   reviewMail,
+  selectReplyDraftSuggestion,
   sendMail,
 } from "@/api/emails"
 import { queryClient } from "@/lib/query-client"
 import { emailKeys } from "@/queries/emails"
 import { labelKeys } from "@/queries/labels"
+
+interface SelectReplyDraftSuggestionVariables {
+  messageId: string
+  suggestionId: string
+}
 
 function invalidateEmailAndLabelQueries() {
   void queryClient.invalidateQueries({ queryKey: emailKeys.all() })
@@ -26,6 +37,16 @@ export const emailMutationOptions = {
     mutationFn: (data: ComposeEmailData) => sendMail(data),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: emailKeys.all() })
+    },
+  }),
+  selectReplyDraftSuggestion: () => ({
+    mutationKey: [...emailKeys.all(), "reply-draft-suggestions", "select"] as const,
+    mutationFn: ({ suggestionId }: SelectReplyDraftSuggestionVariables) => selectReplyDraftSuggestion(suggestionId),
+    onSuccess: (_selectedSuggestion: ReplyDraftSuggestion, { messageId }: SelectReplyDraftSuggestionVariables) => {
+      queryClient.setQueryData<ReplyDraftSuggestionListResponse>(emailKeys.replyDraftSuggestions(messageId), {
+        suggestions: [],
+      })
+      void queryClient.invalidateQueries({ queryKey: emailKeys.replyDraftSuggestions(messageId) })
     },
   }),
 }
@@ -78,4 +99,8 @@ export function useReviewMail() {
   return useMutation({
     mutationFn: (request: MailReviewRequest) => reviewMail(request),
   })
+}
+
+export function useSelectReplyDraftSuggestion() {
+  return useMutation(emailMutationOptions.selectReplyDraftSuggestion())
 }

--- a/src/queries/emails.ts
+++ b/src/queries/emails.ts
@@ -9,6 +9,8 @@ export const emailKeys = {
     [...emailKeys.all(), "mailbox", mailbox, params] as const,
   thread: (id: string) => [...emailKeys.all(), "thread", id] as const,
   replyDraftSuggestions: (messageId: string) => [...emailKeys.all(), "reply-draft-suggestions", messageId] as const,
+  selectedReplyDraftSuggestion: (suggestionId: string) =>
+    [...emailKeys.all(), "reply-draft-suggestions", "selected", suggestionId] as const,
 }
 
 export const emailQueries = {

--- a/src/queries/emails.ts
+++ b/src/queries/emails.ts
@@ -9,8 +9,6 @@ export const emailKeys = {
     [...emailKeys.all(), "mailbox", mailbox, params] as const,
   thread: (id: string) => [...emailKeys.all(), "thread", id] as const,
   replyDraftSuggestions: (messageId: string) => [...emailKeys.all(), "reply-draft-suggestions", messageId] as const,
-  selectedReplyDraftSuggestion: (suggestionId: string) =>
-    [...emailKeys.all(), "reply-draft-suggestions", "selected", suggestionId] as const,
 }
 
 export const emailQueries = {

--- a/src/queries/emails.ts
+++ b/src/queries/emails.ts
@@ -1,6 +1,6 @@
 import { queryOptions, useInfiniteQuery, useQuery } from "@tanstack/react-query"
 
-import { getMailboxThreads, getThreadDetail } from "@/api/emails"
+import { getMailboxThreads, getReplyDraftSuggestions, getThreadDetail } from "@/api/emails"
 import type { ListThreadsParams, SupportedMailboxId } from "@/types/email"
 
 export const emailKeys = {
@@ -8,6 +8,7 @@ export const emailKeys = {
   mailbox: (mailbox: SupportedMailboxId | null, params: Omit<ListThreadsParams, "marker">) =>
     [...emailKeys.all(), "mailbox", mailbox, params] as const,
   thread: (id: string) => [...emailKeys.all(), "thread", id] as const,
+  replyDraftSuggestions: (messageId: string) => [...emailKeys.all(), "reply-draft-suggestions", messageId] as const,
 }
 
 export const emailQueries = {
@@ -19,6 +20,12 @@ export const emailQueries = {
     queryOptions({
       queryKey: [...emailKeys.all(), "label-count", labelId] as const,
       queryFn: () => getMailboxThreads("inbox", { size: 1, labelId: [labelId] }),
+    }),
+  replyDraftSuggestions: (messageId: string) =>
+    queryOptions({
+      queryKey: emailKeys.replyDraftSuggestions(messageId),
+      queryFn: () => getReplyDraftSuggestions(messageId),
+      enabled: !!messageId,
     }),
 }
 
@@ -50,5 +57,12 @@ export function useThread(id: string | null) {
   return useQuery({
     ...emailQueries.thread(id ?? ""),
     enabled: id != null,
+  })
+}
+
+export function useReplyDraftSuggestions(messageId: string | null, enabled?: boolean) {
+  return useQuery({
+    ...emailQueries.replyDraftSuggestions(messageId ?? ""),
+    enabled: (enabled ?? true) && messageId != null,
   })
 }

--- a/src/routes/_authenticated/compose.tsx
+++ b/src/routes/_authenticated/compose.tsx
@@ -1,17 +1,20 @@
 import { createFileRoute } from "@tanstack/react-router"
 
+import { selectReplyDraftSuggestion } from "@/api/emails"
 import { ComposeEmail } from "@/components/compose/compose-email"
 import { ComposeReferenceThreadPanel } from "@/components/compose/compose-reference-thread-panel"
 import { Separator } from "@/components/ui/separator"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { formatMailAddressList } from "@/lib/mail-address"
-import { emailQueries } from "@/queries/emails"
+import { emailKeys, emailQueries } from "@/queries/emails"
 import { mailAccountQueries } from "@/queries/mail-accounts"
+import type { ReplyDraftSuggestionListResponse } from "@/types/email"
 
 interface ComposeRouteSearch {
   from?: string
   replyThreadId?: string
   replyMessageId?: string
+  replySuggestionId?: string
 }
 
 export const Route = createFileRoute("/_authenticated/compose")({
@@ -19,13 +22,41 @@ export const Route = createFileRoute("/_authenticated/compose")({
     const from = typeof search.from === "string" ? search.from.trim() : ""
     const replyThreadId = typeof search.replyThreadId === "string" ? search.replyThreadId.trim() : ""
     const replyMessageId = typeof search.replyMessageId === "string" ? search.replyMessageId.trim() : ""
+    const replySuggestionId = typeof search.replySuggestionId === "string" ? search.replySuggestionId.trim() : ""
     return {
       ...(from ? { from } : {}),
       ...(replyThreadId ? { replyThreadId } : {}),
       ...(replyMessageId ? { replyMessageId } : {}),
+      ...(replySuggestionId ? { replySuggestionId } : {}),
     }
   },
   loaderDeps: ({ search: { replyThreadId, replyMessageId } }) => ({ replyThreadId, replyMessageId }),
+  beforeLoad: async ({ context, search }) => {
+    const replySuggestionId = search.replySuggestionId
+
+    if (!replySuggestionId) {
+      return { replyDraftSuggestion: null }
+    }
+
+    try {
+      const replyDraftSuggestion = await context.queryClient.ensureQueryData({
+        queryKey: emailKeys.selectedReplyDraftSuggestion(replySuggestionId),
+        queryFn: () => selectReplyDraftSuggestion(replySuggestionId),
+        staleTime: Infinity,
+      })
+
+      if (search.replyMessageId) {
+        context.queryClient.setQueryData<ReplyDraftSuggestionListResponse>(
+          emailKeys.replyDraftSuggestions(search.replyMessageId),
+          { suggestions: [] }
+        )
+      }
+
+      return { replyDraftSuggestion }
+    } catch {
+      return { replyDraftSuggestion: null }
+    }
+  },
   loader: async ({ context, deps: { replyThreadId, replyMessageId } }) => {
     if (!replyThreadId) return null
 
@@ -62,6 +93,7 @@ function ComposePage() {
   const isMobile = useIsMobile()
   const { from, replyThreadId } = Route.useSearch()
   const loaderData = Route.useLoaderData()
+  const { replyDraftSuggestion } = Route.useRouteContext()
   const navigate = Route.useNavigate()
 
   const handleFromAddressChange = (nextFrom: string | null) => {
@@ -72,6 +104,8 @@ function ComposePage() {
   }
 
   const fromAddress = from ?? loaderData?.defaultFrom ?? null
+  const initialSubject = replyDraftSuggestion?.subject ?? loaderData?.replySubject
+  const initialBody = replyDraftSuggestion?.body
 
   if (isMobile) {
     return (
@@ -81,8 +115,9 @@ function ComposePage() {
           onFromAddressChange={handleFromAddressChange}
           messageId={loaderData?.messageId}
           initialTo={loaderData?.replyTo}
-          initialSubject={loaderData?.replySubject}
+          initialSubject={initialSubject}
           initialCc={loaderData?.replyCc}
+          initialBody={initialBody}
         />
       </div>
     )
@@ -100,8 +135,9 @@ function ComposePage() {
           onFromAddressChange={handleFromAddressChange}
           messageId={loaderData?.messageId}
           initialTo={loaderData?.replyTo}
-          initialSubject={loaderData?.replySubject}
+          initialSubject={initialSubject}
           initialCc={loaderData?.replyCc}
+          initialBody={initialBody}
         />
       </div>
     </div>

--- a/src/routes/_authenticated/compose.tsx
+++ b/src/routes/_authenticated/compose.tsx
@@ -1,20 +1,17 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, useLocation } from "@tanstack/react-router"
 
-import { selectReplyDraftSuggestion } from "@/api/emails"
 import { ComposeEmail } from "@/components/compose/compose-email"
 import { ComposeReferenceThreadPanel } from "@/components/compose/compose-reference-thread-panel"
 import { Separator } from "@/components/ui/separator"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { formatMailAddressList } from "@/lib/mail-address"
-import { emailKeys, emailQueries } from "@/queries/emails"
+import { emailQueries } from "@/queries/emails"
 import { mailAccountQueries } from "@/queries/mail-accounts"
-import type { ReplyDraftSuggestionListResponse } from "@/types/email"
 
 interface ComposeRouteSearch {
   from?: string
   thread?: string
   message?: string
-  suggestion?: string
 }
 
 export const Route = createFileRoute("/_authenticated/compose")({
@@ -22,42 +19,14 @@ export const Route = createFileRoute("/_authenticated/compose")({
     const from = typeof search.from === "string" ? search.from.trim() : ""
     const thread = typeof search.thread === "string" ? search.thread.trim() : ""
     const message = typeof search.message === "string" ? search.message.trim() : ""
-    const suggestion = typeof search.suggestion === "string" ? search.suggestion.trim() : ""
 
     return {
       ...(from ? { from } : {}),
       ...(thread ? { thread } : {}),
       ...(message ? { message } : {}),
-      ...(suggestion ? { suggestion } : {}),
     }
   },
   loaderDeps: ({ search: { thread, message } }) => ({ thread, message }),
-  beforeLoad: async ({ context, search }) => {
-    const suggestionId = search.suggestion
-
-    if (!suggestionId) {
-      return { replyDraftSuggestion: null }
-    }
-
-    try {
-      const replyDraftSuggestion = await context.queryClient.ensureQueryData({
-        queryKey: emailKeys.selectedReplyDraftSuggestion(suggestionId),
-        queryFn: () => selectReplyDraftSuggestion(suggestionId),
-        staleTime: Infinity,
-      })
-
-      if (search.message) {
-        context.queryClient.setQueryData<ReplyDraftSuggestionListResponse>(
-          emailKeys.replyDraftSuggestions(search.message),
-          { suggestions: [] }
-        )
-      }
-
-      return { replyDraftSuggestion }
-    } catch {
-      return { replyDraftSuggestion: null }
-    }
-  },
   loader: async ({ context, deps: { thread: threadId, message: messageId } }) => {
     if (!threadId) return null
 
@@ -94,12 +63,15 @@ function ComposePage() {
   const isMobile = useIsMobile()
   const { from, thread, message } = Route.useSearch()
   const loaderData = Route.useLoaderData()
-  const { replyDraftSuggestion } = Route.useRouteContext()
+  const replyDraftSuggestion = useLocation({
+    select: (location) => location.state.replyDraftSuggestion ?? null,
+  })
   const navigate = Route.useNavigate()
 
   const handleFromAddressChange = (nextFrom: string | null) => {
     navigate({
       search: (prev) => ({ ...prev, from: nextFrom ?? undefined }),
+      state: true,
       replace: true,
     })
   }

--- a/src/routes/_authenticated/compose.tsx
+++ b/src/routes/_authenticated/compose.tsx
@@ -12,42 +12,43 @@ import type { ReplyDraftSuggestionListResponse } from "@/types/email"
 
 interface ComposeRouteSearch {
   from?: string
-  replyThreadId?: string
-  replyMessageId?: string
-  replySuggestionId?: string
+  thread?: string
+  message?: string
+  suggestion?: string
 }
 
 export const Route = createFileRoute("/_authenticated/compose")({
   validateSearch: (search: Record<string, unknown>): ComposeRouteSearch => {
     const from = typeof search.from === "string" ? search.from.trim() : ""
-    const replyThreadId = typeof search.replyThreadId === "string" ? search.replyThreadId.trim() : ""
-    const replyMessageId = typeof search.replyMessageId === "string" ? search.replyMessageId.trim() : ""
-    const replySuggestionId = typeof search.replySuggestionId === "string" ? search.replySuggestionId.trim() : ""
+    const thread = typeof search.thread === "string" ? search.thread.trim() : ""
+    const message = typeof search.message === "string" ? search.message.trim() : ""
+    const suggestion = typeof search.suggestion === "string" ? search.suggestion.trim() : ""
+
     return {
       ...(from ? { from } : {}),
-      ...(replyThreadId ? { replyThreadId } : {}),
-      ...(replyMessageId ? { replyMessageId } : {}),
-      ...(replySuggestionId ? { replySuggestionId } : {}),
+      ...(thread ? { thread } : {}),
+      ...(message ? { message } : {}),
+      ...(suggestion ? { suggestion } : {}),
     }
   },
-  loaderDeps: ({ search: { replyThreadId, replyMessageId } }) => ({ replyThreadId, replyMessageId }),
+  loaderDeps: ({ search: { thread, message } }) => ({ thread, message }),
   beforeLoad: async ({ context, search }) => {
-    const replySuggestionId = search.replySuggestionId
+    const suggestionId = search.suggestion
 
-    if (!replySuggestionId) {
+    if (!suggestionId) {
       return { replyDraftSuggestion: null }
     }
 
     try {
       const replyDraftSuggestion = await context.queryClient.ensureQueryData({
-        queryKey: emailKeys.selectedReplyDraftSuggestion(replySuggestionId),
-        queryFn: () => selectReplyDraftSuggestion(replySuggestionId),
+        queryKey: emailKeys.selectedReplyDraftSuggestion(suggestionId),
+        queryFn: () => selectReplyDraftSuggestion(suggestionId),
         staleTime: Infinity,
       })
 
-      if (search.replyMessageId) {
+      if (search.message) {
         context.queryClient.setQueryData<ReplyDraftSuggestionListResponse>(
-          emailKeys.replyDraftSuggestions(search.replyMessageId),
+          emailKeys.replyDraftSuggestions(search.message),
           { suggestions: [] }
         )
       }
@@ -57,16 +58,16 @@ export const Route = createFileRoute("/_authenticated/compose")({
       return { replyDraftSuggestion: null }
     }
   },
-  loader: async ({ context, deps: { replyThreadId, replyMessageId } }) => {
-    if (!replyThreadId) return null
+  loader: async ({ context, deps: { thread: threadId, message: messageId } }) => {
+    if (!threadId) return null
 
     const [thread, accounts] = await Promise.all([
-      context.queryClient.ensureQueryData(emailQueries.thread(replyThreadId)),
+      context.queryClient.ensureQueryData(emailQueries.thread(threadId)),
       context.queryClient.ensureQueryData(mailAccountQueries.list()),
     ])
 
-    const replyMessage = replyMessageId
-      ? thread.messages.find((message) => message.id === replyMessageId)
+    const replyMessage = messageId
+      ? thread.messages.find((message) => message.id === messageId)
       : thread.messages.at(-1)
     if (!replyMessage) return null
 
@@ -91,7 +92,7 @@ export const Route = createFileRoute("/_authenticated/compose")({
 
 function ComposePage() {
   const isMobile = useIsMobile()
-  const { from, replyThreadId } = Route.useSearch()
+  const { from, thread } = Route.useSearch()
   const loaderData = Route.useLoaderData()
   const { replyDraftSuggestion } = Route.useRouteContext()
   const navigate = Route.useNavigate()
@@ -126,7 +127,7 @@ function ComposePage() {
   return (
     <div className="flex min-h-0 w-full min-w-0 flex-1 overflow-hidden">
       <div className="min-h-0 min-w-0 basis-1/2 border-r-0">
-        <ComposeReferenceThreadPanel threadId={replyThreadId ?? null} />
+        <ComposeReferenceThreadPanel threadId={thread ?? null} />
       </div>
       <Separator orientation="vertical" />
       <div className="min-h-0 min-w-0 basis-2/3">

--- a/src/routes/_authenticated/compose.tsx
+++ b/src/routes/_authenticated/compose.tsx
@@ -92,7 +92,7 @@ export const Route = createFileRoute("/_authenticated/compose")({
 
 function ComposePage() {
   const isMobile = useIsMobile()
-  const { from, thread } = Route.useSearch()
+  const { from, thread, message } = Route.useSearch()
   const loaderData = Route.useLoaderData()
   const { replyDraftSuggestion } = Route.useRouteContext()
   const navigate = Route.useNavigate()
@@ -127,7 +127,7 @@ function ComposePage() {
   return (
     <div className="flex min-h-0 w-full min-w-0 flex-1 overflow-hidden">
       <div className="min-h-0 min-w-0 basis-1/2 border-r-0">
-        <ComposeReferenceThreadPanel threadId={thread ?? null} />
+        <ComposeReferenceThreadPanel threadId={thread ?? null} messageId={message ?? null} />
       </div>
       <Separator orientation="vertical" />
       <div className="min-h-0 min-w-0 basis-2/3">

--- a/src/routes/_authenticated/mail/$mailbox.tsx
+++ b/src/routes/_authenticated/mail/$mailbox.tsx
@@ -105,6 +105,7 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
     labelId,
     labelGroupId,
     thread: selectedThreadId = null,
+    message: selectedMessageId = null,
   } = Route.useSearch()
   const navigate = Route.useNavigate()
   const queryClient = useQueryClient()
@@ -216,6 +217,7 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
           search: (previous) => ({
             ...previous,
             thread: threadId,
+            message: undefined,
           }),
         })
       }}
@@ -243,11 +245,13 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
         {hasSelection ? (
           <ThreadDetail
             threadId={visibleSelectedThreadId}
+            messageId={selectedMessageId}
             onClose={() => {
               void navigate({
                 search: (previous) => ({
                   ...previous,
                   thread: undefined,
+                  message: undefined,
                 }),
                 replace: true,
               })
@@ -276,11 +280,13 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
           <div className="min-h-0 min-w-0 basis-2/3">
             <ThreadDetail
               threadId={visibleSelectedThreadId}
+              messageId={selectedMessageId}
               onClose={() => {
                 void navigate({
                   search: (previous) => ({
                     ...previous,
                     thread: undefined,
+                    message: undefined,
                   }),
                   replace: true,
                 })

--- a/src/types/email.ts
+++ b/src/types/email.ts
@@ -101,6 +101,17 @@ export interface UnreadCountResponse {
   unreadCount: number
 }
 
+export interface ReplyDraftSuggestion {
+  id: string
+  type: string
+  subject: string
+  body: string
+}
+
+export interface ReplyDraftSuggestionListResponse {
+  suggestions: ReplyDraftSuggestion[]
+}
+
 export interface ComposeInlineImage {
   file: File
   cid: string

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -1,5 +1,13 @@
 import type { QueryClient } from "@tanstack/react-query"
 
+import type { ReplyDraftSuggestion } from "@/types/email"
+
 export interface RouterContext {
   queryClient: QueryClient
+}
+
+declare module "@tanstack/history" {
+  interface HistoryState {
+    replyDraftSuggestion?: ReplyDraftSuggestion | null
+  }
 }


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#26
- mailsangja/docs4capstone#27

### 📌 Task

- Closes #87
- Closes #88
- Closes #89

## 💡 작업 내용

- AI 답장 추천 UI 및 API 구현
- 답장 페이지 쿼리 파라미터 리팩토링
- 스레드 상세 조회 컴포넌트 메시지 기준 펼침 상태 적용
- 답장 작성시 제목 수정 불가능하도록 수정

## 📝 추가 설명

- 메일 메시지 기준 AI 추천 답장 목록 조회 API와 React Query hook을 추가했습니다.
- 스레드 상세 하단에 AI 답장 옵션 액션을 추가하고, 데스크톱에서는 hover popover, 모바일에서는 bottom sheet로 추천 답장 미리보기를 제공하도록 구현했습니다.
- 추천 답장을 선택하면 선택 API를 호출한 뒤 메일 작성 페이지로 이동하고, 추천 제목/본문을 답장 초안의 초기값으로 주입하도록 연결했습니다.
- 답장 작성 경로의 query parameter를 `thread`, `message`, `suggestion` 중심으로 정리하고, 메일 작성 화면의 참조 스레드 패널도 선택 메시지를 기준으로 표시하도록 개선했습니다.
- 스레드 상세와 작성 페이지 참조 패널의 메시지 기본 펼침 상태를 공통 hook으로 분리해, 선택 메시지와 읽지 않은 메시지가 기본으로 펼쳐지도록 했습니다.
- 답장 작성 모드에서는 기존 답장 제목을 유지하도록 AI 초안 스트리밍 subject 반영을 막고, 제목 입력도 수정 불가 처리했습니다.

## 🖼️ 스크린샷

| 데스크탑 (Popover) | 모바일 (Bottom Sheet) |
|--------|--------|
| <img width="506" height="395" alt="image" src="https://github.com/user-attachments/assets/246b4175-0492-4503-a44c-1e1c9fed8941" /> | <img width="407" height="667" alt="image" src="https://github.com/user-attachments/assets/5bb7feb8-5911-400c-b3df-f8c24c08f933" /> | 