### PR TITLE
[STORY-902] 서비스 이용약관 및 사용자 인증 페이지 개선

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,8 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as TermsRouteImport } from './routes/terms'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as GuestRouteImport } from './routes/_guest'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as IndexRouteImport } from './routes/index'
@@ -24,6 +26,16 @@ import { Route as AuthenticatedMailMailboxRouteImport } from './routes/_authenti
 import { Route as AuthenticatedSettingsLabelIndexRouteImport } from './routes/_authenticated/settings/label/index'
 import { Route as AuthenticatedSettingsLabelLabelIdRouteImport } from './routes/_authenticated/settings/label/$labelId'
 
+const TermsRoute = TermsRouteImport.update({
+  id: '/terms',
+  path: '/terms',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const GuestRoute = GuestRouteImport.update({
   id: '/_guest',
   getParentRoute: () => rootRouteImport,
@@ -100,6 +112,8 @@ const AuthenticatedSettingsLabelLabelIdRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/privacy': typeof PrivacyRoute
+  '/terms': typeof TermsRoute
   '/compose': typeof AuthenticatedComposeRoute
   '/mail': typeof AuthenticatedMailRouteWithChildren
   '/settings': typeof AuthenticatedSettingsRouteWithChildren
@@ -114,6 +128,8 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/privacy': typeof PrivacyRoute
+  '/terms': typeof TermsRoute
   '/compose': typeof AuthenticatedComposeRoute
   '/login': typeof GuestLoginRoute
   '/signup': typeof GuestSignupRoute
@@ -129,6 +145,8 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/_authenticated': typeof AuthenticatedRouteWithChildren
   '/_guest': typeof GuestRouteWithChildren
+  '/privacy': typeof PrivacyRoute
+  '/terms': typeof TermsRoute
   '/_authenticated/compose': typeof AuthenticatedComposeRoute
   '/_authenticated/mail': typeof AuthenticatedMailRouteWithChildren
   '/_authenticated/settings': typeof AuthenticatedSettingsRouteWithChildren
@@ -145,6 +163,8 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/privacy'
+    | '/terms'
     | '/compose'
     | '/mail'
     | '/settings'
@@ -159,6 +179,8 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/privacy'
+    | '/terms'
     | '/compose'
     | '/login'
     | '/signup'
@@ -173,6 +195,8 @@ export interface FileRouteTypes {
     | '/'
     | '/_authenticated'
     | '/_guest'
+    | '/privacy'
+    | '/terms'
     | '/_authenticated/compose'
     | '/_authenticated/mail'
     | '/_authenticated/settings'
@@ -190,10 +214,26 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
   GuestRoute: typeof GuestRouteWithChildren
+  PrivacyRoute: typeof PrivacyRoute
+  TermsRoute: typeof TermsRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/terms': {
+      id: '/terms'
+      path: '/terms'
+      fullPath: '/terms'
+      preLoaderRoute: typeof TermsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_guest': {
       id: '/_guest'
       path: ''
@@ -360,6 +400,8 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
   GuestRoute: GuestRouteWithChildren,
+  PrivacyRoute: PrivacyRoute,
+  TermsRoute: TermsRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/_guest/login.tsx
+++ b/src/routes/_guest/login.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react"
 import { createFileRoute, Link } from "@tanstack/react-router"
+import { Eye, EyeOff, Loader2 } from "lucide-react"
 
-import { Button, buttonVariants } from "@/components/ui/button"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { cn } from "@/lib/utils"
 import { useLogin } from "@/mutations/auth"
 
 export const Route = createFileRoute("/_guest/login")({
@@ -14,6 +15,7 @@ export const Route = createFileRoute("/_guest/login")({
 function LoginPage() {
   const [username, setUsername] = useState("")
   const [password, setPassword] = useState("")
+  const [showPassword, setShowPassword] = useState(false)
   const loginMutation = useLogin()
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -22,47 +24,73 @@ function LoginPage() {
   }
 
   return (
-    <div className="flex flex-col gap-12">
-      <h1 className="text-2xl font-bold">로그인</h1>
+    <Card className="bg-transparent">
+      <CardHeader className="items-center justify-items-center text-center">
+        <CardTitle className="text-xl font-bold tracking-tight">메일상자</CardTitle>
+        <CardDescription>계정에 로그인하세요</CardDescription>
+      </CardHeader>
 
-      <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="username">아이디</Label>
-          <Input
-            id="username"
-            type="text"
-            placeholder="아이디를 입력하세요"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            autoComplete="username"
-            required
-          />
-        </div>
+      <CardContent className="pt-2">
+        <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="username">아이디</Label>
+            <Input
+              id="username"
+              type="text"
+              placeholder="아이디를 입력하세요"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              autoComplete="username"
+              required
+            />
+          </div>
 
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="password">비밀번호</Label>
-          <Input
-            id="password"
-            type="password"
-            placeholder="비밀번호를 입력하세요"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            autoComplete="current-password"
-            required
-          />
-        </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="password">비밀번호</Label>
+            <div className="relative">
+              <Input
+                id="password"
+                type={showPassword ? "text" : "password"}
+                placeholder="비밀번호를 입력하세요"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="pr-10"
+                autoComplete="current-password"
+                required
+              />
+              <button
+                type="button"
+                className="absolute top-1/2 right-2.5 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                onClick={() => setShowPassword((v) => !v)}
+                tabIndex={-1}
+              >
+                {showPassword ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+              </button>
+            </div>
+          </div>
 
-        {loginMutation.isError && <p className="text-sm text-destructive">아이디 또는 비밀번호가 올바르지 않습니다.</p>}
+          {loginMutation.isError && (
+            <p className="flex items-center gap-1.5 text-sm text-destructive">
+              <span className="inline-block size-1.5 shrink-0 rounded-full bg-destructive" />
+              아이디 또는 비밀번호가 올바르지 않습니다.
+            </p>
+          )}
 
-        <div className="mt-2 flex flex-col gap-3">
-          <Button type="submit" size="lg" className="w-full" disabled={loginMutation.isPending}>
-            {loginMutation.isPending ? "로그인 중..." : "로그인"}
+          <Button type="submit" size="lg" className="mt-1 w-full" disabled={loginMutation.isPending}>
+            {loginMutation.isPending && <Loader2 className="animate-spin" />}
+            로그인
           </Button>
-          <Link to="/signup" className={cn(buttonVariants({ variant: "outline", size: "lg" }), "w-full")}>
+        </form>
+      </CardContent>
+
+      <CardFooter className="flex-col gap-3">
+        <p className="text-sm text-muted-foreground">
+          계정이 없으신가요? &nbsp;
+          <Link to="/signup" className="font-medium text-primary hover:underline">
             회원가입
           </Link>
-        </div>
-      </form>
-    </div>
+        </p>
+      </CardFooter>
+    </Card>
   )
 }

--- a/src/routes/_guest/signup.tsx
+++ b/src/routes/_guest/signup.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react"
-import { createFileRoute } from "@tanstack/react-router"
-import { Eye, EyeOff } from "lucide-react"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { Eye, EyeOff, Loader2 } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useRegister } from "@/mutations/auth"
@@ -18,6 +20,7 @@ function SignUpPage() {
   const [passwordConfirm, setPasswordConfirm] = useState("")
   const [showPassword, setShowPassword] = useState(false)
   const [showPasswordConfirm, setShowPasswordConfirm] = useState(false)
+  const [agreedToTerms, setAgreedToTerms] = useState(false)
 
   const registerMutation = useRegister()
 
@@ -26,7 +29,8 @@ function SignUpPage() {
     username.trim() !== "" &&
     password !== "" &&
     passwordConfirm !== "" &&
-    password === passwordConfirm
+    password === passwordConfirm &&
+    agreedToTerms
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -34,98 +38,130 @@ function SignUpPage() {
   }
 
   return (
-    <div className="flex flex-col gap-12">
-      <h1 className="text-2xl font-bold">회원가입</h1>
+    <Card className="bg-transparent">
+      <CardHeader className="items-center justify-items-center text-center">
+        <CardTitle className="text-xl font-bold tracking-tight">회원가입</CardTitle>
+        <CardDescription>새 계정을 만들어 시작하세요</CardDescription>
+      </CardHeader>
 
-      <form className="flex flex-col gap-6" onSubmit={handleSubmit}>
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="name">
-            이름<span className="text-destructive">*</span>
-          </Label>
-          <Input
-            id="name"
-            type="text"
-            placeholder="이름"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-            autoComplete="name"
-          />
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="username">
-            아이디<span className="text-destructive">*</span>
-          </Label>
-          <Input
-            id="username"
-            type="text"
-            placeholder="아이디"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            required
-          />
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="password">
-            비밀번호<span className="text-destructive">*</span>
-          </Label>
-          <div className="relative">
+      <CardContent className="pt-2">
+        <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="name">
+              이름<span className="text-destructive">*</span>
+            </Label>
             <Input
-              id="password"
-              type={showPassword ? "text" : "password"}
-              placeholder="비밀번호"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="pr-10"
+              id="name"
+              type="text"
+              placeholder="이름"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
               required
-              autoComplete="new-password"
+              autoComplete="name"
             />
-            <button
-              type="button"
-              className="absolute top-1/2 right-2.5 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-              onClick={() => setShowPassword((v) => !v)}
-              tabIndex={-1}
-            >
-              {showPassword ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
-            </button>
           </div>
-        </div>
 
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="password-confirm">
-            비밀번호 확인<span className="text-destructive">*</span>
-          </Label>
-          <div className="relative">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="username">
+              아이디<span className="text-destructive">*</span>
+            </Label>
             <Input
-              id="password-confirm"
-              type={showPasswordConfirm ? "text" : "password"}
-              placeholder="비밀번호 확인"
-              value={passwordConfirm}
-              onChange={(e) => setPasswordConfirm(e.target.value)}
-              className="pr-10"
+              id="username"
+              type="text"
+              placeholder="아이디"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
               required
             />
-            <button
-              type="button"
-              className="absolute top-1/2 right-2.5 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-              onClick={() => setShowPasswordConfirm((v) => !v)}
-              tabIndex={-1}
-            >
-              {showPasswordConfirm ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
-            </button>
           </div>
-        </div>
 
-        {registerMutation.isError && (
-          <p className="text-sm text-destructive">회원가입에 실패했습니다. 다시 시도해주세요.</p>
-        )}
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="password">
+              비밀번호<span className="text-destructive">*</span>
+            </Label>
+            <div className="relative">
+              <Input
+                id="password"
+                type={showPassword ? "text" : "password"}
+                placeholder="비밀번호"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="pr-10"
+                required
+                autoComplete="new-password"
+              />
+              <button
+                type="button"
+                className="absolute top-1/2 right-2.5 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                onClick={() => setShowPassword((v) => !v)}
+                tabIndex={-1}
+              >
+                {showPassword ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+              </button>
+            </div>
+          </div>
 
-        <Button type="submit" size="lg" className="mt-4 w-full" disabled={!isFormValid || registerMutation.isPending}>
-          {registerMutation.isPending ? "가입 중..." : "회원가입"}
-        </Button>
-      </form>
-    </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="password-confirm">
+              비밀번호 확인<span className="text-destructive">*</span>
+            </Label>
+            <div className="relative">
+              <Input
+                id="password-confirm"
+                type={showPasswordConfirm ? "text" : "password"}
+                placeholder="비밀번호 확인"
+                value={passwordConfirm}
+                onChange={(e) => setPasswordConfirm(e.target.value)}
+                className="pr-10"
+                required
+              />
+              <button
+                type="button"
+                className="absolute top-1/2 right-2.5 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                onClick={() => setShowPasswordConfirm((v) => !v)}
+                tabIndex={-1}
+              >
+                {showPasswordConfirm ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+              </button>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Checkbox id="terms" checked={agreedToTerms} onCheckedChange={(v) => setAgreedToTerms(v === true)} />
+            <Label htmlFor="terms" className="gap-1 text-xs leading-relaxed font-normal">
+              <Link to="/terms" className="font-medium text-primary hover:underline" target="_blank">
+                서비스 이용약관
+              </Link>
+              및
+              <Link to="/privacy" className="font-medium text-primary hover:underline" target="_blank">
+                개인정보처리방침
+              </Link>
+              에 동의합니다.
+            </Label>
+          </div>
+
+          {registerMutation.isError && (
+            <p className="flex items-center gap-1.5 text-sm text-destructive">
+              <span className="inline-block size-1.5 shrink-0 rounded-full bg-destructive" />
+              회원가입에 실패했습니다. 다시 시도해주세요.
+            </p>
+          )}
+
+          <Button type="submit" size="lg" className="mt-1 w-full" disabled={!isFormValid || registerMutation.isPending}>
+            {registerMutation.isPending && <Loader2 className="animate-spin" />}
+            회원가입
+          </Button>
+        </form>
+      </CardContent>
+
+      <CardFooter className="flex-col gap-3">
+        <p className="text-sm text-muted-foreground">
+          이미 계정이 있으신가요? &nbsp;
+          <Link to="/login" className="font-medium text-primary hover:underline">
+            로그인
+          </Link>
+        </p>
+      </CardFooter>
+    </Card>
   )
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -425,7 +425,15 @@ function RouteComponent() {
             <Mail className="size-4" />
             <span>메일상자</span>
           </div>
-          <span>© 2026 메일상자. All rights reserved.</span>
+          <div className="flex items-center gap-4">
+            <Link to="/terms" className="transition-colors hover:text-foreground">
+              이용약관
+            </Link>
+            <Link to="/privacy" className="transition-colors hover:text-foreground">
+              개인정보처리방침
+            </Link>
+            <span>© 2026 메일상자. All rights reserved.</span>
+          </div>
         </div>
       </footer>
     </div>

--- a/src/routes/privacy.tsx
+++ b/src/routes/privacy.tsx
@@ -1,0 +1,422 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { Mail } from "lucide-react"
+
+export const Route = createFileRoute("/privacy")({
+  component: PrivacyPage,
+})
+
+function PrivacyPage() {
+  return (
+    <div className="min-h-svh bg-background">
+      <header className="sticky inset-x-0 top-0 z-50 border-b bg-background/80 backdrop-blur-md">
+        <div className="mx-auto flex max-w-3xl items-center gap-3 px-6 py-4">
+          <Link
+            to="/"
+            className="flex items-center gap-2 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <Mail className="size-5 text-primary" />
+            <span className="font-semibold">메일상자</span>
+          </Link>
+          <div className="h-4 w-px bg-border" />
+          <span className="text-sm font-medium">개인정보처리방침</span>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-6 py-12">
+        <h1 className="text-2xl font-bold">메일상자 개인정보처리방침</h1>
+        <p className="mt-2 text-sm text-muted-foreground">시행일: 2026년 05월 25일</p>
+
+        <div className="mt-10 space-y-10 text-[15px] leading-7 text-foreground/90">
+          <Section title="제1조(목적)">
+            <p>
+              메일상자 운영팀(이하 &quot;회사&quot;라 합니다)은 메일상자 서비스(이하 &quot;서비스&quot;라 합니다)를
+              제공함에 있어 이용자의 개인정보 및 Google 사용자 데이터를 안전하게 보호하기 위해 본 개인정보처리방침을
+              수립합니다.
+            </p>
+            <p className="mt-2">
+              본 개인정보처리방침은 회사가 어떤 정보를 수집하고, 어떤 목적으로 이용하며, 어떻게 보관 및 삭제하는지를
+              설명합니다.
+            </p>
+          </Section>
+
+          <Section title="제2조(수집하는 개인정보 항목)">
+            <p className="mb-3">회사는 서비스 제공을 위해 다음 각 호의 개인정보를 수집할 수 있습니다.</p>
+            <ol className="list-decimal space-y-4 pl-5">
+              <li>
+                <span className="font-medium">Google 계정 연동 시 수집하는 정보</span>
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>Google 계정 이메일 주소</li>
+                  <li>Google 계정 이메일 검증 여부</li>
+                </ul>
+              </li>
+              <li>
+                <span className="font-medium">서비스 이용 과정에서 수집되는 정보</span>
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>서비스 내 사용자 식별자</li>
+                  <li>로그인 기록</li>
+                  <li>서비스 이용 기록</li>
+                  <li>API 요청 기록</li>
+                  <li>오류 로그</li>
+                  <li>접속 기기 및 브라우저 정보</li>
+                  <li>IP 주소</li>
+                </ul>
+              </li>
+              <li>
+                <span className="font-medium">문의 또는 데이터 삭제 요청 시 수집하는 정보</span>
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>이메일 주소</li>
+                  <li>문의 내용</li>
+                  <li>본인 확인을 위해 필요한 정보</li>
+                </ul>
+              </li>
+            </ol>
+          </Section>
+
+          <Section title="제3조(Google 사용자 데이터 수집 항목)">
+            <p className="mb-3">
+              회사는 이용자가 Google OAuth 동의 화면에서 허용한 권한 범위 내에서 다음 각 호의 Google 사용자 데이터에
+              접근할 수 있습니다.
+            </p>
+            <ol className="list-decimal space-y-4 pl-5">
+              <li>
+                <span className="font-medium">Gmail 메일 데이터</span>
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>메일 제목</li>
+                  <li>메일 본문</li>
+                  <li>발신자 정보</li>
+                  <li>수신자 정보</li>
+                  <li>참조 및 숨은참조 정보</li>
+                  <li>수신 및 발신 시각</li>
+                  <li>메일 스레드 정보</li>
+                  <li>첨부파일 메타데이터</li>
+                </ul>
+              </li>
+              <li>
+                <span className="font-medium">Gmail 상태 및 라벨 데이터</span>
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>읽음/안읽음 상태</li>
+                  <li>Gmail 라벨 정보</li>
+                  <li>메일 라벨 및 상태 정보</li>
+                  <li>메일 삭제 또는 휴지통 이동/복구 상태</li>
+                </ul>
+              </li>
+              <li>
+                <span className="font-medium">메일 발송 관련 데이터</span>
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>이용자가 작성한 메일 제목</li>
+                  <li>이용자가 작성한 메일 본문</li>
+                  <li>수신자, 참조, 숨은참조 정보</li>
+                  <li>이용자가 발송 요청한 메일 정보</li>
+                </ul>
+              </li>
+              <li>
+                <span className="font-medium">Google 주소록 및 기타 연락처 데이터</span>
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>연락처 이름</li>
+                  <li>연락처 이메일 주소</li>
+                  <li>Google 주소록 연락처 정보</li>
+                  <li>Google 기타 연락처 정보</li>
+                </ul>
+              </li>
+            </ol>
+            <p className="mt-3 text-sm text-muted-foreground">
+              회사는 이용자가 허용하지 않은 Google 사용자 데이터에는 접근하지 않습니다.
+            </p>
+          </Section>
+
+          <Section title="제4조(개인정보 및 Google 사용자 데이터의 이용 목적)">
+            <p className="mb-3">
+              회사는 수집한 개인정보 및 Google 사용자 데이터를 다음 각 호의 목적을 위해 이용합니다.
+            </p>
+            <ol className="list-decimal space-y-1 pl-5">
+              <li>회원 식별 및 Google 계정 연동</li>
+              <li>여러 Gmail 계정의 통합 인박스 제공</li>
+              <li>메일 목록 및 상세 내용 조회</li>
+              <li>메일 스레드 조회</li>
+              <li>메일 검색 기능 제공</li>
+              <li>메일 라벨링 및 자동 분류 기능 제공</li>
+              <li>읽음/안읽음, 라벨 변경, 휴지통 이동/복구 등 Gmail 상태 동기화</li>
+              <li>AI 기반 메일 초안 작성, 답장 추천 기능 제공</li>
+              <li>이용자가 작성한 메일 또는 답장의 Gmail 발송</li>
+              <li>메일 작성 및 수신자 추천 등 주소록 기반 기능 제공</li>
+              <li>서비스 장애 분석 및 품질 개선</li>
+              <li>보안 모니터링 및 비정상 이용 탐지</li>
+              <li>이용자 문의 및 데이터 삭제 요청 처리</li>
+            </ol>
+            <p className="mt-3 text-sm font-medium text-muted-foreground">
+              회사는 Google 사용자 데이터를 광고 목적으로 사용하지 않으며, 제3자에게 판매하지 않습니다.
+            </p>
+          </Section>
+
+          <Section title="제5조(Google OAuth Scope별 사용 목적)">
+            <p className="mb-3">회사는 서비스 제공에 필요한 최소한의 Google OAuth Scope만 요청합니다.</p>
+            <ol className="list-decimal space-y-4 pl-5">
+              <li>
+                <code className="rounded bg-muted px-1.5 py-0.5 text-xs">openid</code>
+                <p className="mt-1">Google 계정 연동 과정에서 이용자 식별을 위해 사용합니다.</p>
+              </li>
+              <li>
+                <code className="rounded bg-muted px-1.5 py-0.5 text-xs">email</code>
+                <p className="mt-1">연동된 Google 계정의 이메일 주소 및 이메일 검증 여부를 확인하기 위해 사용합니다.</p>
+              </li>
+              <li>
+                <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                  https://www.googleapis.com/auth/gmail.modify
+                </code>
+                <p className="mt-1">
+                  Gmail 메일 목록, 메일 본문, 스레드, 라벨 및 상태 정보를 조회하고, 메일 발송, 읽음/안읽음 처리, 라벨
+                  변경, 휴지통 이동/복구 등 서비스 내 Gmail 기능 제공을 위해 사용합니다.
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  회사는 이용자의 명시적인 조작 또는 서비스 제공에 필요한 동기화 범위 내에서만 Gmail 데이터를
+                  처리합니다.
+                </p>
+              </li>
+              <li>
+                <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                  https://www.googleapis.com/auth/contacts.readonly
+                </code>
+                <p className="mt-1">
+                  이용자의 Google 주소록 연락처를 조회하여 메일 작성 및 수신자 추천 등 주소록 기반 기능을 제공하기 위해
+                  사용합니다.
+                </p>
+              </li>
+              <li>
+                <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                  https://www.googleapis.com/auth/contacts.other.readonly
+                </code>
+                <p className="mt-1">
+                  이용자의 Google 기타 연락처를 조회하여 메일 작성 및 수신자 추천 등 주소록 기반 기능을 제공하기 위해
+                  사용합니다.
+                </p>
+              </li>
+            </ol>
+            <p className="mt-3 text-sm text-muted-foreground">
+              회사는 <code className="rounded bg-muted px-1 py-0.5 text-xs">https://mail.google.com/</code>과 같이
+              서비스 기능 제공 범위를 초과하는 권한은 요청하지 않으며, 서비스 제공에 필요한 최소 범위의 권한만
+              요청합니다.
+            </p>
+          </Section>
+
+          <Section title="제6조(Google API Services User Data Policy 준수)">
+            <p className="mb-3">
+              회사는 Google API를 통해 수신한 사용자 데이터를 Google API Services User Data Policy 및 Limited Use
+              요구사항에 따라 처리합니다.
+            </p>
+            <p className="mb-2">회사는 Google 사용자 데이터에 대해 다음 각 호의 원칙을 준수합니다.</p>
+            <ol className="list-decimal space-y-1 pl-5">
+              <li>이용자가 명시적으로 동의한 서비스 기능 제공 목적에 한하여 사용합니다.</li>
+              <li>Google 사용자 데이터를 광고 목적으로 사용하지 않습니다.</li>
+              <li>Google 사용자 데이터를 제3자에게 판매하지 않습니다.</li>
+              <li>Google 사용자 데이터를 이용자에게 제공되는 기능 외의 목적으로 사용하지 않습니다.</li>
+              <li>서비스 제공에 필요한 최소한의 데이터만 접근하고 저장합니다.</li>
+              <li>이용자가 요청하는 경우 관련 데이터를 삭제할 수 있도록 합니다.</li>
+            </ol>
+          </Section>
+
+          <Section title="제7조(AI 기능에서의 데이터 처리)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>회사는 이용자의 요청에 따라 메일 초안 작성, 답장 추천 등 AI 기능을 제공할 수 있습니다.</li>
+              <li>AI 기능은 이용자가 선택한 메일 내용, 이용자가 입력한 내용 또는 대화 맥락을 기반으로 동작합니다.</li>
+              <li>회사는 AI 기능 제공을 위해 필요한 최소한의 메일 데이터만 처리합니다.</li>
+              <li>
+                AI 기능 제공을 위해 이용자가 요청한 메일 내용 또는 입력 내용이 AI 처리 서비스 제공업체에 전송될 수
+                있습니다.
+              </li>
+              <li>회사는 이용자의 Gmail 데이터를 광고 목적 또는 AI 모델 학습 목적으로 사용하지 않습니다.</li>
+              <li>AI가 생성한 결과는 이용자가 직접 검토한 후 사용해야 합니다.</li>
+            </ol>
+          </Section>
+
+          <Section title="제8조(개인정보 및 Google 사용자 데이터의 보관 기간)">
+            <p className="mb-3">회사는 서비스 제공에 필요한 기간 동안 개인정보 및 Google 사용자 데이터를 보관합니다.</p>
+            <p className="mb-2">다음 각 호에 해당하는 경우 회사는 관련 데이터를 삭제하거나 비식별화합니다.</p>
+            <ol className="list-decimal space-y-1 pl-5">
+              <li>이용자가 서비스 탈퇴를 요청한 경우</li>
+              <li>이용자가 Google 계정 연결 해제를 요청한 경우</li>
+              <li>이용자가 데이터 삭제를 요청한 경우</li>
+              <li>서비스 제공 목적이 달성되어 더 이상 보관할 필요가 없는 경우</li>
+            </ol>
+            <p className="mt-3 text-sm text-muted-foreground">
+              단, 관련 법령에 따라 일정 기간 보관이 필요한 정보는 해당 법령에서 정한 기간 동안 보관할 수 있습니다.
+            </p>
+          </Section>
+
+          <Section title="제9조(개인정보 및 Google 사용자 데이터의 제3자 제공)">
+            <p className="mb-3">
+              회사는 이용자의 개인정보 및 Google 사용자 데이터를 제3자에게 판매하거나 제공하지 않습니다.
+            </p>
+            <p className="mb-2">다만 다음 각 호의 경우에는 예외적으로 제공될 수 있습니다.</p>
+            <ol className="list-decimal space-y-1 pl-5">
+              <li>이용자가 사전에 명시적으로 동의한 경우</li>
+              <li>법령에 따라 제공 의무가 발생한 경우</li>
+              <li>수사기관 또는 법원의 적법한 요청이 있는 경우</li>
+            </ol>
+          </Section>
+
+          <Section title="제10조(개인정보 처리 위탁)">
+            <p className="mb-3">
+              회사는 안정적인 서비스 제공을 위해 클라우드 인프라, 데이터베이스, 모니터링, AI API 등 외부 서비스를 이용할
+              수 있습니다.
+            </p>
+            <p className="mb-2">
+              외부 서비스를 이용하는 경우에도 회사는 서비스 제공 목적 범위 내에서만 이용자 데이터를 처리하며, 필요한
+              최소한의 데이터만 전달합니다.
+            </p>
+            <p className="mb-2">회사가 이용할 수 있는 위탁 업무의 범위는 다음 각 호와 같습니다.</p>
+            <ol className="list-decimal space-y-1 pl-5">
+              <li>클라우드 인프라 및 데이터베이스 운영</li>
+              <li>서비스 장애 모니터링 및 로그 분석</li>
+              <li>AI 기능 제공을 위한 AI API 처리</li>
+              <li>이메일 문의 및 고객 지원 처리</li>
+            </ol>
+            <p className="mt-3 text-sm text-muted-foreground">
+              구체적인 위탁 업체, 위탁 업무 내용, 보유 및 이용 기간이 확정되는 경우 회사는 개인정보처리방침 또는 별도
+              고지를 통해 안내합니다.
+            </p>
+          </Section>
+
+          <Section title="제11조(로그 및 보안 처리)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>회사는 서비스 안정성, 장애 분석, 보안 모니터링을 위해 일부 로그를 수집할 수 있습니다.</li>
+              <li>
+                로그에는 다음 각 호의 정보가 포함될 수 있습니다.
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>요청 시각</li>
+                  <li>사용자 식별자</li>
+                  <li>API 요청 경로</li>
+                  <li>오류 정보</li>
+                  <li>응답 시간</li>
+                  <li>외부 API 호출 결과</li>
+                </ul>
+              </li>
+              <li>
+                회사는 비밀번호, OAuth Access Token, Refresh Token, 인증 코드, 민감한 메일 본문 등 민감정보가 로그에
+                남지 않도록 마스킹 및 접근 통제를 적용합니다.
+              </li>
+            </ol>
+          </Section>
+
+          <Section title="제12조(이용자의 권리)">
+            <p className="mb-2">이용자는 언제든지 다음 각 호의 권리를 행사할 수 있습니다.</p>
+            <ol className="list-decimal space-y-1 pl-5">
+              <li>개인정보 열람 요청</li>
+              <li>개인정보 정정 요청</li>
+              <li>개인정보 삭제 요청</li>
+              <li>Google 계정 연결 해제 요청</li>
+              <li>서비스 탈퇴 요청</li>
+              <li>Google 사용자 데이터 삭제 요청</li>
+            </ol>
+            <p className="mt-3 text-sm text-muted-foreground">
+              이용자는 Google 계정 보안 설정 페이지에서도 메일상자의 Google 계정 접근 권한을 해제할 수 있습니다.
+            </p>
+          </Section>
+
+          <Section title="제13조(데이터 삭제 요청 방법)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>
+                이용자는 아래 이메일을 통해 데이터 삭제를 요청할 수 있습니다.
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>
+                    이메일:{" "}
+                    <a href="mailto:mailsangja2026@gmail.com" className="text-primary underline underline-offset-2">
+                      mailsangja2026@gmail.com
+                    </a>
+                  </li>
+                </ul>
+              </li>
+              <li>
+                회사는 데이터 삭제 요청을 접수한 경우 본인 확인 후 서비스 제공을 위해 저장된 개인정보 및 Google 사용자
+                데이터를 삭제합니다.
+              </li>
+              <li>단, 관계 법령에 따라 보관이 필요한 정보는 해당 법령에서 정한 기간 동안 보관할 수 있습니다.</li>
+            </ol>
+          </Section>
+
+          <Section title="제14조(보안 조치)">
+            <p className="mb-2">
+              회사는 이용자의 개인정보 및 Google 사용자 데이터를 보호하기 위해 다음 각 호의 보안 조치를 적용합니다.
+            </p>
+            <ol className="list-decimal space-y-1 pl-5">
+              <li>HTTPS 기반 통신 암호화</li>
+              <li>OAuth 기반 사용자 인증</li>
+              <li>Access Token 및 Refresh Token의 안전한 저장</li>
+              <li>민감정보 로그 마스킹</li>
+              <li>데이터베이스 접근 권한 제한</li>
+              <li>장애 및 이상 징후 모니터링</li>
+              <li>사용자 요청 기반 데이터 삭제 절차 운영</li>
+            </ol>
+          </Section>
+
+          <Section title="제15조(개인정보처리방침의 변경)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>회사는 필요한 경우 본 개인정보처리방침을 변경할 수 있습니다.</li>
+              <li>
+                회사는 개인정보처리방침을 변경하는 경우 변경 내용과 시행일을 서비스 화면 또는 이메일 등을 통해
+                안내합니다.
+              </li>
+              <li>중요한 변경 사항이 있는 경우 이용자가 명확히 확인할 수 있도록 별도로 고지합니다.</li>
+            </ol>
+          </Section>
+
+          <Section title="제16조(문의처)">
+            <p className="mb-2">
+              개인정보 및 Google 사용자 데이터 처리와 관련한 문의는 아래 연락처로 문의할 수 있습니다.
+            </p>
+            <ul className="list-disc space-y-1 pl-5">
+              <li>서비스명: 메일상자</li>
+              <li>
+                이메일:{" "}
+                <a href="mailto:mailsangja2026@gmail.com" className="text-primary underline underline-offset-2">
+                  mailsangja2026@gmail.com
+                </a>
+              </li>
+              <li>
+                홈페이지:{" "}
+                <a
+                  href="https://mail.ajou.app/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline underline-offset-2"
+                >
+                  https://mail.ajou.app/
+                </a>
+              </li>
+            </ul>
+          </Section>
+
+          <div className="rounded-lg border bg-muted/30 px-6 py-4">
+            <p className="text-sm font-medium">부칙</p>
+            <p className="mt-1 text-sm text-muted-foreground">본 개인정보처리방침은 2026년 05월 25일부터 시행합니다.</p>
+          </div>
+        </div>
+      </main>
+
+      <footer className="border-t px-6 py-8">
+        <div className="mx-auto flex max-w-3xl items-center justify-between text-sm text-muted-foreground">
+          <div className="flex items-center gap-2">
+            <Mail className="size-4" />
+            <span>메일상자</span>
+          </div>
+          <div className="flex items-center gap-4">
+            <Link to="/terms" className="transition-colors hover:text-foreground">
+              이용약관
+            </Link>
+            <Link to="/privacy" className="transition-colors hover:text-foreground">
+              개인정보처리방침
+            </Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <h2 className="mb-3 text-lg font-semibold">{title}</h2>
+      <div>{children}</div>
+    </section>
+  )
+}

--- a/src/routes/terms.tsx
+++ b/src/routes/terms.tsx
@@ -1,0 +1,373 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { Mail } from "lucide-react"
+
+export const Route = createFileRoute("/terms")({
+  component: TermsPage,
+})
+
+function TermsPage() {
+  return (
+    <div className="min-h-svh bg-background">
+      <header className="sticky inset-x-0 top-0 z-50 border-b bg-background/80 backdrop-blur-md">
+        <div className="mx-auto flex max-w-3xl items-center gap-3 px-6 py-4">
+          <Link
+            to="/"
+            className="flex items-center gap-2 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <Mail className="size-5 text-primary" />
+            <span className="font-semibold">메일상자</span>
+          </Link>
+          <div className="h-4 w-px bg-border" />
+          <span className="text-sm font-medium">서비스 이용약관</span>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-6 py-12">
+        <h1 className="text-2xl font-bold">메일상자 서비스 이용약관</h1>
+        <p className="mt-2 text-sm text-muted-foreground">시행일: 2026년 05월 25일</p>
+
+        <div className="mt-10 space-y-10 text-[15px] leading-7 text-foreground/90">
+          <Section title="제1조(목적)">
+            본 약관은 메일상자 운영팀(이하 &quot;회사&quot;라 합니다)이 운영하는 메일상자 서비스(이하
+            &quot;서비스&quot;라 합니다)를 이용함에 있어 회사와 이용자의 권리, 의무 및 책임사항을 규정함을 목적으로
+            합니다.
+          </Section>
+
+          <Section title="제2조(정의)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>
+                &quot;서비스&quot;란 회사가 제공하는 Gmail 기반 통합 메일 인박스, 메일 조회, 메일 검색, 메일 라벨링, AI
+                기반 초안 작성 및 답장 보조 기능을 의미합니다.
+              </li>
+              <li>&quot;이용자&quot;란 본 약관에 따라 회사가 제공하는 서비스를 이용하는 자를 말합니다.</li>
+              <li>
+                &quot;회원&quot;이란 Google 계정 연동 또는 회원가입 절차를 통해 서비스 이용 자격을 부여받은 자로서,
+                지속적으로 서비스를 이용할 수 있는 자를 말합니다.
+              </li>
+              <li>
+                &quot;Google 계정&quot;이란 이용자가 서비스와 연동하는 Gmail 또는 Google Workspace 계정을 의미합니다.
+              </li>
+              <li>
+                &quot;Google 사용자 데이터&quot;란 Google API를 통해 회사가 접근하는 이용자의 Gmail 메일, 메일
+                메타데이터, 라벨 정보, 스레드 정보, 계정 이메일 정보, Google 주소록 및 기타 연락처 정보를 의미합니다.
+              </li>
+              <li>
+                &quot;AI 기능&quot;이란 메일 본문 또는 대화 맥락을 기반으로 메일 초안 작성, 답장 추천 등을 제공하는
+                기능을 의미합니다.
+              </li>
+            </ol>
+          </Section>
+
+          <Section title="제3조(회원가입 및 Google 계정 연동)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>이용자는 Google 계정을 통해 서비스 이용을 신청할 수 있습니다.</li>
+              <li>
+                회사는 서비스 제공을 위해 다음 각 호의 정보를 수집하거나 접근할 수 있습니다.
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>Google 계정 이메일 주소</li>
+                  <li>Google 계정 이메일 검증 여부</li>
+                  <li>이용자가 연동한 Gmail 계정 정보</li>
+                  <li>이용자가 연동한 Google 주소록 및 기타 연락처 정보</li>
+                  <li>이용자가 Google OAuth 동의 화면에서 허용한 범위 내의 Gmail 데이터</li>
+                </ul>
+              </li>
+              <li>
+                회사는 다음 각 호에 해당하는 경우 회원가입 또는 Google 계정 연동을 제한하거나 거절할 수 있습니다.
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>타인의 Google 계정을 무단으로 사용하는 경우</li>
+                  <li>허위 정보를 제공한 경우</li>
+                  <li>이전에 본 약관 위반으로 서비스 이용이 제한된 이력이 있는 경우</li>
+                  <li>서비스 운영 또는 보안상 현저한 지장이 있다고 판단되는 경우</li>
+                </ul>
+              </li>
+            </ol>
+          </Section>
+
+          <Section title="제4조(Google OAuth 권한 및 데이터 접근)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>
+                회사는 이용자의 명시적인 동의를 받은 경우에 한하여 Google API를 통해 Google 사용자 데이터에 접근합니다.
+              </li>
+              <li>회사는 서비스 제공에 필요한 최소한의 Google OAuth Scope만 요청합니다.</li>
+              <li>
+                회사가 요청할 수 있는 Google OAuth Scope와 사용 목적은 다음 각 호와 같습니다.
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>
+                    <code className="rounded bg-muted px-1.5 py-0.5 text-xs">openid</code>: Google 계정 연동 과정에서
+                    이용자 식별을 위해 사용합니다.
+                  </li>
+                  <li>
+                    <code className="rounded bg-muted px-1.5 py-0.5 text-xs">email</code>: 연동된 Google 계정의 이메일
+                    주소 확인을 위해 사용합니다.
+                  </li>
+                  <li>
+                    <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                      https://www.googleapis.com/auth/gmail.modify
+                    </code>
+                    : Gmail 메일 목록, 본문, 스레드, 라벨 및 상태 정보를 조회하고, 메일 발송, 읽음/안읽음 처리, 라벨
+                    변경, 휴지통 이동/복구 등 서비스 내 Gmail 기능 제공을 위해 사용합니다.
+                  </li>
+                  <li>
+                    <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                      https://www.googleapis.com/auth/contacts.readonly
+                    </code>
+                    : 이용자의 Google 주소록 연락처를 조회하여 메일 작성 및 수신자 추천 등 주소록 기반 기능을 제공하기
+                    위해 사용합니다.
+                  </li>
+                  <li>
+                    <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                      https://www.googleapis.com/auth/contacts.other.readonly
+                    </code>
+                    : 이용자의 Google 기타 연락처를 조회하여 메일 작성 및 수신자 추천 등 주소록 기반 기능을 제공하기
+                    위해 사용합니다.
+                  </li>
+                </ul>
+              </li>
+              <li>회사는 이용자가 허용하지 않은 Google 사용자 데이터에는 접근하지 않습니다.</li>
+              <li>이용자는 언제든지 Google 계정 설정을 통해 서비스의 Google 계정 접근 권한을 해제할 수 있습니다.</li>
+            </ol>
+          </Section>
+
+          <Section title="제5조(서비스의 제공 내용)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>
+                회사는 회원에게 다음 각 호의 서비스를 제공할 수 있습니다.
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>여러 Gmail 계정의 통합 인박스 조회</li>
+                  <li>메일 목록 및 상세 내용 조회</li>
+                  <li>메일 스레드 조회</li>
+                  <li>메일 검색</li>
+                  <li>메일 라벨링 및 자동 분류</li>
+                  <li>읽음/안읽음 상태 변경</li>
+                  <li>메일 라벨 및 상태 변경</li>
+                  <li>메일 삭제 요청 및 휴지통 이동/복구</li>
+                  <li>AI 기반 메일 초안 작성</li>
+                  <li>AI 기반 답장 추천</li>
+                  <li>이용자의 Gmail 계정을 통한 메일 발송</li>
+                </ul>
+              </li>
+              <li>회사는 운영상, 기술상 필요에 따라 서비스의 일부 또는 전부를 변경할 수 있습니다.</li>
+              <li>
+                회사는 서비스 변경이 이용자에게 중대한 영향을 미치는 경우 사전에 서비스 화면 또는 이메일 등을 통해
+                안내합니다.
+              </li>
+            </ol>
+          </Section>
+
+          <Section title="제6조(AI 기능 이용)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>
+                회사는 이용자의 메일 작성 및 답장 작성을 보조하기 위해 AI 기반 초안 작성, 답장 추천 기능을 제공할 수
+                있습니다.
+              </li>
+              <li>
+                AI 기능은 이용자의 요청에 따라 선택된 메일 내용, 이용자가 입력한 내용 또는 대화 맥락을 기반으로
+                동작합니다.
+              </li>
+              <li>
+                AI 기능 제공을 위해 이용자가 요청한 메일 내용 또는 입력 내용이 AI 처리 서비스 제공업체에 전송될 수
+                있습니다.
+              </li>
+              <li>AI가 생성한 내용은 참고용이며, 회사는 AI 생성 결과의 정확성, 완전성, 적법성을 보장하지 않습니다.</li>
+              <li>이용자는 AI가 생성한 내용을 직접 검토한 후 사용해야 합니다.</li>
+              <li>AI가 생성한 메일 내용을 검토하지 않고 사용하여 발생한 문제에 대한 책임은 이용자에게 있습니다.</li>
+              <li>회사는 이용자의 Gmail 데이터를 광고 목적 또는 AI 모델 학습 목적으로 사용하지 않습니다.</li>
+            </ol>
+          </Section>
+
+          <Section title="제7조(메일 발송)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>
+                회사는 이용자가 서비스에서 작성하거나 승인한 메일을 이용자의 Gmail 계정을 통해 발송할 수 있도록 기능을
+                제공합니다.
+              </li>
+              <li>회사는 이용자의 명시적인 발송 요청 없이 메일을 자동으로 발송하지 않습니다.</li>
+              <li>
+                이용자가 서비스를 통해 발송한 메일의 내용, 수신자, 첨부파일 및 그로 인해 발생하는 법적 책임은 이용자에게
+                있습니다.
+              </li>
+              <li>
+                이용자는 스팸, 피싱, 사기, 명예훼손, 개인정보 침해, 저작권 침해 등 불법적이거나 부적절한 메일을
+                발송해서는 안 됩니다.
+              </li>
+            </ol>
+          </Section>
+
+          <Section title="제8조(개인정보 및 Google 사용자 데이터 보호)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>
+                회사는 관련 법령 및 Google API Services User Data Policy를 준수하여 이용자의 개인정보와 Google 사용자
+                데이터를 보호합니다.
+              </li>
+              <li>회사는 Google API를 통해 수집한 사용자 데이터를 서비스 제공 목적 범위 내에서만 사용합니다.</li>
+              <li>
+                회사의 Google API를 통해 수집한 정보의 사용 및 이전은 Google API Services User Data Policy의 Limited Use
+                요구사항을 준수합니다.
+              </li>
+              <li>회사는 Google 사용자 데이터를 광고 목적으로 사용하지 않으며, 제3자에게 판매하지 않습니다.</li>
+              <li>회사는 서비스 제공에 필요한 최소한의 데이터만 접근하고 저장합니다.</li>
+              <li>
+                개인정보 및 Google 사용자 데이터 처리에 관한 상세한 내용은 개인정보처리방침을 통해 확인할 수 있습니다.
+              </li>
+            </ol>
+          </Section>
+
+          <Section title="제9조(회원의 의무)">
+            <ol className="list-decimal space-y-1 pl-5">
+              <li>
+                회원은 다음 각 호의 행위를 하여서는 안 됩니다.
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>타인의 Google 계정을 무단으로 연결하거나 사용하는 행위</li>
+                  <li>타인의 메일을 무단으로 열람, 저장, 전송하는 행위</li>
+                  <li>허위 정보를 등록하거나 타인의 정보를 도용하는 행위</li>
+                  <li>서비스의 정상적인 운영을 방해하는 행위</li>
+                  <li>비정상적인 자동화 요청, 과도한 트래픽, 공격성 요청을 발생시키는 행위</li>
+                  <li>회사 또는 제3자의 저작권, 개인정보, 명예 등 권리를 침해하는 행위</li>
+                  <li>스팸, 피싱, 악성코드, 사기성 메일을 발송하는 행위</li>
+                  <li>관련 법령, Google API 정책 또는 본 약관을 위반하는 행위</li>
+                </ul>
+              </li>
+            </ol>
+          </Section>
+
+          <Section title="제10조(서비스 이용 제한 및 계약 해지)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>
+                회사는 회원이 다음 각 호에 해당하는 경우 서비스 이용을 제한하거나 계약을 해지할 수 있습니다.
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>본 약관을 위반한 경우</li>
+                  <li>타인의 Google 계정을 무단으로 사용한 경우</li>
+                  <li>서비스 운영을 고의 또는 중대한 과실로 방해한 경우</li>
+                  <li>비정상적인 트래픽 또는 보안 위협을 발생시킨 경우</li>
+                  <li>Google API 정책 또는 관련 법령을 위반한 경우</li>
+                </ul>
+              </li>
+              <li>회원은 언제든지 서비스 탈퇴 또는 Google 계정 연결 해제를 요청할 수 있습니다.</li>
+              <li>
+                회원이 Google 계정 연결을 해제하는 경우 Gmail 데이터 동기화 및 일부 서비스 기능 이용이 제한될 수
+                있습니다.
+              </li>
+            </ol>
+          </Section>
+
+          <Section title="제11조(서비스 중단)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>
+                회사는 다음 각 호에 해당하는 경우 서비스의 전부 또는 일부를 일시적으로 중단할 수 있습니다.
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>서버 점검, 유지보수 또는 배포가 필요한 경우</li>
+                  <li>서비스 장애 또는 보안 사고가 발생한 경우</li>
+                  <li>Google API, Gmail, 클라우드 인프라 등 외부 서비스 장애가 발생한 경우</li>
+                  <li>네트워크 장애 또는 천재지변 등 불가항력적 사유가 발생한 경우</li>
+                </ul>
+              </li>
+              <li>회사는 서비스 중단이 예상되는 경우 가능한 범위 내에서 사전에 안내합니다.</li>
+              <li>긴급 장애, 보안 사고 등 부득이한 사유가 있는 경우 사전 안내 없이 서비스가 중단될 수 있습니다.</li>
+            </ol>
+          </Section>
+
+          <Section title="제12조(데이터 삭제 및 계정 연결 해제)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>회원은 언제든지 서비스 탈퇴, Google 계정 연결 해제 또는 저장된 데이터 삭제를 요청할 수 있습니다.</li>
+              <li>회사는 회원의 데이터 삭제 요청이 접수된 경우 본인 확인 후 관련 데이터를 삭제합니다.</li>
+              <li>
+                단, 관련 법령에 따라 일정 기간 보관이 필요한 정보는 해당 법령에서 정한 기간 동안 보관할 수 있습니다.
+              </li>
+              <li>
+                데이터 삭제 요청은 아래 연락처를 통해 접수할 수 있습니다.
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>
+                    이메일:{" "}
+                    <a href="mailto:mailsangja2026@gmail.com" className="text-primary underline underline-offset-2">
+                      mailsangja2026@gmail.com
+                    </a>
+                  </li>
+                </ul>
+              </li>
+            </ol>
+          </Section>
+
+          <Section title="제13조(책임의 제한)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>
+                회사는 안정적인 서비스 제공을 위해 노력하나, 다음 각 호의 사유로 발생한 손해에 대해서는 책임을 지지
+                않습니다.
+                <ul className="mt-1 list-disc space-y-1 pl-5">
+                  <li>이용자의 귀책 사유로 발생한 문제</li>
+                  <li>이용자의 Google 계정 관리 소홀로 발생한 문제</li>
+                  <li>Google API, Gmail, 외부 클라우드 서비스 장애로 발생한 문제</li>
+                  <li>천재지변, 네트워크 장애, 서버 장애 등 불가항력적 사유로 발생한 문제</li>
+                  <li>이용자가 AI 생성 결과를 검토하지 않고 사용하여 발생한 문제</li>
+                  <li>이용자가 서비스를 통해 발송한 메일로 인해 발생한 분쟁</li>
+                </ul>
+              </li>
+              <li>회사는 AI 기능이 생성한 결과의 정확성, 완전성, 적합성을 보장하지 않습니다.</li>
+              <li>회사는 이용자의 명시적인 요청 또는 조작 없이 메일을 임의로 발송하지 않습니다.</li>
+            </ol>
+          </Section>
+
+          <Section title="제14조(지식재산권)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>서비스의 소프트웨어, 디자인, 로고, UI, 문서 등에 대한 권리는 회사에게 있습니다.</li>
+              <li>이용자는 서비스를 이용함으로써 서비스 자체에 대한 소유권 또는 지식재산권을 취득하지 않습니다.</li>
+              <li>
+                이용자는 회사의 사전 동의 없이 서비스의 일부 또는 전부를 복제, 배포, 수정, 역설계하거나 상업적으로
+                이용할 수 없습니다.
+              </li>
+            </ol>
+          </Section>
+
+          <Section title="제15조(약관의 변경)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>회사는 필요한 경우 본 약관을 변경할 수 있습니다.</li>
+              <li>회사는 약관을 변경하는 경우 변경 내용과 시행일을 서비스 화면 또는 이메일 등을 통해 안내합니다.</li>
+              <li>회원이 변경된 약관에 동의하지 않는 경우 서비스 이용을 중단하고 탈퇴할 수 있습니다.</li>
+              <li>변경된 약관 시행 이후에도 서비스를 계속 이용하는 경우 변경된 약관에 동의한 것으로 봅니다.</li>
+            </ol>
+          </Section>
+
+          <Section title="제16조(분쟁 해결)">
+            <ol className="list-decimal space-y-2 pl-5">
+              <li>
+                회사와 회원 간에 발생한 서비스 이용과 관련한 분쟁은 원만한 합의에 의해 해결하는 것을 원칙으로 합니다.
+              </li>
+              <li>본 약관은 대한민국 법률에 따라 규정되고 이행됩니다.</li>
+              <li>서비스 이용과 관련하여 소송이 제기되는 경우 관할 법원은 관련 법령에 따릅니다.</li>
+            </ol>
+          </Section>
+
+          <div className="rounded-lg border bg-muted/30 px-6 py-4">
+            <p className="text-sm font-medium">부칙</p>
+            <p className="mt-1 text-sm text-muted-foreground">본 약관은 2026년 05월 25일부터 시행합니다.</p>
+          </div>
+        </div>
+      </main>
+
+      <footer className="border-t px-6 py-8">
+        <div className="mx-auto flex max-w-3xl items-center justify-between text-sm text-muted-foreground">
+          <div className="flex items-center gap-2">
+            <Mail className="size-4" />
+            <span>메일상자</span>
+          </div>
+          <div className="flex items-center gap-4">
+            <Link to="/terms" className="transition-colors hover:text-foreground">
+              이용약관
+            </Link>
+            <Link to="/privacy" className="transition-colors hover:text-foreground">
+              개인정보처리방침
+            </Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <h2 className="mb-3 text-lg font-semibold">{title}</h2>
+      <div>{children}</div>
+    </section>
+  )
+}


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#35

### 📌 Task

- Closes #103 

## 💡 작업 내용

- 서비스 이용약관 페이지 추가
- 개인정보처리방침 페이지 추가
- 회원가입 페이지 개선
- 로그인 페이지 개선

## 📝 추가 설명

- 서비스 이용약관 페이지(`/terms`)와 개인정보처리방침 페이지(`/privacy`)를 추가했습니다.
- 랜딩 페이지 푸터에서 이용약관 및 개인정보처리방침으로 이동할 수 있도록 링크를 추가했습니다.
- 회원가입 페이지에 서비스 이용약관 및 개인정보처리방침 동의 체크박스를 추가하고, 동의 전에는 가입 버튼이 비활성화되도록 개선했습니다.
- 로그인, 회원가입 화면을 카드 기반 UI로 정리하고, 비밀번호 표시 토글과 로딩 상태 표시를 보강했습니다.
- 신규 라우트 반영을 위해 `routeTree.gen.ts`를 갱신했습니다.

## 🖼️ 스크린샷

| 서비스 이용약관 | 개인정보처리방침 |
|--------|--------|
| <img width="1565" height="977" alt="image" src="https://github.com/user-attachments/assets/047bde6c-436f-4b32-8589-d671589e9d76" /> | <img width="1565" height="977" alt="image" src="https://github.com/user-attachments/assets/239b53ee-ee78-4c7e-b7f9-91673abdcc28" /> | 

| 로그인 | 회원가입 |
|--------|--------|
| <img width="1576" height="906" alt="image" src="https://github.com/user-attachments/assets/9d0b3c57-a2b3-4d0b-b91f-1bddf37aa3c2" /> | <img width="1576" height="906" alt="image" src="https://github.com/user-attachments/assets/39757c88-20b4-44aa-9759-8c34d2dfd662" /> | 