### PR TITLE
[STORY-407] 라벨 알림 설정 및 설정 페이지 UI 개선

### DIFF
--- a/src/components/add-account-dialog.tsx
+++ b/src/components/add-account-dialog.tsx
@@ -9,7 +9,7 @@ import { trackEvent } from "@/lib/analytics"
 import { ICON_ENTRIES, type AccountIconName } from "@/lib/icon-entries"
 import { cn } from "@/lib/utils"
 
-const COLORS = ["#EF4444", "#F97316", "#EAB308", "#22C55E", "#3B82F6", "#8B5CF6", "#EC4899", "#6B7280"]
+const COLORS = ["#FA2A2A", "#FA882A", "#FAD42A", "#22C55E", "#36C0EB", "#3B82F6", "#8B5CF6", "#ED64A7"]
 
 export function AddAccountDialog({ children }: { children: React.ReactNode }) {
   const [open, setOpen] = useState(false)

--- a/src/components/inbox-preview.tsx
+++ b/src/components/inbox-preview.tsx
@@ -1,0 +1,59 @@
+import { cn } from "@/lib/utils"
+
+export function InboxSingleLinePreview() {
+  return (
+    <div className="w-full overflow-hidden rounded-lg bg-slate-50">
+      <div className="flex h-3.5 items-center gap-1 bg-slate-100 px-2">
+        <div className="h-1 w-6 rounded-full bg-slate-300" />
+      </div>
+      <div className="flex flex-col divide-y divide-slate-100 bg-white">
+        {[
+          { bold: true, accent: false },
+          { bold: true, accent: true },
+          { bold: false, accent: false },
+          { bold: false, accent: false },
+        ].map(({ bold, accent }, i) => (
+          <div key={i} className={cn("flex items-center gap-1.5 px-2 py-1", accent && "bg-sky-50")}>
+            <div className={cn("size-2 shrink-0 rounded-full", bold ? "bg-blue-300" : "bg-slate-200")} />
+            <div className={cn("h-1 w-5 shrink-0 rounded", bold ? "bg-slate-500" : "bg-slate-300")} />
+            <div className={cn("h-1 flex-1 rounded", bold ? "bg-slate-300" : "bg-slate-200")} />
+            <div className="h-1 w-3 shrink-0 rounded bg-slate-200" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function InboxTwoLinePreview() {
+  return (
+    <div className="w-full overflow-hidden rounded-lg bg-slate-50">
+      <div className="flex h-3.5 items-center gap-1 bg-slate-100 px-2">
+        <div className="h-1 w-6 rounded-full bg-slate-300" />
+      </div>
+      <div className="flex flex-col divide-y divide-slate-100 bg-white">
+        {[
+          { bold: true, accent: false, subWidth: "3/4" },
+          { bold: true, accent: true, subWidth: "1/2" },
+          { bold: false, accent: false, subWidth: "2/3" },
+        ].map(({ bold, accent, subWidth }, i) => (
+          <div key={i} className={cn("flex gap-1.5 px-2 py-1", accent && "bg-sky-50")}>
+            <div className={cn("mt-0.5 size-2 shrink-0 rounded-full", bold ? "bg-blue-300" : "bg-slate-200")} />
+            <div className="flex flex-1 flex-col gap-0.5">
+              <div className="flex items-center justify-between">
+                <div className={cn("h-1 w-5 rounded", bold ? "bg-slate-500" : "bg-slate-300")} />
+                <div className="h-1 w-3 rounded bg-slate-200" />
+              </div>
+              <div
+                className={cn(
+                  "h-1 rounded bg-slate-200",
+                  subWidth === "3/4" ? "w-3/4" : subWidth === "1/2" ? "w-1/2" : "w-2/3"
+                )}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/label/label-condition-list.tsx
+++ b/src/components/label/label-condition-list.tsx
@@ -7,20 +7,19 @@ import {
 
 export function LabelConditionList({ conditions }: { conditions: LabelCondition[] }) {
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col divide-y divide-border/50">
       {conditions.map((condition, index) => (
-        <div
-          key={index}
-          className="flex flex-wrap items-center gap-1.5 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm"
-        >
-          <span className="font-medium text-foreground">{LABEL_CONDITION_FIELD_LABELS[condition.field]}</span>
-          <span className="text-foreground">
+        <div key={index} className="flex flex-wrap items-baseline gap-2 py-2 text-sm first:pt-0 last:pb-0">
+          <span className="rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-foreground">
+            {LABEL_CONDITION_FIELD_LABELS[condition.field]}
+          </span>
+          <span className="text-sm text-foreground">
             {condition.field === "HAS_ATTACHMENT"
               ? (LABEL_ATTACHMENT_VALUE_LABELS[condition.value] ?? condition.value)
               : condition.value}
           </span>
           {condition.field !== "HAS_ATTACHMENT" && (
-            <span className="text-muted-foreground">{LABEL_CONDITION_OPERATOR_LABELS[condition.operator]}</span>
+            <span className="text-xs text-muted-foreground">{LABEL_CONDITION_OPERATOR_LABELS[condition.operator]}</span>
           )}
         </div>
       ))}

--- a/src/components/label/label-delete-dialog.tsx
+++ b/src/components/label/label-delete-dialog.tsx
@@ -8,15 +8,17 @@ import { getErrorMessage } from "@/lib/http-error"
 import { useDeleteLabel } from "@/mutations/labels"
 import { emailQueries } from "@/queries/emails"
 import { labelQueries } from "@/queries/labels"
-import { LABEL_CONDITION_FIELD_LABELS, LABEL_CONDITION_OPERATOR_LABELS, type LabelListItem } from "@/types/label"
+import { type Label } from "@/types/label"
+import { LabelConditionList } from "@/components/label/label-condition-list"
 
 interface LabelDeleteDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  label: LabelListItem
+  label: Label
+  onSuccess?: () => void
 }
 
-export function LabelDeleteDialog({ open, onOpenChange, label }: LabelDeleteDialogProps) {
+export function LabelDeleteDialog({ open, onOpenChange, label, onSuccess }: LabelDeleteDialogProps) {
   const navigate = useNavigate()
   const search = useSearch({ strict: false })
   const deleteLabel = useDeleteLabel()
@@ -35,7 +37,9 @@ export function LabelDeleteDialog({ open, onOpenChange, label }: LabelDeleteDial
       onSuccess: () => {
         onOpenChange(false)
         toast.warning(`${label.name} 라벨이 삭제되었습니다`)
-        if ("labelId" in search && search.labelId === label.id) {
+        if (onSuccess) {
+          onSuccess()
+        } else if ("labelId" in search && search.labelId === label.id) {
           void navigate({ to: "/mail/$mailbox", params: { mailbox: "inbox" }, replace: true })
         }
       },
@@ -63,23 +67,13 @@ export function LabelDeleteDialog({ open, onOpenChange, label }: LabelDeleteDial
                 </p>
               )}
               {labelDetail?.rule?.groups && (
-                <div className="space-y-1.5">
-                  <div className="space-y-1 rounded-md border bg-muted/40 px-3 py-2 text-xs">
-                    {labelDetail.rule.groups.flatMap((group, gi) => [
-                      ...(gi > 0 ? [<hr key={`sep-${gi}`} className="my-1 border-border" />] : []),
-                      ...group.conditions.map((cond, ci) => (
-                        <p key={`${gi}-${ci}`} className="text-muted-foreground">
-                          <span className="font-medium text-foreground">
-                            {LABEL_CONDITION_FIELD_LABELS[cond.field]}
-                          </span>{" "}
-                          {LABEL_CONDITION_OPERATOR_LABELS[cond.operator]}{" "}
-                          {cond.operator !== "BOOLEAN" && (
-                            <span className="font-mono text-foreground">&quot;{cond.value}&quot;</span>
-                          )}
-                        </p>
-                      )),
-                    ])}
-                  </div>
+                <div className="flex flex-col gap-1.5 rounded-xl border px-4 py-3">
+                  {labelDetail.rule.groups.map((group, gi) => (
+                    <div key={gi}>
+                      {gi > 0 && <hr className="my-1 border-border" />}
+                      <LabelConditionList conditions={group.conditions} />
+                    </div>
+                  ))}
                 </div>
               )}
             </>

--- a/src/components/notification-settings-card.tsx
+++ b/src/components/notification-settings-card.tsx
@@ -4,7 +4,7 @@ import { toast } from "sonner"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Switch } from "@/components/ui/switch"
 import {
   disableFcm,
@@ -139,18 +139,20 @@ export function NotificationSettingsCard() {
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>푸시 알림</CardTitle>
+      <CardHeader className="gap-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <CardTitle>푸시 알림</CardTitle>
+          <div className="flex items-center gap-3">
+            <Badge variant={statusVariant}>{statusLabel}</Badge>
+            <Switch
+              checked={isEnabled}
+              onCheckedChange={handleSwitchChange}
+              disabled={isMutating || !user || permission === "unsupported" || permission === "denied"}
+              aria-label="푸시 알림 활성화"
+            />
+          </div>
+        </div>
         <CardDescription>{description}</CardDescription>
-        <CardAction className="flex items-center gap-3">
-          <Badge variant={statusVariant}>{statusLabel}</Badge>
-          <Switch
-            checked={isEnabled}
-            onCheckedChange={handleSwitchChange}
-            disabled={isMutating || !user || permission === "unsupported" || permission === "denied"}
-            aria-label="푸시 알림 활성화"
-          />
-        </CardAction>
       </CardHeader>
       <CardContent className="flex flex-wrap items-center gap-3">
         <Button

--- a/src/components/sidebar/user-menu.tsx
+++ b/src/components/sidebar/user-menu.tsx
@@ -62,13 +62,13 @@ export function SidebarUserMenu() {
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
-              <DropdownMenuItem render={<Link to="/settings/account" />}>
-                <UserIcon />
-                <span>내 계정</span>
-              </DropdownMenuItem>
               <DropdownMenuItem render={<Link to="/settings" />}>
                 <Settings />
                 <span>설정</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem render={<Link to="/settings/account" />}>
+                <UserIcon />
+                <span>내 계정</span>
               </DropdownMenuItem>
               <DropdownMenuItem render={<Link to="/settings/label" />}>
                 <Tag />

--- a/src/components/theme-preview.tsx
+++ b/src/components/theme-preview.tsx
@@ -1,0 +1,84 @@
+export function LightPreview() {
+  return (
+    <div className="w-full overflow-hidden rounded-lg">
+      <div className="flex h-4 items-center gap-1 bg-slate-50 px-2">
+        <div className="size-1.5 rounded-full bg-slate-300" />
+        <div className="h-1 w-10 rounded-full bg-slate-200" />
+      </div>
+      <div className="flex gap-1.5 bg-white p-1.5">
+        <div className="flex w-5 flex-col gap-1">
+          <div className="h-1.5 rounded bg-slate-100" />
+          <div className="h-1.5 rounded bg-slate-100" />
+          <div className="h-1.5 rounded bg-slate-200" />
+          <div className="h-1.5 rounded bg-slate-100" />
+        </div>
+        <div className="flex flex-1 flex-col gap-1">
+          <div className="h-1.5 rounded bg-slate-100" />
+          <div className="h-1.5 w-3/4 rounded bg-slate-200" />
+          <div className="h-1.5 rounded bg-slate-100" />
+          <div className="h-1.5 w-3/4 rounded bg-slate-200" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function SystemPreview() {
+  return (
+    <div className="relative w-full overflow-hidden rounded-lg">
+      <div className="absolute inset-0 left-0 w-1/2 bg-white" />
+      <div className="absolute inset-0 left-1/2" style={{ background: "var(--tds-grey-900)" }} />
+      <div className="absolute inset-y-0 left-1/2 w-px" style={{ background: "var(--tds-grey-600)" }} />
+      <div className="relative">
+        <div
+          className="flex h-4 items-center gap-1 px-2"
+          style={{ background: "linear-gradient(90deg, #f8fafc 50%, var(--tds-grey-900) 50%)" }}
+        >
+          <div className="size-1.5 rounded-full" style={{ background: "var(--tds-grey-400)" }} />
+          <div className="h-1 w-10 rounded-full" style={{ background: "var(--tds-grey-400)", opacity: 0.5 }} />
+        </div>
+        <div className="flex gap-1.5 p-1.5">
+          <div className="flex w-5 flex-col gap-1">
+            <div className="h-1.5 rounded" style={{ background: "var(--tds-grey-400)", opacity: 0.5 }} />
+            <div className="h-1.5 rounded" style={{ background: "var(--tds-grey-400)", opacity: 0.5 }} />
+            <div className="h-1.5 rounded" style={{ background: "var(--tds-grey-400)", opacity: 0.5 }} />
+            <div className="h-1.5 rounded" style={{ background: "var(--tds-grey-400)", opacity: 0.35 }} />
+          </div>
+          <div className="flex flex-1 flex-col gap-1">
+            <div className="h-1.5 rounded" style={{ background: "var(--tds-grey-400)", opacity: 0.5 }} />
+            <div className="h-1.5 w-3/4 rounded" style={{ background: "var(--tds-grey-400)", opacity: 0.35 }} />
+            <div className="h-1.5 rounded" style={{ background: "var(--tds-grey-400)", opacity: 0.5 }} />
+            <div className="h-1.5 w-3/4 rounded" style={{ background: "var(--tds-grey-400)", opacity: 0.35 }} />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// 다크 테마의 고정 미리보기 — 현재 테마와 무관하게 항상 어두운 색상을 유지해야 합니다.
+// index.css의 --tds-grey 팔레트를 직접 참조합니다.
+export function DarkPreview() {
+  return (
+    <div className="w-full overflow-hidden rounded-lg">
+      <div className="flex h-4 items-center gap-1 px-2" style={{ background: "var(--tds-grey-900)" }}>
+        <div className="size-1.5 rounded-full" style={{ background: "var(--tds-grey-700)" }} />
+        <div className="h-1 w-10 rounded-full" style={{ background: "var(--tds-grey-700)" }} />
+      </div>
+      <div className="flex gap-1.5 p-1.5" style={{ background: "var(--tds-grey-900)" }}>
+        <div className="flex w-5 flex-col gap-1">
+          <div className="h-1.5 rounded" style={{ background: "var(--tds-grey-800)" }} />
+          <div className="h-1.5 rounded" style={{ background: "var(--tds-grey-800)" }} />
+          <div className="h-1.5 rounded" style={{ background: "var(--tds-grey-700)" }} />
+          <div className="h-1.5 rounded" style={{ background: "var(--tds-grey-800)" }} />
+        </div>
+        <div className="flex flex-1 flex-col gap-1">
+          <div className="h-1.5 rounded" style={{ background: "var(--tds-grey-700)" }} />
+          <div className="h-1.5 w-3/4 rounded" style={{ background: "var(--tds-grey-800)" }} />
+          <div className="h-1.5 rounded" style={{ background: "var(--tds-grey-700)" }} />
+          <div className="h-1.5 w-3/4 rounded" style={{ background: "var(--tds-grey-800)" }} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -55,7 +55,12 @@ function NotificationSettingsLink() {
   const label = isEnabled ? "푸시 알림 설정, 활성화됨" : "푸시 알림 설정, 비활성화됨"
 
   return (
-    <Link to="/settings" className={buttonVariants({ variant: "ghost", size: "icon" })} aria-label={label}>
+    <Link
+      to="/settings"
+      hash="notification-settings"
+      className={buttonVariants({ variant: "ghost", size: "icon" })}
+      aria-label={label}
+    >
       <Icon className={cn("size-5", !isEnabled && "text-muted-foreground")} />
     </Link>
   )

--- a/src/routes/_authenticated/settings.tsx
+++ b/src/routes/_authenticated/settings.tsx
@@ -69,7 +69,7 @@ function SettingsLayout() {
                 <>
                   <BreadcrumbSeparator />
                   <BreadcrumbItem>
-                    <BreadcrumbPage className="font-semibold">계정</BreadcrumbPage>
+                    <BreadcrumbPage className="font-semibold">메일 계정</BreadcrumbPage>
                   </BreadcrumbItem>
                 </>
               )}
@@ -104,7 +104,7 @@ function SettingsLayout() {
             </TabsTrigger>
             <TabsTrigger value="account" className="min-w-24 rounded-none px-4">
               <User data-icon="inline-start" />
-              계정
+              메일 계정
             </TabsTrigger>
             <TabsTrigger value="label" className="min-w-24 rounded-none px-4">
               <Tag data-icon="inline-start" />

--- a/src/routes/_authenticated/settings.tsx
+++ b/src/routes/_authenticated/settings.tsx
@@ -41,9 +41,9 @@ function SettingsLayout() {
   const isLabelDetail = !!labelId
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col p-6">
-      <div className="mx-auto flex min-h-0 w-full max-w-5xl flex-1 flex-col gap-6">
-        <div className="flex flex-col gap-1">
+    <div className="flex min-h-0 flex-1 flex-col p-0">
+      <div className="mx-auto flex min-h-0 w-full max-w-5xl flex-1 flex-col gap-0">
+        <div className="flex flex-col gap-1 px-6 py-4 sm:pt-5">
           <Breadcrumb>
             <BreadcrumbList className="text-2xl font-semibold [&>li[role=presentation]>svg]:size-5">
               <BreadcrumbItem>
@@ -111,7 +111,7 @@ function SettingsLayout() {
               라벨
             </TabsTrigger>
           </TabsList>
-          <TabsContent value={activeTab} className="flex min-h-0 flex-col">
+          <TabsContent value={activeTab} className="flex min-h-0 flex-col px-3 sm:px-5">
             <Outlet />
           </TabsContent>
         </Tabs>

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -47,7 +47,13 @@ function SettingsAccountPage() {
   const selectedDefaultAccount = defaultAccount ?? user?.defaultMailAccountId ?? null
 
   useEffect(() => {
-    if (!isAccountsPending && !isAccountsError && !user?.defaultMailAccountId) {
+    if (
+      !isAccountsPending &&
+      !isAccountsError &&
+      !user?.defaultMailAccountId &&
+      mailAccounts &&
+      mailAccounts.length > 0
+    ) {
       mutateDefaultAccount({ mailAccountId: mailAccounts[0].id })
     }
   }, [mailAccounts, user?.defaultMailAccountId, isAccountsPending, isAccountsError, mutateDefaultAccount])

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -77,7 +77,7 @@ function SettingsAccountPage() {
 
   return (
     <ScrollArea className="min-h-0 flex-1">
-      <div className="flex flex-col gap-6 px-3 pt-1 pb-4">
+      <div className="flex flex-col gap-4 pb-4">
         <Card>
           <CardHeader>
             <CardTitle>기본 메일 계정</CardTitle>

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -20,7 +20,7 @@ export const Route = createFileRoute("/_authenticated/settings/account")({
 })
 
 function SettingsAccountPage() {
-  const { data: user, isPending: isUserPending } = useUser()
+  const { data: user } = useUser()
   const { data: mailAccounts, isPending: isAccountsPending, isError: isAccountsError } = useMailAccounts()
   const [toggledIds, setToggledIds] = useState<Set<string>>(new Set())
   const [defaultAccount, setDefaultAccount] = useState<string | null>(null)
@@ -65,23 +65,6 @@ function SettingsAccountPage() {
   return (
     <ScrollArea className="min-h-0 flex-1">
       <div className="flex flex-col gap-6 px-3 pt-1 pb-4">
-        <Card>
-          <CardHeader>
-            <CardTitle>계정 정보</CardTitle>
-            <CardDescription>현재 로그인한 사용자와 구독 플랜 정보를 확인합니다.</CardDescription>
-          </CardHeader>
-          <CardContent className="flex items-center justify-between gap-4">
-            <div className="flex flex-col gap-1">
-              <p className="font-medium">{isUserPending ? "불러오는 중..." : (user?.name ?? "-")}</p>
-              <p className="text-sm text-muted-foreground">아이디: {user?.username ?? "-"}</p>
-              <p className="text-sm text-muted-foreground">플랜: {user?.plan ?? "-"}</p>
-            </div>
-            <Button variant="outline" disabled>
-              회원 탈퇴
-            </Button>
-          </CardContent>
-        </Card>
-
         <Card>
           <CardHeader>
             <CardTitle>기본 메일 계정</CardTitle>

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { createFileRoute } from "@tanstack/react-router"
 import { Plus, Trash2 } from "lucide-react"
 
@@ -25,6 +25,7 @@ function SettingsAccountPage() {
   const [toggledIds, setToggledIds] = useState<Set<string>>(new Set())
   const [defaultAccount, setDefaultAccount] = useState<string | null>(null)
   const updateDefaultAccountMutation = useUpdateDefaultAccount()
+  const { mutate: mutateDefaultAccount } = updateDefaultAccountMutation
 
   // 추후 API 구현 후, 연동 예정
   const accounts = useMemo(() => {
@@ -44,6 +45,12 @@ function SettingsAccountPage() {
   )
 
   const selectedDefaultAccount = defaultAccount ?? user?.defaultMailAccountId ?? null
+
+  useEffect(() => {
+    if (!isAccountsPending && !isAccountsError && !user?.defaultMailAccountId) {
+      mutateDefaultAccount({ mailAccountId: mailAccounts[0].id })
+    }
+  }, [mailAccounts, user?.defaultMailAccountId, isAccountsPending, isAccountsError, mutateDefaultAccount])
 
   const handleSaveDefaultAccount = () => {
     if (!selectedDefaultAccount) return

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -20,7 +20,7 @@ export const Route = createFileRoute("/_authenticated/settings/account")({
 })
 
 function SettingsAccountPage() {
-  const { data: user } = useUser()
+  const { data: user, isPending: isUserPending } = useUser()
   const { data: mailAccounts, isPending: isAccountsPending, isError: isAccountsError } = useMailAccounts()
   const [toggledIds, setToggledIds] = useState<Set<string>>(new Set())
   const [defaultAccount, setDefaultAccount] = useState<string | null>(null)
@@ -48,15 +48,17 @@ function SettingsAccountPage() {
 
   useEffect(() => {
     if (
+      !isUserPending &&
+      user &&
       !isAccountsPending &&
       !isAccountsError &&
-      !user?.defaultMailAccountId &&
+      !user.defaultMailAccountId &&
       mailAccounts &&
       mailAccounts.length > 0
     ) {
       mutateDefaultAccount({ mailAccountId: mailAccounts[0].id })
     }
-  }, [mailAccounts, user?.defaultMailAccountId, isAccountsPending, isAccountsError, mutateDefaultAccount])
+  }, [mailAccounts, user, isUserPending, isAccountsPending, isAccountsError, mutateDefaultAccount])
 
   const handleSaveDefaultAccount = () => {
     if (!selectedDefaultAccount) return
@@ -119,7 +121,7 @@ function SettingsAccountPage() {
 
         <Card>
           <CardHeader>
-            <CardTitle>계정 관리</CardTitle>
+            <CardTitle>메일 계정 관리</CardTitle>
             <CardDescription>연결된 메일 계정의 활성화 상태와 별칭을 확인합니다.</CardDescription>
           </CardHeader>
           <CardContent className="px-0">
@@ -198,7 +200,7 @@ function SettingsAccountPage() {
 
         <Card>
           <CardHeader>
-            <CardTitle>계정 추가하기</CardTitle>
+            <CardTitle>메일 계정 추가하기</CardTitle>
             <CardDescription>
               계정의 별칭, 아이콘, 색상을 선택한 뒤 로그인 절차를 거쳐 메일 계정을 연결할 수 있습니다.
             </CardDescription>

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -87,6 +87,7 @@ function SettingsPage() {
                     type="button"
                     // TODO: 실제 설정 저장 기능 구현 시 주석 해제
                     onClick={() => setInboxView(value)}
+                    aria-pressed={inboxView === value}
                     className={cn(
                       "group flex flex-col gap-2 rounded-xl border-2 p-2.5 text-left transition-all focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
                       inboxView === value
@@ -133,6 +134,7 @@ function SettingsPage() {
                     key={value}
                     type="button"
                     onClick={() => setTheme(value)}
+                    aria-pressed={theme === value}
                     className={cn(
                       "group flex flex-col gap-2 rounded-xl border-2 p-2.5 text-left transition-all focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
                       theme === value
@@ -178,6 +180,7 @@ function SettingsPage() {
                     key={value}
                     type="button"
                     onClick={() => setHoverAction(value)}
+                    aria-pressed={hoverAction === value}
                     className={cn(
                       "flex items-center justify-between rounded-xl border-2 px-3 py-2 text-left transition-all focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
                       hoverAction === value

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { Link, createFileRoute, useLocation } from "@tanstack/react-router"
-import { Check, Monitor, Moon, Sparkles, Sun } from "lucide-react"
+import { Check, LayoutList, List, Monitor, Moon, Sparkles, Sun } from "lucide-react"
 
+import { InboxSingleLinePreview, InboxTwoLinePreview } from "@/components/inbox-preview"
 import { NotificationSettingsCard } from "@/components/notification-settings-card"
 import { useTheme } from "@/components/theme-provider"
 import { DarkPreview, LightPreview, SystemPreview } from "@/components/theme-preview"
@@ -19,6 +20,9 @@ function SettingsPage() {
   const { data: user, isPending: isUserPending } = useUser()
   const { theme, setTheme } = useTheme()
   const { hash } = useLocation()
+
+  // TODO: 실제 설정 저장/불러오기 기능은 추후 구현 예정
+  const [inboxView, setInboxView] = useState<"single" | "double">("double")
 
   useEffect(() => {
     if (!hash) return
@@ -66,10 +70,46 @@ function SettingsPage() {
           <p className="text-md px-1 font-semibold text-muted-foreground">빠른 설정</p>
           <Card>
             <CardHeader>
-              <CardTitle>받은 편지함</CardTitle>
-              <CardDescription>받은 편지함의 읽기창을 설정합니다.</CardDescription>
+              <CardTitle>받은편지함</CardTitle>
+              <CardDescription>메일 목록의 표시 방식을 선택합니다.</CardDescription>
             </CardHeader>
-            <CardContent className="py-4 text-center text-sm text-muted-foreground">준비 중입니다.</CardContent>
+            <CardContent className="pt-1 pb-5">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {(
+                  [
+                    { value: "single", label: "한 줄 보기", icon: List, preview: <InboxSingleLinePreview /> },
+                    { value: "double", label: "두 줄 보기", icon: LayoutList, preview: <InboxTwoLinePreview /> },
+                  ] as const
+                ).map(({ value, label, icon: Icon, preview }) => (
+                  <button
+                    key={value}
+                    type="button"
+                    // TODO: 실제 설정 저장 기능 구현 시 주석 해제
+                    onClick={() => setInboxView(value)}
+                    className={cn(
+                      "group flex flex-col gap-2 rounded-xl border-2 p-2.5 text-left transition-all focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+                      inboxView === value
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:border-border/80 hover:bg-muted/40"
+                    )}
+                  >
+                    {preview}
+                    <div className="flex items-center justify-between px-0.5">
+                      <span
+                        className={cn(
+                          "flex items-center gap-1.5 text-xs font-medium",
+                          inboxView === value ? "text-primary" : "text-muted-foreground"
+                        )}
+                      >
+                        <Icon className="size-3.5" />
+                        {label}
+                      </span>
+                      {inboxView === value && <Check className="size-3.5 text-primary" />}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </CardContent>
           </Card>
         </div>
 

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import { Link, createFileRoute, useLocation } from "@tanstack/react-router"
-import { Check, LayoutList, List, Monitor, Moon, Sparkles, Sun } from "lucide-react"
+import { Check, LayoutList, List, Monitor, Moon, MousePointer, MousePointerClick, Sparkles, Sun } from "lucide-react"
 
 import { InboxSingleLinePreview, InboxTwoLinePreview } from "@/components/inbox-preview"
 import { NotificationSettingsCard } from "@/components/notification-settings-card"
@@ -23,6 +23,7 @@ function SettingsPage() {
 
   // TODO: 실제 설정 저장/불러오기 기능은 추후 구현 예정
   const [inboxView, setInboxView] = useState<"single" | "double">("double")
+  const [hoverAction, setHoverAction] = useState<"enabled" | "disabled">("enabled")
 
   useEffect(() => {
     if (!hash) return
@@ -152,6 +153,48 @@ function SettingsPage() {
                       </span>
                       {theme === value && <Check className="size-3.5 text-primary" />}
                     </div>
+                  </button>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <Card>
+            <CardHeader>
+              <CardTitle>마우스 오버 작업 사용</CardTitle>
+              <CardDescription>마우스 오버 동작으로 메일 내용 미리보기 등의 기능을 사용할 수 있습니다.</CardDescription>
+            </CardHeader>
+            <CardContent className="pt-1 pb-5">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {(
+                  [
+                    { value: "enabled", label: "사용", icon: MousePointerClick },
+                    { value: "disabled", label: "미사용", icon: MousePointer },
+                  ] as const
+                ).map(({ value, label, icon: Icon }) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setHoverAction(value)}
+                    className={cn(
+                      "flex items-center justify-between rounded-xl border-2 px-3 py-2 text-left transition-all focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+                      hoverAction === value
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:border-border/80 hover:bg-muted/40"
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "flex items-center gap-2 text-sm font-medium",
+                        hoverAction === value ? "text-primary" : "text-muted-foreground"
+                      )}
+                    >
+                      <Icon className="size-4" />
+                      {label}
+                    </span>
+                    {hoverAction === value && <Check className="size-4 text-primary" />}
                   </button>
                 ))}
               </div>

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -1,31 +1,127 @@
 import { Link, createFileRoute } from "@tanstack/react-router"
+import { Check, Monitor, Moon, Sparkles, Sun } from "lucide-react"
 
 import { NotificationSettingsCard } from "@/components/notification-settings-card"
+import { useTheme } from "@/components/theme-provider"
+import { DarkPreview, LightPreview, SystemPreview } from "@/components/theme-preview"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { ScrollArea } from "@/components/ui/scroll-area"
 import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { useUser } from "@/queries/user"
 
 export const Route = createFileRoute("/_authenticated/settings/")({
   component: SettingsPage,
 })
 
 function SettingsPage() {
-  return (
-    <div className="flex flex-col gap-6 px-3 pt-1 pb-4">
-      <Card>
-        <CardHeader>
-          <CardTitle>설정 홈</CardTitle>
-          <CardDescription>메일상자 환경과 연결된 계정을 여기서 관리할 수 있습니다.</CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          <div>
-            <Button variant="outline" render={<Link to="/settings/account" />}>
-              계정 설정으로 이동
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+  const { data: user, isPending: isUserPending } = useUser()
+  const { theme, setTheme } = useTheme()
 
-      <NotificationSettingsCard />
-    </div>
+  return (
+    <ScrollArea className="h-full">
+      <div className="flex flex-col gap-4 px-3 pt-1 pb-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>계정 정보</CardTitle>
+            <CardDescription>현재 로그인한 사용자와 구독 플랜 정보를 확인합니다.</CardDescription>
+          </CardHeader>
+          <CardContent className="pt-4">
+            <div className="grid grid-cols-3 divide-x">
+              <div className="flex flex-col gap-1 pr-4">
+                <p className="text-xs text-muted-foreground">이름</p>
+                <p className="text-sm font-medium">{isUserPending ? "..." : (user?.name ?? "-")}</p>
+              </div>
+              <div className="flex flex-col gap-1 px-4">
+                <p className="text-xs text-muted-foreground">아이디</p>
+                <p className="text-sm font-medium">{user?.username ?? "-"}</p>
+              </div>
+              <div className="relative flex flex-col gap-1 pl-4">
+                {user?.plan === "FREE" && (
+                  <Link
+                    to="/"
+                    className="absolute -top-8 left-2 z-10 inline-flex animate-bounce items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-primary transition-colors hover:bg-primary/20"
+                  >
+                    <Sparkles className="size-3" />
+                    요금제 업그레이드
+                    <span className="absolute -bottom-1.75 left-3 size-0 border-x-[6px] border-t-[7px] border-x-transparent border-t-primary/10" />
+                  </Link>
+                )}
+                <p className="text-xs text-muted-foreground">플랜</p>
+                <p className="text-sm font-medium">{user?.plan ?? "-"}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="flex flex-col gap-3">
+          <p className="text-md px-1 font-semibold text-muted-foreground">빠른 설정</p>
+          <Card>
+            <CardHeader>
+              <CardTitle>받은 편지함</CardTitle>
+              <CardDescription>받은 편지함의 읽기창을 설정합니다.</CardDescription>
+            </CardHeader>
+            <CardContent className="py-4 text-center text-sm text-muted-foreground">준비 중입니다.</CardContent>
+          </Card>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <Card>
+            <CardHeader>
+              <CardTitle>다크모드</CardTitle>
+              <CardDescription>서비스의 테마를 선택합니다.</CardDescription>
+            </CardHeader>
+            <CardContent className="pt-1 pb-5">
+              <div className="grid grid-cols-3 gap-3">
+                {(
+                  [
+                    { value: "light", label: "라이트", icon: Sun, preview: <LightPreview /> },
+                    { value: "system", label: "시스템", icon: Monitor, preview: <SystemPreview /> },
+                    { value: "dark", label: "다크", icon: Moon, preview: <DarkPreview /> },
+                  ] as const
+                ).map(({ value, label, icon: Icon, preview }) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setTheme(value)}
+                    className={cn(
+                      "group flex flex-col gap-2 rounded-xl border-2 p-2.5 text-left transition-all focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+                      theme === value
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:border-border/80 hover:bg-muted/40"
+                    )}
+                  >
+                    {preview}
+                    <div className="flex items-center justify-between px-0.5">
+                      <span
+                        className={cn(
+                          "flex items-center gap-1.5 text-xs font-medium",
+                          theme === value ? "text-primary" : "text-muted-foreground"
+                        )}
+                      >
+                        <Icon className="size-3.5" />
+                        {label}
+                      </span>
+                      {theme === value && <Check className="size-3.5 text-primary" />}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <p className="text-md px-1 font-semibold text-muted-foreground">알림</p>
+          <NotificationSettingsCard />
+        </div>
+
+        <div className="flex justify-end pt-4">
+          <Button variant="ghost" size="sm" className="text-xs text-muted-foreground hover:text-destructive" disabled>
+            회원 탈퇴
+          </Button>
+        </div>
+      </div>
+    </ScrollArea>
   )
 }

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react"
-import { Link, createFileRoute, useLocation } from "@tanstack/react-router"
+import { useState } from "react"
+import { Link, createFileRoute } from "@tanstack/react-router"
 import { Check, LayoutList, List, Monitor, Moon, MousePointer, MousePointerClick, Sparkles, Sun } from "lucide-react"
 
 import { InboxSingleLinePreview, InboxTwoLinePreview } from "@/components/inbox-preview"
@@ -8,7 +8,6 @@ import { useTheme } from "@/components/theme-provider"
 import { DarkPreview, LightPreview, SystemPreview } from "@/components/theme-preview"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { useUser } from "@/queries/user"
 
@@ -19,23 +18,16 @@ export const Route = createFileRoute("/_authenticated/settings/")({
 function SettingsPage() {
   const { data: user, isPending: isUserPending } = useUser()
   const { theme, setTheme } = useTheme()
-  const { hash } = useLocation()
-
   // TODO: 실제 설정 저장/불러오기 기능은 추후 구현 예정
   const [inboxView, setInboxView] = useState<"single" | "double">("double")
   const [hoverAction, setHoverAction] = useState<"enabled" | "disabled">("enabled")
-
-  useEffect(() => {
-    if (!hash) return
-    document.getElementById(hash)?.scrollIntoView({ behavior: "smooth" })
-  }, [hash])
 
   return (
     <ScrollArea className="h-full">
       <div className="flex flex-col gap-4 pb-4">
         <Card>
           <CardHeader>
-            <CardTitle>계정 정보</CardTitle>
+            <CardTitle>사용자 정보</CardTitle>
             <CardDescription>현재 로그인한 사용자와 구독 플랜 정보를 확인합니다.</CardDescription>
           </CardHeader>
           <CardContent className="pt-4">
@@ -67,6 +59,11 @@ function SettingsPage() {
           </CardContent>
         </Card>
 
+        <div id="notification-settings" className="flex flex-col gap-3">
+          <p className="text-md px-1 font-semibold text-muted-foreground">알림</p>
+          <NotificationSettingsCard />
+        </div>
+
         <div className="flex flex-col gap-3">
           <p className="text-md px-1 font-semibold text-muted-foreground">빠른 설정</p>
           <Card>
@@ -96,7 +93,7 @@ function SettingsPage() {
                     )}
                   >
                     {preview}
-                    <div className="flex items-center justify-between px-0.5">
+                    <div className="mt-auto flex items-center justify-between px-0.5">
                       <span
                         className={cn(
                           "flex items-center gap-1.5 text-xs font-medium",
@@ -205,20 +202,13 @@ function SettingsPage() {
           </Card>
         </div>
 
-        <div id="notification-settings" className="flex flex-col gap-3">
-          <p className="text-md px-1 font-semibold text-muted-foreground">알림</p>
-          <NotificationSettingsCard />
-        </div>
-
-        <div className="flex justify-end">
-          <Button
-            variant="ghost"
-            size="sm"
+        <div className="flex justify-end pr-4">
+          <a
+            href="mailto:mailsangja2026@gmail.com?subject=회원 탈퇴 요청"
             className="cursor-pointer text-xs text-muted-foreground hover:text-destructive"
-            disabled
           >
             회원 탈퇴
-          </Button>
+          </a>
         </div>
       </div>
     </ScrollArea>

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -165,8 +165,8 @@ function SettingsPage() {
         <div className="flex flex-col gap-3">
           <Card>
             <CardHeader>
-              <CardTitle>마우스 오버 작업 사용</CardTitle>
-              <CardDescription>마우스 오버 동작으로 메일 내용 미리보기 등의 기능을 사용할 수 있습니다.</CardDescription>
+              <CardTitle>메일 미리보기 활성화</CardTitle>
+              <CardDescription>메일 위에 마우스를 올리면 내용을 미리 확인할 수 있습니다.</CardDescription>
             </CardHeader>
             <CardContent className="pt-1 pb-5">
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -32,7 +32,7 @@ function SettingsPage() {
 
   return (
     <ScrollArea className="h-full">
-      <div className="flex flex-col gap-4 px-3 pt-1 pb-4">
+      <div className="flex flex-col gap-4 pb-4">
         <Card>
           <CardHeader>
             <CardTitle>계정 정보</CardTitle>

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -1,4 +1,5 @@
-import { Link, createFileRoute } from "@tanstack/react-router"
+import { useEffect } from "react"
+import { Link, createFileRoute, useLocation } from "@tanstack/react-router"
 import { Check, Monitor, Moon, Sparkles, Sun } from "lucide-react"
 
 import { NotificationSettingsCard } from "@/components/notification-settings-card"
@@ -17,6 +18,12 @@ export const Route = createFileRoute("/_authenticated/settings/")({
 function SettingsPage() {
   const { data: user, isPending: isUserPending } = useUser()
   const { theme, setTheme } = useTheme()
+  const { hash } = useLocation()
+
+  useEffect(() => {
+    if (!hash) return
+    document.getElementById(hash)?.scrollIntoView({ behavior: "smooth" })
+  }, [hash])
 
   return (
     <ScrollArea className="h-full">
@@ -27,28 +34,29 @@ function SettingsPage() {
             <CardDescription>현재 로그인한 사용자와 구독 플랜 정보를 확인합니다.</CardDescription>
           </CardHeader>
           <CardContent className="pt-4">
-            <div className="grid grid-cols-3 divide-x">
-              <div className="flex flex-col gap-1 pr-4">
+            <div className="grid grid-cols-1 divide-y sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+              <div className="flex flex-col gap-1 pb-4 sm:pr-4 sm:pb-0">
                 <p className="text-xs text-muted-foreground">이름</p>
                 <p className="text-sm font-medium">{isUserPending ? "..." : (user?.name ?? "-")}</p>
               </div>
-              <div className="flex flex-col gap-1 px-4">
+              <div className="flex flex-col gap-1 py-4 sm:px-4 sm:py-0">
                 <p className="text-xs text-muted-foreground">아이디</p>
                 <p className="text-sm font-medium">{user?.username ?? "-"}</p>
               </div>
-              <div className="relative flex flex-col gap-1 pl-4">
+              <div className="relative flex flex-col gap-1 pt-4 sm:pt-0 sm:pl-4">
+                <p className="text-xs text-muted-foreground">플랜</p>
+                <p className="text-sm font-medium">{user?.plan ?? "-"}</p>
                 {user?.plan === "FREE" && (
                   <Link
+                    // 추후에 요금제 페이지가 생기면 해당 페이지로 링크 변경 필요
                     to="/"
-                    className="absolute -top-8 left-2 z-10 inline-flex animate-bounce items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-primary transition-colors hover:bg-primary/20"
+                    className="relative mt-1 inline-flex w-fit animate-bounce items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-primary transition-colors hover:bg-primary/20 sm:absolute sm:-top-8 sm:left-2 sm:z-10 sm:mt-0"
                   >
                     <Sparkles className="size-3" />
                     요금제 업그레이드
-                    <span className="absolute -bottom-1.75 left-3 size-0 border-x-[6px] border-t-[7px] border-x-transparent border-t-primary/10" />
+                    <span className="absolute -bottom-1.75 left-3 hidden size-0 border-x-[6px] border-t-[7px] border-x-transparent border-t-primary/10 sm:block" />
                   </Link>
                 )}
-                <p className="text-xs text-muted-foreground">플랜</p>
-                <p className="text-sm font-medium">{user?.plan ?? "-"}</p>
               </div>
             </div>
           </CardContent>
@@ -72,7 +80,7 @@ function SettingsPage() {
               <CardDescription>서비스의 테마를 선택합니다.</CardDescription>
             </CardHeader>
             <CardContent className="pt-1 pb-5">
-              <div className="grid grid-cols-3 gap-3">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
                 {(
                   [
                     { value: "light", label: "라이트", icon: Sun, preview: <LightPreview /> },
@@ -111,13 +119,18 @@ function SettingsPage() {
           </Card>
         </div>
 
-        <div className="flex flex-col gap-3">
+        <div id="notification-settings" className="flex flex-col gap-3">
           <p className="text-md px-1 font-semibold text-muted-foreground">알림</p>
           <NotificationSettingsCard />
         </div>
 
-        <div className="flex justify-end pt-4">
-          <Button variant="ghost" size="sm" className="text-xs text-muted-foreground hover:text-destructive" disabled>
+        <div className="flex justify-end">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="cursor-pointer text-xs text-muted-foreground hover:text-destructive"
+            disabled
+          >
             회원 탈퇴
           </Button>
         </div>

--- a/src/routes/_authenticated/settings/label/$labelId.tsx
+++ b/src/routes/_authenticated/settings/label/$labelId.tsx
@@ -1,72 +1,84 @@
-import { useState } from "react"
-import { Link, createFileRoute } from "@tanstack/react-router"
-import { ArrowLeft, Plus, X } from "lucide-react"
+import { useState, type ElementType } from "react"
+import { createFileRoute, useNavigate, Link } from "@tanstack/react-router"
+import { BellRing, Bell, BellOff, Plus, X, ChevronLeft, ChevronDown } from "lucide-react"
 import { toast } from "sonner"
 
-import { Button, buttonVariants } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Skeleton } from "@/components/ui/skeleton"
 import { LabelConditionList } from "@/components/label/label-condition-list"
+import { LabelDeleteDialog } from "@/components/label/label-delete-dialog"
 import { LabelRuleDialog } from "@/components/label/label-rule-dialog"
 import { getErrorMessage } from "@/lib/http-error"
-import { useUpdateLabelRule } from "@/mutations/labels"
+import { LABEL_COLORS } from "@/lib/label-colors"
+import { cn } from "@/lib/utils"
+import { useUpdateLabel, useUpdateLabelRule } from "@/mutations/labels"
 import { useLabelDetail } from "@/queries/labels"
+import { NOTIFICATION_POLICY_LABELS, type LabelDetail, type NotificationPolicy } from "@/types/label"
 
 export const Route = createFileRoute("/_authenticated/settings/label/$labelId")({
   component: LabelDetailPage,
 })
 
+const NOTIFICATION_OPTIONS: { value: NotificationPolicy; icon: ElementType }[] = [
+  { value: "URGENT", icon: BellRing },
+  { value: "INHERIT", icon: Bell },
+  { value: "SILENT", icon: BellOff },
+]
+
 function LabelDetailPage() {
   const { labelId } = Route.useParams()
   const { data: label, isPending, isError } = useLabelDetail(labelId)
-  const updateRule = useUpdateLabelRule()
-  const [ruleDialogOpen, setRuleDialogOpen] = useState(false)
-
-  const groups = label?.rule?.groups ?? []
-
-  function handleDeleteGroup(groupIndex: number) {
-    const newGroups = groups.filter((_, i) => i !== groupIndex)
-    updateRule.mutate(
-      { labelId, data: { groups: newGroups } },
-      {
-        onSuccess: () => toast.success("규칙이 삭제되었습니다."),
-        onError: (e) => toast.error(getErrorMessage(e, "규칙 삭제에 실패했습니다.")),
-      }
-    )
-  }
 
   if (isPending) {
     return (
       <ScrollArea className="min-h-0 flex-1">
         <div className="flex flex-col gap-6 px-3 pt-1 pb-4">
-          <div>
-            <Skeleton className="h-8 w-40 rounded-md" />
+          <div className="flex items-center gap-2">
+            <Skeleton className="size-3.5 shrink-0 rounded-sm" />
+            <Skeleton className="h-6 w-24" />
           </div>
-          <div className="flex flex-col gap-4">
-            <div>
-              <div className="flex items-center gap-2">
-                <Skeleton className="size-3.5 shrink-0 rounded-sm" />
-                <Skeleton className="h-6 w-24" />
-              </div>
-              <Skeleton className="mt-2 h-4 w-80 max-w-full" />
-            </div>
-            {[0, 1].map((i) => (
-              <Card key={i} className="gap-0 overflow-hidden">
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 border-b px-4 py-2.5">
-                  <Skeleton className="h-4 w-12" />
-                  <Skeleton className="size-7 rounded-md" />
-                </CardHeader>
-                <CardContent className="flex flex-col gap-2 px-4 py-3">
-                  <div className="flex items-center gap-2">
-                    <Skeleton className="h-5 w-20 rounded-full" />
-                    <Skeleton className="h-3.5 w-8" />
-                    <Skeleton className="h-5 w-36 rounded-sm" />
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-5 w-28" />
+              <Skeleton className="h-3.5 w-64" />
+            </CardHeader>
+            <CardContent className="flex flex-col gap-2">
+              {[0, 1].map((i) => (
+                <div key={i} className="overflow-hidden rounded-lg border">
+                  <div className="flex items-center justify-between bg-muted/50 px-3 py-1.5">
+                    <Skeleton className="h-3.5 w-10" />
+                    <Skeleton className="size-7 rounded-md" />
                   </div>
-                </CardContent>
-              </Card>
-            ))}
-            <Skeleton className="h-9 w-full rounded-md" />
+                  <div className="px-3 py-2.5">
+                    <div className="flex items-center gap-2">
+                      <Skeleton className="h-5 w-20 rounded-full" />
+                      <Skeleton className="h-3.5 w-8" />
+                      <Skeleton className="h-5 w-36 rounded-sm" />
+                    </div>
+                  </div>
+                </div>
+              ))}
+              <Skeleton className="h-9 w-full rounded-md" />
+            </CardContent>
+          </Card>
+          <div className="flex flex-col gap-3">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-11 w-full rounded-xl" />
+          </div>
+          <div className="flex flex-col gap-3">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-11 w-full rounded-xl" />
+          </div>
+          <div className="flex flex-col gap-3">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-24 w-full rounded-xl" />
+          </div>
+          <div className="flex flex-col gap-3">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-14 w-full rounded-xl" />
           </div>
         </div>
       </ScrollArea>
@@ -87,65 +99,264 @@ function LabelDetailPage() {
     )
   }
 
+  return <LabelDetailContent labelId={labelId} label={label} />
+}
+
+function LabelDetailContent({ labelId, label }: { labelId: string; label: LabelDetail }) {
+  const navigate = useNavigate()
+  const updateLabel = useUpdateLabel()
+  const updateRule = useUpdateLabelRule()
+
+  const [ruleDialogOpen, setRuleDialogOpen] = useState(false)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [name, setName] = useState(label.name)
+  const [selectedColor, setSelectedColor] = useState(label.colorCode)
+  const [notificationPolicy, setNotificationPolicy] = useState<NotificationPolicy>(label.notificationPolicy)
+
+  const groups = label.rule?.groups ?? []
+  const [expandedGroups, setExpandedGroups] = useState<Set<number>>(() => new Set(groups.map((_, i) => i)))
+
+  function toggleGroup(index: number) {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev)
+      if (next.has(index)) next.delete(index)
+      else next.add(index)
+      return next
+    })
+  }
+
+  function handleDeleteGroup(groupIndex: number) {
+    const newGroups = groups.filter((_, i) => i !== groupIndex)
+    updateRule.mutate(
+      { labelId, data: { groups: newGroups } },
+      {
+        onSuccess: () => toast.success("규칙이 삭제되었습니다."),
+        onError: (e) => toast.error(getErrorMessage(e, "규칙 삭제에 실패했습니다.")),
+      }
+    )
+  }
+
+  function handleSaveNotification(policy: NotificationPolicy) {
+    setNotificationPolicy(policy)
+    updateLabel.mutate(
+      { labelId, data: { notificationPolicy: policy } },
+      {
+        onSuccess: () => toast.success("알림 설정이 변경되었습니다."),
+        onError: (e) => {
+          setNotificationPolicy(label.notificationPolicy)
+          toast.error(getErrorMessage(e, "알림 설정 변경에 실패했습니다."))
+        },
+      }
+    )
+  }
+
+  function handleSaveName() {
+    const trimmed = name.trim()
+    if (!trimmed || trimmed === label.name) return
+    updateLabel.mutate(
+      { labelId, data: { name: trimmed } },
+      {
+        onSuccess: () => toast.success("라벨 이름이 변경되었습니다."),
+        onError: (e) => {
+          setName(label.name)
+          toast.error(getErrorMessage(e, "라벨 이름 변경에 실패했습니다."))
+        },
+      }
+    )
+  }
+
+  function handleSaveColor() {
+    if (selectedColor === label.colorCode) return
+    updateLabel.mutate(
+      { labelId, data: { colorCode: selectedColor } },
+      {
+        onSuccess: () => toast.success("라벨 색상이 변경되었습니다."),
+        onError: (e) => {
+          setSelectedColor(label.colorCode)
+          toast.error(getErrorMessage(e, "라벨 색상 변경에 실패했습니다."))
+        },
+      }
+    )
+  }
+
   return (
     <ScrollArea className="min-h-0 flex-1">
       <div className="flex flex-col gap-6 px-3 pt-1 pb-4">
-        <div>
-          <Link to="/settings/label" className={buttonVariants({ variant: "ghost", size: "sm" })}>
-            <ArrowLeft className="size-5" />
-            라벨 목록으로 돌아가기
-          </Link>
-        </div>
+        <Link to="/settings/label" className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+          <ChevronLeft className="size-4" />
+          뒤로
+        </Link>
+        <section className="flex flex-col gap-3">
+          <Card>
+            <CardHeader>
+              <CardTitle>라벨 규칙 관리</CardTitle>
+              <CardDescription>
+                이 라벨에 자동으로 분류될 메일의 규칙을 설정합니다. 규칙이 여러 개이면 하나라도 만족하면 분류됩니다.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-2">
+              {groups.map((group, groupIndex) => {
+                const isExpanded = expandedGroups.has(groupIndex)
+                return (
+                  <div key={groupIndex} className="overflow-hidden rounded-xl border bg-card">
+                    <div className="flex items-center gap-1 p-2.5">
+                      <button
+                        type="button"
+                        className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                        onClick={() => toggleGroup(groupIndex)}
+                      >
+                        <ChevronDown
+                          className={cn(
+                            "size-4 shrink-0 text-muted-foreground transition-transform",
+                            isExpanded ? "rotate-0" : "-rotate-90"
+                          )}
+                        />
+                        <span className="text-sm font-medium">규칙 {groupIndex + 1}</span>
+                      </button>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={() => handleDeleteGroup(groupIndex)}
+                        disabled={updateRule.isPending}
+                        aria-label="규칙 삭제"
+                      >
+                        <X className="size-4 text-muted-foreground" />
+                      </Button>
+                    </div>
+                    {isExpanded && (
+                      <div className="border-t px-4 py-3">
+                        <LabelConditionList conditions={group.conditions} />
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={() => setRuleDialogOpen(true)}
+                disabled={updateRule.isPending}
+              >
+                <Plus className="size-4" />
+                규칙 추가
+              </Button>
+            </CardContent>
+          </Card>
+        </section>
 
-        <div className="flex flex-col gap-4">
-          <div>
-            <div className="flex items-center gap-2">
-              <span
-                className="inline-block size-3.5 shrink-0 rounded-sm"
-                style={{ backgroundColor: label.colorCode }}
-              />
-              <h2 className="text-lg font-semibold">{label.name}</h2>
-            </div>
-            <p className="mt-1 text-sm text-muted-foreground">
-              이 라벨에 자동으로 분류될 메일의 규칙을 설정합니다. 규칙이 여러 개이면 하나라도 만족하면 분류됩니다.
-            </p>
-          </div>
-
-          {groups.map((group, groupIndex) => (
-            <div key={groupIndex} className="flex flex-col gap-2">
-              <Card className="gap-0">
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
-                  <CardTitle className="text-sm font-medium text-muted-foreground">규칙 {groupIndex + 1}</CardTitle>
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    onClick={() => handleDeleteGroup(groupIndex)}
-                    disabled={updateRule.isPending}
-                    aria-label="규칙 삭제"
+        <section className="flex flex-col gap-3">
+          <Card>
+            <CardHeader>
+              <CardTitle>알림 설정</CardTitle>
+              <CardDescription>
+                알림 설정은 <strong>기본 ＜ 알림 안함 ＜ 항상 알림</strong> 순으로 우선순위를 가집니다.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex gap-2">
+                {NOTIFICATION_OPTIONS.map(({ value, icon: Icon }) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => handleSaveNotification(value)}
+                    disabled={updateLabel.isPending}
+                    className={cn(
+                      "flex flex-1 items-center justify-center gap-1.5 rounded-md border px-3 py-1.5 text-xs transition-colors",
+                      notificationPolicy === value
+                        ? "border-primary bg-primary/10 text-primary"
+                        : "border-border text-muted-foreground hover:bg-muted"
+                    )}
                   >
-                    <X className="size-4" />
-                  </Button>
-                </CardHeader>
-                <CardContent>
-                  <LabelConditionList conditions={group.conditions} />
-                </CardContent>
-              </Card>
-            </div>
-          ))}
+                    <Icon className="size-3.5" />
+                    {NOTIFICATION_POLICY_LABELS[value]}
+                  </button>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </section>
 
-          <Button
-            variant="outline"
-            className="w-full"
-            onClick={() => setRuleDialogOpen(true)}
-            disabled={updateRule.isPending}
-          >
-            <Plus className="size-4" />
-            규칙 추가
-          </Button>
-        </div>
+        <section className="flex flex-col gap-3">
+          <Card>
+            <CardHeader>
+              <CardTitle>이름 변경</CardTitle>
+              <CardDescription>라벨의 이름을 변경합니다.</CardDescription>
+            </CardHeader>
+            <CardContent className="flex gap-2">
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleSaveName()}
+                placeholder="라벨 이름"
+                className="w-2/5"
+              />
+              <Button
+                onClick={handleSaveName}
+                disabled={!name.trim() || name.trim() === label.name || updateLabel.isPending}
+              >
+                저장
+              </Button>
+            </CardContent>
+          </Card>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <Card>
+            <CardHeader>
+              <CardTitle>색상 변경</CardTitle>
+              <CardDescription>라벨의 색상을 변경합니다.</CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-6">
+              <div className="grid grid-cols-10 place-items-center gap-1.5">
+                {LABEL_COLORS.map((color) => (
+                  <button
+                    key={color}
+                    type="button"
+                    className="size-6 rounded-full ring-offset-2 transition-transform hover:scale-110 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                    style={{
+                      backgroundColor: color,
+                      boxShadow: selectedColor === color ? `0 0 0 2px white, 0 0 0 4px ${color}` : undefined,
+                    }}
+                    onClick={() => setSelectedColor(color)}
+                    aria-label={color}
+                    aria-pressed={selectedColor === color}
+                  />
+                ))}
+              </div>
+              <Button
+                onClick={handleSaveColor}
+                disabled={selectedColor === label.colorCode || updateLabel.isPending}
+                className="w-full"
+              >
+                저장
+              </Button>
+            </CardContent>
+          </Card>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-destructive">라벨 삭제</CardTitle>
+              <CardDescription>라벨을 삭제하면 해당 라벨이 적용된 메일에서 라벨이 제거됩니다.</CardDescription>
+            </CardHeader>
+            <CardContent className="flex items-center justify-between">
+              <Button variant="destructive" size="sm" onClick={() => setDeleteDialogOpen(true)}>
+                삭제
+              </Button>
+            </CardContent>
+          </Card>
+        </section>
       </div>
 
       <LabelRuleDialog open={ruleDialogOpen} onOpenChange={setRuleDialogOpen} labelId={labelId} />
+
+      <LabelDeleteDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        label={label}
+        onSuccess={() => void navigate({ to: "/settings/label" })}
+      />
     </ScrollArea>
   )
 }

--- a/src/routes/_authenticated/settings/label/$labelId.tsx
+++ b/src/routes/_authenticated/settings/label/$labelId.tsx
@@ -114,10 +114,10 @@ function LabelDetailContent({ labelId, label }: { labelId: string; label: LabelD
   const [notificationPolicy, setNotificationPolicy] = useState<NotificationPolicy>(label.notificationPolicy)
 
   const groups = label.rule?.groups ?? []
-  const [expandedGroups, setExpandedGroups] = useState<Set<number>>(() => new Set(groups.map((_, i) => i)))
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<number>>(new Set())
 
   function toggleGroup(index: number) {
-    setExpandedGroups((prev) => {
+    setCollapsedGroups((prev) => {
       const next = new Set(prev)
       if (next.has(index)) next.delete(index)
       else next.add(index)
@@ -126,6 +126,14 @@ function LabelDetailContent({ labelId, label }: { labelId: string; label: LabelD
   }
 
   function handleDeleteGroup(groupIndex: number) {
+    setCollapsedGroups((prev) => {
+      const next = new Set<number>()
+      for (const i of prev) {
+        if (i < groupIndex) next.add(i)
+        else if (i > groupIndex) next.add(i - 1)
+      }
+      return next
+    })
     const newGroups = groups.filter((_, i) => i !== groupIndex)
     updateRule.mutate(
       { labelId, data: { groups: newGroups } },
@@ -196,7 +204,7 @@ function LabelDetailContent({ labelId, label }: { labelId: string; label: LabelD
             </CardHeader>
             <CardContent className="flex flex-col gap-2">
               {groups.map((group, groupIndex) => {
-                const isExpanded = expandedGroups.has(groupIndex)
+                const isExpanded = !collapsedGroups.has(groupIndex)
                 return (
                   <div key={groupIndex} className="overflow-hidden rounded-xl border bg-card">
                     <div className="flex items-center gap-1 p-2.5">

--- a/src/routes/_authenticated/settings/label/$labelId.tsx
+++ b/src/routes/_authenticated/settings/label/$labelId.tsx
@@ -99,7 +99,7 @@ function LabelDetailPage() {
     )
   }
 
-  return <LabelDetailContent labelId={labelId} label={label} />
+  return <LabelDetailContent key={labelId} labelId={labelId} label={label} />
 }
 
 function LabelDetailContent({ labelId, label }: { labelId: string; label: LabelDetail }) {
@@ -257,7 +257,7 @@ function LabelDetailContent({ labelId, label }: { labelId: string; label: LabelD
             <CardHeader>
               <CardTitle>알림 설정</CardTitle>
               <CardDescription>
-                알림 설정은 <strong>기본 ＜ 알림 안함 ＜ 항상 알림</strong> 순으로 우선순위를 가집니다.
+                알림 설정은 <strong>항상 알림 ＞ 알림 안함 ＞ 기본</strong> 순으로 우선순위를 가집니다.
               </CardDescription>
             </CardHeader>
             <CardContent>

--- a/src/routes/_authenticated/settings/label/$labelId.tsx
+++ b/src/routes/_authenticated/settings/label/$labelId.tsx
@@ -189,7 +189,7 @@ function LabelDetailContent({ labelId, label }: { labelId: string; label: LabelD
 
   return (
     <ScrollArea className="min-h-0 flex-1">
-      <div className="flex flex-col gap-6 px-3 pt-1 pb-4">
+      <div className="flex flex-col gap-4 pb-4">
         <Link to="/settings/label" className="inline-flex items-center gap-2 text-sm text-muted-foreground">
           <ChevronLeft className="size-4" />
           뒤로

--- a/src/routes/_authenticated/settings/label/index.tsx
+++ b/src/routes/_authenticated/settings/label/index.tsx
@@ -2,23 +2,130 @@ import { useState, useRef, useEffect } from "react"
 import { createFileRoute, Link, useLocation } from "@tanstack/react-router"
 import { DndContext, closestCenter } from "@dnd-kit/core"
 import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable"
-import { ChevronRight, GripVertical, Plus } from "lucide-react"
+import { ChevronRight, GripVertical, MoreVertical, Pencil, Plus, Trash2 } from "lucide-react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { getErrorMessage } from "@/lib/http-error"
-import { useCreateLabel } from "@/mutations/labels"
-import { useLabels } from "@/queries/labels"
+import { useCreateLabel, useDeleteLabelGroup } from "@/mutations/labels"
+import { useLabels, useLabelGroups } from "@/queries/labels"
 import { useLabelOrder } from "@/hooks/use-label-order"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { LabelFormDialog, type LabelFormData } from "@/components/label/label-form-dialog"
-import type { LabelListItem } from "@/types/label"
+import { CreateLabelGroupDialog, EditLabelGroupDialog } from "@/components/label/label-group-form-dialog"
+import type { LabelGroupItem, LabelListItem } from "@/types/label"
 
 export const Route = createFileRoute("/_authenticated/settings/label/")({
   component: SettingsLabelPage,
 })
+
+function LabelGroupDeleteDialog({
+  open,
+  onOpenChange,
+  group,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  group: LabelGroupItem
+}) {
+  const deleteLabelGroup = useDeleteLabelGroup()
+
+  function handleDelete() {
+    deleteLabelGroup.mutate(group.id, {
+      onSuccess: () => {
+        onOpenChange(false)
+        toast.success(`${group.name} 그룹이 삭제되었습니다`)
+      },
+      onError: (e) => toast.error(getErrorMessage(e, "라벨 그룹 삭제에 실패했습니다.")),
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>삭제</DialogTitle>
+        </DialogHeader>
+        <p className="text-base text-muted-foreground">
+          {group.name} 그룹을 삭제하시겠습니까? 라벨 자체는 삭제되지 않습니다.
+        </p>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            취소
+          </Button>
+          <Button variant="destructive" onClick={handleDelete} disabled={deleteLabelGroup.isPending}>
+            삭제
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function LabelGroupTableRow({ group, allLabels }: { group: LabelGroupItem; allLabels: LabelListItem[] }) {
+  const [editOpen, setEditOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const groupLabels = allLabels.filter((label) => group.labelIds.includes(label.id))
+
+  return (
+    <TableRow>
+      <TableCell className="font-medium">
+        <div className="flex items-center gap-2.5">
+          <div className="flex w-8 shrink-0 items-center">
+            {groupLabels.slice(0, 3).map((label, i) => (
+              <span
+                key={label.id}
+                className="size-3 rounded-full"
+                style={{ backgroundColor: label.colorCode, marginLeft: i === 0 ? 0 : -6 }}
+              />
+            ))}
+            {groupLabels.length === 0 && (
+              <span className="size-3 rounded-full bg-muted-foreground/20 ring-1 ring-background" />
+            )}
+          </div>
+          {group.name}
+        </div>
+      </TableCell>
+      <TableCell className="text-center text-sm text-muted-foreground">{group.labelIds.length}개</TableCell>
+      <TableCell className="pr-6 text-right">
+        <DropdownMenu>
+          <DropdownMenuTrigger render={<Button variant="ghost" size="icon-sm" aria-label="그룹 메뉴" />}>
+            <MoreVertical className="size-4" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-36">
+            <DropdownMenuItem onClick={() => setEditOpen(true)}>
+              <Pencil />
+              수정
+            </DropdownMenuItem>
+            <DropdownMenuSeparator className="my-0.5" />
+            <DropdownMenuItem variant="destructive" onClick={() => setDeleteOpen(true)}>
+              <Trash2 />
+              삭제
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </TableCell>
+      <EditLabelGroupDialog
+        key={String(editOpen)}
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        group={group}
+        allLabels={allLabels}
+      />
+      <LabelGroupDeleteDialog open={deleteOpen} onOpenChange={setDeleteOpen} group={group} />
+    </TableRow>
+  )
+}
 
 function SortableLabelRow({ label }: { label: LabelListItem }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: label.id })
@@ -67,7 +174,9 @@ function SettingsLabelPage() {
   const location = useLocation()
   const createFilterRef = useRef<HTMLDivElement>(null)
   const [createOpen, setCreateOpen] = useState(false)
+  const [createGroupOpen, setCreateGroupOpen] = useState(false)
   const createLabel = useCreateLabel()
+  const { data: labelGroups = [] } = useLabelGroups()
 
   function handleCreate({ name, colorCode, notificationPolicy }: LabelFormData) {
     createLabel.mutate(
@@ -91,76 +200,130 @@ function SettingsLabelPage() {
 
   return (
     <ScrollArea className="min-h-0 flex-1">
-      <div className="flex flex-col gap-6 px-3 pt-1 pb-4">
-        <Card>
-          <CardHeader>
-            <CardTitle>라벨 관리</CardTitle>
-            <CardDescription>라벨 규칙 등 전반적인 설정을 관리합니다.</CardDescription>
-          </CardHeader>
-          <CardContent className="px-0">
-            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <div className="flex flex-col gap-6 px-2 pt-1 pb-4">
+        <div className="flex flex-col gap-3">
+          <p className="text-md px-1 font-semibold text-muted-foreground">라벨</p>
+          <Card>
+            <CardHeader>
+              <CardTitle>라벨 관리</CardTitle>
+              <CardDescription>라벨 규칙 등 전반적인 설정을 관리합니다.</CardDescription>
+            </CardHeader>
+            <CardContent className="px-0">
+              <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-8" />
+                      <TableHead className="w-10 text-center">색상</TableHead>
+                      <TableHead className="w-full">이름</TableHead>
+                      <TableHead className="w-16 pr-6 text-right">관리</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {isPending && (
+                      <TableRow>
+                        <TableCell colSpan={4} className="text-center text-sm text-muted-foreground">
+                          라벨 목록을 불러오는 중입니다.
+                        </TableCell>
+                      </TableRow>
+                    )}
+                    {isError && (
+                      <TableRow>
+                        <TableCell colSpan={4} className="text-center text-sm text-destructive">
+                          라벨 목록을 불러오지 못했습니다.
+                        </TableCell>
+                      </TableRow>
+                    )}
+                    {!isPending && !isError && orderedLabels.length === 0 && (
+                      <TableRow>
+                        <TableCell colSpan={4} className="text-center text-sm text-muted-foreground">
+                          등록된 라벨이 없습니다.
+                        </TableCell>
+                      </TableRow>
+                    )}
+                    <SortableContext items={orderedLabels.map((l) => l.id)} strategy={verticalListSortingStrategy}>
+                      {orderedLabels.map((label) => (
+                        <SortableLabelRow key={label.id} label={label} />
+                      ))}
+                    </SortableContext>
+                  </TableBody>
+                </Table>
+              </DndContext>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>라벨 추가하기</CardTitle>
+              <CardDescription>이름과 색상을 지정해 새 라벨을 만들 수 있습니다.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button variant="outline" onClick={() => setCreateOpen(true)}>
+                <Plus data-icon="inline-start" />
+                라벨 추가
+              </Button>
+              <LabelFormDialog
+                open={createOpen}
+                onOpenChange={setCreateOpen}
+                title="새 라벨 만들기"
+                submitLabel="만들기"
+                isPending={createLabel.isPending}
+                onSubmit={handleCreate}
+              />
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <p className="text-md px-1 font-semibold text-muted-foreground">라벨 그룹</p>
+          <Card>
+            <CardHeader>
+              <CardTitle>라벨 그룹 관리</CardTitle>
+              <CardDescription>라벨 그룹 목록을 확인하고 수정하거나 삭제합니다.</CardDescription>
+            </CardHeader>
+            <CardContent className="px-0">
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead className="w-8" />
-                    <TableHead className="w-10 text-center">색상</TableHead>
-                    <TableHead className="w-full">이름</TableHead>
+                    <TableHead className="w-full pl-12.5">이름</TableHead>
+                    <TableHead className="w-20 text-center">라벨 수</TableHead>
                     <TableHead className="w-16 pr-6 text-right">관리</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {isPending && (
+                  {labelGroups.length === 0 && (
                     <TableRow>
-                      <TableCell colSpan={4} className="text-center text-sm text-muted-foreground">
-                        라벨 목록을 불러오는 중입니다.
+                      <TableCell colSpan={3} className="text-center text-sm text-muted-foreground">
+                        등록된 라벨 그룹이 없습니다.
                       </TableCell>
                     </TableRow>
                   )}
-                  {isError && (
-                    <TableRow>
-                      <TableCell colSpan={4} className="text-center text-sm text-destructive">
-                        라벨 목록을 불러오지 못했습니다.
-                      </TableCell>
-                    </TableRow>
-                  )}
-                  {!isPending && !isError && orderedLabels.length === 0 && (
-                    <TableRow>
-                      <TableCell colSpan={4} className="text-center text-sm text-muted-foreground">
-                        등록된 라벨이 없습니다.
-                      </TableCell>
-                    </TableRow>
-                  )}
-                  <SortableContext items={orderedLabels.map((l) => l.id)} strategy={verticalListSortingStrategy}>
-                    {orderedLabels.map((label) => (
-                      <SortableLabelRow key={label.id} label={label} />
-                    ))}
-                  </SortableContext>
+                  {labelGroups.map((group) => (
+                    <LabelGroupTableRow key={group.id} group={group} allLabels={serverLabels} />
+                  ))}
                 </TableBody>
               </Table>
-            </DndContext>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>라벨 추가하기</CardTitle>
-            <CardDescription>이름과 색상을 지정해 새 라벨을 만들 수 있습니다.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button variant="outline" onClick={() => setCreateOpen(true)}>
-              <Plus data-icon="inline-start" />
-              라벨 추가
-            </Button>
-            <LabelFormDialog
-              open={createOpen}
-              onOpenChange={setCreateOpen}
-              title="새 라벨 만들기"
-              submitLabel="만들기"
-              isPending={createLabel.isPending}
-              onSubmit={handleCreate}
-            />
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>라벨 그룹 추가하기</CardTitle>
+              <CardDescription>다수의 라벨을 하나의 라벨 그룹으로 묶을 수 있습니다.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button variant="outline" onClick={() => setCreateGroupOpen(true)}>
+                <Plus data-icon="inline-start" />
+                라벨 그룹 추가
+              </Button>
+              <CreateLabelGroupDialog
+                open={createGroupOpen}
+                onOpenChange={setCreateGroupOpen}
+                labels={serverLabels}
+                groups={labelGroups}
+              />
+            </CardContent>
+          </Card>
+        </div>
       </div>
     </ScrollArea>
   )

--- a/src/routes/_authenticated/settings/label/index.tsx
+++ b/src/routes/_authenticated/settings/label/index.tsx
@@ -176,7 +176,7 @@ function SettingsLabelPage() {
   const [createOpen, setCreateOpen] = useState(false)
   const [createGroupOpen, setCreateGroupOpen] = useState(false)
   const createLabel = useCreateLabel()
-  const { data: labelGroups = [] } = useLabelGroups()
+  const { data: labelGroups = [], isPending: isGroupsPending, isError: isGroupsError } = useLabelGroups()
 
   function handleCreate({ name, colorCode, notificationPolicy }: LabelFormData) {
     createLabel.mutate(
@@ -252,26 +252,28 @@ function SettingsLabelPage() {
             </CardContent>
           </Card>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>라벨 추가하기</CardTitle>
-              <CardDescription>이름과 색상을 지정해 새 라벨을 만들 수 있습니다.</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Button variant="outline" onClick={() => setCreateOpen(true)}>
-                <Plus data-icon="inline-start" />
-                라벨 추가
-              </Button>
-              <LabelFormDialog
-                open={createOpen}
-                onOpenChange={setCreateOpen}
-                title="새 라벨 만들기"
-                submitLabel="만들기"
-                isPending={createLabel.isPending}
-                onSubmit={handleCreate}
-              />
-            </CardContent>
-          </Card>
+          <div ref={createFilterRef}>
+            <Card>
+              <CardHeader>
+                <CardTitle>라벨 추가하기</CardTitle>
+                <CardDescription>이름과 색상을 지정해 새 라벨을 만들 수 있습니다.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button variant="outline" onClick={() => setCreateOpen(true)}>
+                  <Plus data-icon="inline-start" />
+                  라벨 추가
+                </Button>
+                <LabelFormDialog
+                  open={createOpen}
+                  onOpenChange={setCreateOpen}
+                  title="새 라벨 만들기"
+                  submitLabel="만들기"
+                  isPending={createLabel.isPending}
+                  onSubmit={handleCreate}
+                />
+              </CardContent>
+            </Card>
+          </div>
         </div>
 
         <div className="flex flex-col gap-3">
@@ -291,7 +293,21 @@ function SettingsLabelPage() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {labelGroups.length === 0 && (
+                  {isGroupsPending && (
+                    <TableRow>
+                      <TableCell colSpan={3} className="text-center text-sm text-muted-foreground">
+                        라벨 그룹 목록을 불러오는 중입니다.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  {isGroupsError && (
+                    <TableRow>
+                      <TableCell colSpan={3} className="text-center text-sm text-destructive">
+                        라벨 그룹 목록을 불러오지 못했습니다.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  {!isGroupsPending && !isGroupsError && labelGroups.length === 0 && (
                     <TableRow>
                       <TableCell colSpan={3} className="text-center text-sm text-muted-foreground">
                         등록된 라벨 그룹이 없습니다.

--- a/src/routes/_authenticated/settings/label/index.tsx
+++ b/src/routes/_authenticated/settings/label/index.tsx
@@ -200,7 +200,7 @@ function SettingsLabelPage() {
 
   return (
     <ScrollArea className="min-h-0 flex-1">
-      <div className="flex flex-col gap-6 px-2 pt-1 pb-4">
+      <div className="flex flex-col gap-4 pb-4">
         <div className="flex flex-col gap-3">
           <p className="text-md px-1 font-semibold text-muted-foreground">라벨</p>
           <Card>


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#22
- mailsangja/docs4capstone#31

### 📌 Task

- Closes #62 
- Closes #99 

## 💡 작업 내용

- 라벨 설정 상세페이지에 알림 설정 추가
- 일반, 계정, 라벨 설정 페이지 UI 개선
- 첫 구글 로그인 시 기본 계정으로 자동 설정
- 일반 설정 페이지에 설정 내용 추가
- 라벨 설정 페이지에 라벨 그룹 설정 추가

## 📝 추가 설명

### 일반 설정

- 계정 설정에 있던 사용자 정보를 일반 설정으로 옮김
- 계정 플랜이 `FREE` 일 때, "요금제 업그레이드" 뱃지 표시. (`/`로 이동하도록 하였는데 추후에 요금제 페이지로 변경 필요)
- 받은편지함, 다크모드, 마우스 오버 작업 설정 추가, 현재는 로컬 useState로만 동작하며 실제 저장 로직은 미구현 상태
- 회원 탈퇴 버튼 우측 하단으로 옮긴 후 작게 변경
- 받은편지함 (1줄 or 2줄)과 마우스 오버 작업 설정 기능은 작동 x

### 계정 설정

- 첫 구글 로그인 시 기본 계정으로 자동 설정
- 계정 컬러 팔레트 변경 (회색 제거 및 톤다운)

### 라벨 설정

- 라벨 상세 설정 페이지(`settings/label/{labelId}`)에 라벨 이름, 알림, 색상 변경 및 라벨 제거 기능 생성
- 라벨 규칙 UI 수정
- 라벨 설정 페이지(`settings/label`)에 라벨 그룹 테이블 및 라벨 그룹 추가 생성
- 라벨 그룹에 대해서 상세 페이지를 만들지 않고, 기존의 다이얼로그 이용

### 기타

- 헤더의 알림 버튼 클릭 시 `일반 설정 > 푸시 알림`으로 이동하도록 hash 값 추가
- 사이드바 유저 메뉴에서 "설정"을 "내 계정"보다 위로 순서 변경


## 🖼️ 스크린샷

- 일반 설정
<img width="1919" height="866" alt="image" src="https://github.com/user-attachments/assets/7a43194c-e77f-4006-9417-bd24c1a6e8a0" />
<img width="1919" height="865" alt="image" src="https://github.com/user-attachments/assets/067fbf20-ad9d-4ebe-9aa5-07bb2ed3c4a3" />

- 계정 설정 컬러팔레트
<img width="598" height="597" alt="image" src="https://github.com/user-attachments/assets/1489f924-78c4-4507-b554-5c0ccf60a1f6" />

- 라벨 설정
<img width="1919" height="862" alt="image" src="https://github.com/user-attachments/assets/31087c33-6953-4ad6-bd75-9afd90636541" />

- 라벨 설정 상세 페이지
<img width="1062" height="687" alt="image" src="https://github.com/user-attachments/assets/a744830f-ad7f-4d6c-86aa-5596db65ce49" />
<img width="1037" height="794" alt="image" src="https://github.com/user-attachments/assets/e500ed49-aa57-43c6-ab67-0c98f41f915e" />
