### PR TITLE
[STORY-803] 요금제 및 사용량 구현

### DIFF
--- a/src/api/ai.ts
+++ b/src/api/ai.ts
@@ -1,0 +1,8 @@
+import { apiClient } from "@/lib/api-client"
+import type { AiUsageListResponse, AiUsageType } from "@/types/ai"
+
+export async function getAiUsages(types?: AiUsageType[]): Promise<AiUsageListResponse> {
+  return apiClient.get<AiUsageListResponse>("/api/v1/ai/usages", {
+    params: { type: types },
+  })
+}

--- a/src/components/sidebar/user-menu.tsx
+++ b/src/components/sidebar/user-menu.tsx
@@ -37,7 +37,7 @@ export function SidebarUserMenu() {
             </Avatar>
             <div className="grid flex-1 text-left text-sm leading-tight">
               <span className="truncate font-medium">{user.name}</span>
-              <span className="truncate text-xs text-muted-foreground">{user.username}</span>
+              <span className="truncate text-xs text-muted-foreground">{user.plan} 요금제</span>
             </div>
             <ChevronsUpDown className="ml-auto size-4" />
           </DropdownMenuTrigger>

--- a/src/queries/ai.ts
+++ b/src/queries/ai.ts
@@ -1,0 +1,21 @@
+import { queryOptions, useQuery } from "@tanstack/react-query"
+
+import { getAiUsages } from "@/api/ai"
+import type { AiUsageType } from "@/types/ai"
+
+export const aiKeys = {
+  all: () => ["ai"] as const,
+  usages: (types?: AiUsageType[]) => [...aiKeys.all(), "usages", types] as const,
+}
+
+export const aiQueries = {
+  usages: (types?: AiUsageType[]) =>
+    queryOptions({
+      queryKey: aiKeys.usages(types),
+      queryFn: () => getAiUsages(types),
+    }),
+}
+
+export function useAiUsages(types?: AiUsageType[]) {
+  return useQuery(aiQueries.usages(types))
+}

--- a/src/queries/ai.ts
+++ b/src/queries/ai.ts
@@ -5,7 +5,8 @@ import type { AiUsageType } from "@/types/ai"
 
 export const aiKeys = {
   all: () => ["ai"] as const,
-  usages: (types?: AiUsageType[]) => [...aiKeys.all(), "usages", types] as const,
+  usages: (types?: AiUsageType[]) =>
+    types ? ([...aiKeys.all(), "usages", types] as const) : ([...aiKeys.all(), "usages"] as const),
 }
 
 export const aiQueries = {

--- a/src/routes/_authenticated/settings.tsx
+++ b/src/routes/_authenticated/settings.tsx
@@ -111,7 +111,7 @@ function SettingsLayout() {
               라벨
             </TabsTrigger>
           </TabsList>
-          <TabsContent value={activeTab} className="flex min-h-0 flex-col px-3 sm:px-5">
+          <TabsContent value={activeTab} className="flex min-h-0 flex-col">
             <Outlet />
           </TabsContent>
         </Tabs>

--- a/src/routes/_authenticated/settings/account.tsx
+++ b/src/routes/_authenticated/settings/account.tsx
@@ -79,7 +79,7 @@ function SettingsAccountPage() {
 
   return (
     <ScrollArea className="min-h-0 flex-1">
-      <div className="flex flex-col gap-4 pb-4">
+      <div className="flex flex-col gap-4 px-6 pb-4">
         <Card>
           <CardHeader>
             <CardTitle>기본 메일 계정</CardTitle>

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -24,7 +24,7 @@ function SettingsPage() {
 
   return (
     <ScrollArea className="h-full">
-      <div className="flex flex-col gap-4 pb-4">
+      <div className="flex flex-col gap-4 px-6 pb-4">
         <Card>
           <CardHeader>
             <CardTitle>사용자 정보</CardTitle>

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -34,6 +34,7 @@ function SettingsPage() {
   const {
     data: aiUsages,
     isPending: isAiUsagesPending,
+    isError: isAiUsagesError,
     isRefetching: isAiUsagesRefetching,
     refetch: refetchAiUsages,
   } = useAiUsages()
@@ -99,44 +100,50 @@ function SettingsPage() {
             </CardHeader>
             <CardContent className="pt-4">
               <div className="flex flex-col gap-3">
-                {isAiUsagesPending
-                  ? Array.from({ length: 3 }).map((_, i) => (
-                      <div key={i} className="flex flex-col gap-1.5">
-                        <div className="flex justify-between">
-                          <Skeleton className="h-4 w-24" />
-                          <Skeleton className="h-4 w-12" />
-                        </div>
-                        <Skeleton className="h-2 w-full rounded-full" />
+                {isAiUsagesPending ? (
+                  Array.from({ length: 3 }).map((_, i) => (
+                    <div key={i} className="flex flex-col gap-1.5">
+                      <div className="flex justify-between">
+                        <Skeleton className="h-4 w-24" />
+                        <Skeleton className="h-4 w-12" />
                       </div>
-                    ))
-                  : aiUsages?.usages.map((item) => {
-                      const ratio = item.limit > 0 ? item.used / item.limit : 0
-                      const isExhausted = item.used >= item.limit
-                      return (
-                        <div key={item.type} className="flex flex-col gap-1.5">
-                          <div className="flex items-center justify-between">
-                            <span className="text-sm font-medium">{AI_USAGE_TYPE_LABELS[item.type]}</span>
-                            <span
-                              className={cn(
-                                "text-xs tabular-nums",
-                                isExhausted ? "text-destructive" : "text-muted-foreground"
-                              )}
-                            >
-                              {Math.min(item.used, item.limit)} / {item.limit}
-                            </span>
-                          </div>
-                          <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-                            <div
-                              className={cn(
-                                "h-full rounded-full transition-all",
-                                isExhausted ? "bg-destructive" : "bg-primary"
-                              )}
-                              style={{ width: `${Math.min(ratio * 100, 100)}%` }}
-                            />
-                          </div>
+                      <Skeleton className="h-2 w-full rounded-full" />
+                    </div>
+                  ))
+                ) : isAiUsagesError ? (
+                  <p className="text-sm text-muted-foreground">
+                    사용량을 불러오지 못했습니다. 새로고침을 눌러 다시 시도해 주세요.
+                  </p>
+                ) : (
+                  aiUsages?.usages.map((item) => {
+                    const ratio = item.limit > 0 ? item.used / item.limit : 0
+                    const isExhausted = item.used >= item.limit
+                    return (
+                      <div key={item.type} className="flex flex-col gap-1.5">
+                        <div className="flex items-center justify-between">
+                          <span className="text-sm font-medium">{AI_USAGE_TYPE_LABELS[item.type]}</span>
+                          <span
+                            className={cn(
+                              "text-xs tabular-nums",
+                              isExhausted ? "text-destructive" : "text-muted-foreground"
+                            )}
+                          >
+                            {Math.min(item.used, item.limit)} / {item.limit}
+                          </span>
                         </div>
-                      )
-                    })}
+                        <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                          <div
+                            className={cn(
+                              "h-full rounded-full transition-all",
+                              isExhausted ? "bg-destructive" : "bg-primary"
+                            )}
+                            style={{ width: `${Math.min(ratio * 100, 100)}%` }}
+                          />
+                        </div>
+                      </div>
+                    )
+                  })
+                )}
               </div>
             </CardContent>
           </Card>

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -1,6 +1,17 @@
 import { useState } from "react"
 import { Link, createFileRoute } from "@tanstack/react-router"
-import { Check, LayoutList, List, Monitor, Moon, MousePointer, MousePointerClick, Sparkles, Sun } from "lucide-react"
+import {
+  Check,
+  LayoutList,
+  List,
+  Monitor,
+  Moon,
+  MousePointer,
+  MousePointerClick,
+  RefreshCw,
+  Sparkles,
+  Sun,
+} from "lucide-react"
 
 import { InboxSingleLinePreview, InboxTwoLinePreview } from "@/components/inbox-preview"
 import { NotificationSettingsCard } from "@/components/notification-settings-card"
@@ -20,7 +31,12 @@ export const Route = createFileRoute("/_authenticated/settings/")({
 
 function SettingsPage() {
   const { data: user, isPending: isUserPending } = useUser()
-  const { data: aiUsages, isPending: isAiUsagesPending } = useAiUsages()
+  const {
+    data: aiUsages,
+    isPending: isAiUsagesPending,
+    isRefetching: isAiUsagesRefetching,
+    refetch: refetchAiUsages,
+  } = useAiUsages()
   const { theme, setTheme } = useTheme()
   // TODO: 실제 설정 저장/불러오기 기능은 추후 구현 예정
   const [inboxView, setInboxView] = useState<"single" | "double">("double")
@@ -29,88 +45,102 @@ function SettingsPage() {
   return (
     <ScrollArea className="h-full">
       <div className="flex flex-col gap-4 px-6 pb-4">
-        <Card>
-          <CardHeader>
-            <CardTitle>사용자 정보</CardTitle>
-            <CardDescription>현재 로그인한 사용자와 구독 플랜 정보를 확인합니다.</CardDescription>
-          </CardHeader>
-          <CardContent className="pt-4">
-            <div className="grid grid-cols-1 divide-y sm:grid-cols-3 sm:divide-x sm:divide-y-0">
-              <div className="flex flex-col gap-1 pb-4 sm:pr-4 sm:pb-0">
-                <p className="text-xs text-muted-foreground">이름</p>
-                <p className="text-sm font-medium">{isUserPending ? "..." : (user?.name ?? "-")}</p>
+        <div className="flex flex-col gap-4 sm:flex-row">
+          <Card className="flex-1">
+            <CardHeader>
+              <CardTitle>사용자 정보</CardTitle>
+              <CardDescription>현재 로그인한 사용자와 구독 플랜 정보를 확인합니다.</CardDescription>
+            </CardHeader>
+            <CardContent className="pt-4">
+              <div className="flex flex-col gap-3">
+                <div className="flex flex-col gap-1">
+                  <p className="text-xs text-muted-foreground">이름</p>
+                  <p className="text-sm font-medium">{isUserPending ? "..." : (user?.name ?? "-")}</p>
+                </div>
+                <div className="flex flex-col gap-1">
+                  <p className="text-xs text-muted-foreground">아이디</p>
+                  <p className="text-sm font-medium">{user?.username ?? "-"}</p>
+                </div>
+                <div className="flex flex-col gap-1">
+                  <p className="text-xs text-muted-foreground">플랜</p>
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-medium">{user?.plan ?? "-"}</p>
+                    {user?.plan === "FREE" && (
+                      <Link
+                        // 추후에 요금제 페이지가 생기면 해당 페이지로 링크 변경 필요
+                        to="/"
+                        className="inline-flex animate-bounce items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-primary transition-colors hover:bg-primary/20"
+                      >
+                        <Sparkles className="size-3" />
+                        요금제 업그레이드
+                      </Link>
+                    )}
+                  </div>
+                </div>
               </div>
-              <div className="flex flex-col gap-1 py-4 sm:px-4 sm:py-0">
-                <p className="text-xs text-muted-foreground">아이디</p>
-                <p className="text-sm font-medium">{user?.username ?? "-"}</p>
-              </div>
-              <div className="relative flex flex-col gap-1 pt-4 sm:pt-0 sm:pl-4">
-                <p className="text-xs text-muted-foreground">플랜</p>
-                <p className="text-sm font-medium">{user?.plan ?? "-"}</p>
-                {user?.plan === "FREE" && (
-                  <Link
-                    // 추후에 요금제 페이지가 생기면 해당 페이지로 링크 변경 필요
-                    to="/"
-                    className="relative mt-1 inline-flex w-fit animate-bounce items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-primary transition-colors hover:bg-primary/20 sm:absolute sm:-top-8 sm:left-2 sm:z-10 sm:mt-0"
-                  >
-                    <Sparkles className="size-3" />
-                    요금제 업그레이드
-                    <span className="absolute -bottom-1.75 left-3 hidden size-0 border-x-[6px] border-t-[7px] border-x-transparent border-t-primary/10 sm:block" />
-                  </Link>
-                )}
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>AI 기능 사용량</CardTitle>
-            <CardDescription>이번 주 AI 기능별 사용 현황입니다.</CardDescription>
-          </CardHeader>
-          <CardContent className="pt-4">
-            <div className="flex flex-col gap-3">
-              {isAiUsagesPending
-                ? Array.from({ length: 3 }).map((_, i) => (
-                    <div key={i} className="flex flex-col gap-1.5">
-                      <div className="flex justify-between">
-                        <Skeleton className="h-4 w-24" />
-                        <Skeleton className="h-4 w-12" />
-                      </div>
-                      <Skeleton className="h-2 w-full rounded-full" />
-                    </div>
-                  ))
-                : aiUsages?.usages.map((item) => {
-                    const ratio = item.limit > 0 ? item.used / item.limit : 0
-                    const isExhausted = item.used >= item.limit
-                    return (
-                      <div key={item.type} className="flex flex-col gap-1.5">
-                        <div className="flex items-center justify-between">
-                          <span className="text-sm font-medium">{AI_USAGE_TYPE_LABELS[item.type]}</span>
-                          <span
-                            className={cn(
-                              "text-xs tabular-nums",
-                              isExhausted ? "text-destructive" : "text-muted-foreground"
-                            )}
-                          >
-                            {item.used} / {item.limit}
-                          </span>
+          <Card className="flex-1">
+            <CardHeader className="flex items-start justify-between">
+              <div>
+                <CardTitle>AI 기능 사용량</CardTitle>
+                <CardDescription>이번 주 AI 기능별 사용 현황입니다.</CardDescription>
+              </div>
+              <button
+                type="button"
+                onClick={() => refetchAiUsages()}
+                disabled={isAiUsagesPending || isAiUsagesRefetching}
+                className="rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
+                aria-label="사용량 새로고침"
+              >
+                <RefreshCw className={cn("size-4", isAiUsagesRefetching && "animate-spin")} />
+              </button>
+            </CardHeader>
+            <CardContent className="pt-4">
+              <div className="flex flex-col gap-3">
+                {isAiUsagesPending
+                  ? Array.from({ length: 3 }).map((_, i) => (
+                      <div key={i} className="flex flex-col gap-1.5">
+                        <div className="flex justify-between">
+                          <Skeleton className="h-4 w-24" />
+                          <Skeleton className="h-4 w-12" />
                         </div>
-                        <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-                          <div
-                            className={cn(
-                              "h-full rounded-full transition-all",
-                              isExhausted ? "bg-destructive" : "bg-primary"
-                            )}
-                            style={{ width: `${Math.min(ratio * 100, 100)}%` }}
-                          />
-                        </div>
+                        <Skeleton className="h-2 w-full rounded-full" />
                       </div>
-                    )
-                  })}
-            </div>
-          </CardContent>
-        </Card>
+                    ))
+                  : aiUsages?.usages.map((item) => {
+                      const ratio = item.limit > 0 ? item.used / item.limit : 0
+                      const isExhausted = item.used >= item.limit
+                      return (
+                        <div key={item.type} className="flex flex-col gap-1.5">
+                          <div className="flex items-center justify-between">
+                            <span className="text-sm font-medium">{AI_USAGE_TYPE_LABELS[item.type]}</span>
+                            <span
+                              className={cn(
+                                "text-xs tabular-nums",
+                                isExhausted ? "text-destructive" : "text-muted-foreground"
+                              )}
+                            >
+                              {Math.min(item.used, item.limit)} / {item.limit}
+                            </span>
+                          </div>
+                          <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                            <div
+                              className={cn(
+                                "h-full rounded-full transition-all",
+                                isExhausted ? "bg-destructive" : "bg-primary"
+                              )}
+                              style={{ width: `${Math.min(ratio * 100, 100)}%` }}
+                            />
+                          </div>
+                        </div>
+                      )
+                    })}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
 
         <div id="notification-settings" className="flex flex-col gap-3">
           <p className="text-md px-1 font-semibold text-muted-foreground">알림</p>

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -8,8 +8,11 @@ import { useTheme } from "@/components/theme-provider"
 import { DarkPreview, LightPreview, SystemPreview } from "@/components/theme-preview"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import { Skeleton } from "@/components/ui/skeleton"
 import { cn } from "@/lib/utils"
+import { useAiUsages } from "@/queries/ai"
 import { useUser } from "@/queries/user"
+import { AI_USAGE_TYPE_LABELS } from "@/types/ai"
 
 export const Route = createFileRoute("/_authenticated/settings/")({
   component: SettingsPage,
@@ -17,6 +20,7 @@ export const Route = createFileRoute("/_authenticated/settings/")({
 
 function SettingsPage() {
   const { data: user, isPending: isUserPending } = useUser()
+  const { data: aiUsages, isPending: isAiUsagesPending } = useAiUsages()
   const { theme, setTheme } = useTheme()
   // TODO: 실제 설정 저장/불러오기 기능은 추후 구현 예정
   const [inboxView, setInboxView] = useState<"single" | "double">("double")
@@ -55,6 +59,55 @@ function SettingsPage() {
                   </Link>
                 )}
               </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>AI 기능 사용량</CardTitle>
+            <CardDescription>이번 주 AI 기능별 사용 현황입니다.</CardDescription>
+          </CardHeader>
+          <CardContent className="pt-4">
+            <div className="flex flex-col gap-3">
+              {isAiUsagesPending
+                ? Array.from({ length: 3 }).map((_, i) => (
+                    <div key={i} className="flex flex-col gap-1.5">
+                      <div className="flex justify-between">
+                        <Skeleton className="h-4 w-24" />
+                        <Skeleton className="h-4 w-12" />
+                      </div>
+                      <Skeleton className="h-2 w-full rounded-full" />
+                    </div>
+                  ))
+                : aiUsages?.usages.map((item) => {
+                    const ratio = item.limit > 0 ? item.used / item.limit : 0
+                    const isExhausted = item.used >= item.limit
+                    return (
+                      <div key={item.type} className="flex flex-col gap-1.5">
+                        <div className="flex items-center justify-between">
+                          <span className="text-sm font-medium">{AI_USAGE_TYPE_LABELS[item.type]}</span>
+                          <span
+                            className={cn(
+                              "text-xs tabular-nums",
+                              isExhausted ? "text-destructive" : "text-muted-foreground"
+                            )}
+                          >
+                            {item.used} / {item.limit}
+                          </span>
+                        </div>
+                        <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                          <div
+                            className={cn(
+                              "h-full rounded-full transition-all",
+                              isExhausted ? "bg-destructive" : "bg-primary"
+                            )}
+                            style={{ width: `${Math.min(ratio * 100, 100)}%` }}
+                          />
+                        </div>
+                      </div>
+                    )
+                  })}
             </div>
           </CardContent>
         </Card>

--- a/src/routes/_authenticated/settings/label/$labelId.tsx
+++ b/src/routes/_authenticated/settings/label/$labelId.tsx
@@ -35,7 +35,7 @@ function LabelDetailPage() {
   if (isPending) {
     return (
       <ScrollArea className="min-h-0 flex-1">
-        <div className="flex flex-col gap-6 px-3 pt-1 pb-4">
+        <div className="flex flex-col gap-6 px-6 pt-1 pb-4">
           <div className="flex items-center gap-2">
             <Skeleton className="size-3.5 shrink-0 rounded-sm" />
             <Skeleton className="h-6 w-24" />
@@ -88,7 +88,7 @@ function LabelDetailPage() {
   if (isError || !label) {
     return (
       <ScrollArea className="min-h-0 flex-1">
-        <div className="flex flex-col gap-6 px-3 pt-1 pb-4">
+        <div className="flex flex-col gap-6 px-6 pt-1 pb-4">
           <Card>
             <CardHeader>
               <CardTitle className="text-destructive">라벨을 불러오지 못했습니다</CardTitle>

--- a/src/routes/_authenticated/settings/label/$labelId.tsx
+++ b/src/routes/_authenticated/settings/label/$labelId.tsx
@@ -189,7 +189,7 @@ function LabelDetailContent({ labelId, label }: { labelId: string; label: LabelD
 
   return (
     <ScrollArea className="min-h-0 flex-1">
-      <div className="flex flex-col gap-4 pb-4">
+      <div className="flex flex-col gap-4 px-6 pb-4">
         <Link to="/settings/label" className="inline-flex items-center gap-2 text-sm text-muted-foreground">
           <ChevronLeft className="size-4" />
           뒤로

--- a/src/routes/_authenticated/settings/label/index.tsx
+++ b/src/routes/_authenticated/settings/label/index.tsx
@@ -200,7 +200,7 @@ function SettingsLabelPage() {
 
   return (
     <ScrollArea className="min-h-0 flex-1">
-      <div className="flex flex-col gap-4 pb-4">
+      <div className="flex flex-col gap-4 px-6 pb-4">
         <div className="flex flex-col gap-3">
           <p className="text-md px-1 font-semibold text-muted-foreground">라벨</p>
           <Card>

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -1,0 +1,17 @@
+export type AiUsageType = "MAIL_DRAFT" | "MAIL_REVIEW" | "LABEL_SUGGESTION"
+
+export const AI_USAGE_TYPE_LABELS: Record<AiUsageType, string> = {
+  MAIL_DRAFT: "AI 초안 생성",
+  MAIL_REVIEW: "AI 메일 검토",
+  LABEL_SUGGESTION: "라벨 제안",
+}
+
+export interface AiUsageItem {
+  type: AiUsageType
+  used: number
+  limit: number
+}
+
+export interface AiUsageListResponse {
+  usages: AiUsageItem[]
+}


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#32

### 📌 Task

- Closes #92 

## 💡 작업 내용

- AI 기능 주간 사용량 조회 API 구현
- AI 사용량 UI 구현
- 사용자 정보, AI 사용량 배치 수정

## 📝 추가 설명

- `Math.min( )` 함수로 최대 사용량 표시
- 쿼리 키는 aiKeys 객체로 도메인 분리(`src/queries/ai.ts`)해 관리
- 요금제 업그레이드 링크는 현재 `/`로 임시 연결되어 있으며, 별도 요금제 페이지 구현 시 변경이 필요 (다음 PR에서 할 예정)
- 설정 페이지 여백 변경
- 사이드바 하단 유저 메뉴에서 기존의 `username` 대신 `plan`으로 현재 플랜 표시하도록 변경
- AI 사용량을 동기화 할 수 있도록 새로고침 아이콘 추가

## 🖼️ 스크린샷

<img width="313" height="81" alt="image" src="https://github.com/user-attachments/assets/a8206fc8-331a-4da6-a93a-cce1127884a0" />

| 데스트톱 | 모바일 |
| -- | -- |
|<img width="1919" height="866" alt="image" src="https://github.com/user-attachments/assets/4724cd10-c912-4c4f-a74d-ac6a96d0afa5" /> | <img width="457" height="759" alt="image" src="https://github.com/user-attachments/assets/bb8c6ebf-b0ef-4dde-8821-3fb30e4924ed" /> |
