### PR TITLE
[STROY-801] 요금제 비교 페이지 구현

### DIFF
--- a/src/components/sidebar/user-menu.tsx
+++ b/src/components/sidebar/user-menu.tsx
@@ -13,7 +13,7 @@ import {
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar } from "@/components/ui/sidebar"
 import { useLogout } from "@/mutations/auth"
 import { useUser } from "@/queries/user"
-import { ChevronsUpDown, LogOut, Settings, Tag, UserIcon } from "lucide-react"
+import { ChevronsUpDown, CircleArrowUp, LogOut, Settings, Tag, UserIcon } from "lucide-react"
 
 export function SidebarUserMenu() {
   const { data: user } = useUser()
@@ -62,6 +62,10 @@ export function SidebarUserMenu() {
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
+              <DropdownMenuItem render={<Link to="/upgrade" />}>
+                <CircleArrowUp />
+                <span>요금제 업그레이드</span>
+              </DropdownMenuItem>
               <DropdownMenuItem render={<Link to="/settings" />}>
                 <Settings />
                 <span>설정</span>

--- a/src/index.css
+++ b/src/index.css
@@ -250,7 +250,7 @@
   --chart-3: var(--tds-yellow-300);
   --chart-4: var(--tds-red-400);
   --chart-5: var(--tds-purple-300);
-  --sidebar: color-mix(in oklch, var(--tds-grey-900) 88%, black);
+  --sidebar: oklch(0.208951 0.01718 258.355);
   --sidebar-foreground: var(--tds-grey-200);
   --sidebar-primary: var(--tds-blue-300);
   --sidebar-primary-foreground: var(--tds-grey-900);

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as UpgradeRouteImport } from './routes/upgrade'
 import { Route as TermsRouteImport } from './routes/terms'
 import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as GuestRouteImport } from './routes/_guest'
@@ -26,6 +27,11 @@ import { Route as AuthenticatedMailMailboxRouteImport } from './routes/_authenti
 import { Route as AuthenticatedSettingsLabelIndexRouteImport } from './routes/_authenticated/settings/label/index'
 import { Route as AuthenticatedSettingsLabelLabelIdRouteImport } from './routes/_authenticated/settings/label/$labelId'
 
+const UpgradeRoute = UpgradeRouteImport.update({
+  id: '/upgrade',
+  path: '/upgrade',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const TermsRoute = TermsRouteImport.update({
   id: '/terms',
   path: '/terms',
@@ -114,6 +120,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/privacy': typeof PrivacyRoute
   '/terms': typeof TermsRoute
+  '/upgrade': typeof UpgradeRoute
   '/compose': typeof AuthenticatedComposeRoute
   '/mail': typeof AuthenticatedMailRouteWithChildren
   '/settings': typeof AuthenticatedSettingsRouteWithChildren
@@ -130,6 +137,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/privacy': typeof PrivacyRoute
   '/terms': typeof TermsRoute
+  '/upgrade': typeof UpgradeRoute
   '/compose': typeof AuthenticatedComposeRoute
   '/login': typeof GuestLoginRoute
   '/signup': typeof GuestSignupRoute
@@ -147,6 +155,7 @@ export interface FileRoutesById {
   '/_guest': typeof GuestRouteWithChildren
   '/privacy': typeof PrivacyRoute
   '/terms': typeof TermsRoute
+  '/upgrade': typeof UpgradeRoute
   '/_authenticated/compose': typeof AuthenticatedComposeRoute
   '/_authenticated/mail': typeof AuthenticatedMailRouteWithChildren
   '/_authenticated/settings': typeof AuthenticatedSettingsRouteWithChildren
@@ -165,6 +174,7 @@ export interface FileRouteTypes {
     | '/'
     | '/privacy'
     | '/terms'
+    | '/upgrade'
     | '/compose'
     | '/mail'
     | '/settings'
@@ -181,6 +191,7 @@ export interface FileRouteTypes {
     | '/'
     | '/privacy'
     | '/terms'
+    | '/upgrade'
     | '/compose'
     | '/login'
     | '/signup'
@@ -197,6 +208,7 @@ export interface FileRouteTypes {
     | '/_guest'
     | '/privacy'
     | '/terms'
+    | '/upgrade'
     | '/_authenticated/compose'
     | '/_authenticated/mail'
     | '/_authenticated/settings'
@@ -216,10 +228,18 @@ export interface RootRouteChildren {
   GuestRoute: typeof GuestRouteWithChildren
   PrivacyRoute: typeof PrivacyRoute
   TermsRoute: typeof TermsRoute
+  UpgradeRoute: typeof UpgradeRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/upgrade': {
+      id: '/upgrade'
+      path: '/upgrade'
+      fullPath: '/upgrade'
+      preLoaderRoute: typeof UpgradeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/terms': {
       id: '/terms'
       path: '/terms'
@@ -402,6 +422,7 @@ const rootRouteChildren: RootRouteChildren = {
   GuestRoute: GuestRouteWithChildren,
   PrivacyRoute: PrivacyRoute,
   TermsRoute: TermsRoute,
+  UpgradeRoute: UpgradeRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/_authenticated/settings/index.tsx
+++ b/src/routes/_authenticated/settings/index.tsx
@@ -68,8 +68,7 @@ function SettingsPage() {
                     <p className="text-sm font-medium">{user?.plan ?? "-"}</p>
                     {user?.plan === "FREE" && (
                       <Link
-                        // 추후에 요금제 페이지가 생기면 해당 페이지로 링크 변경 필요
-                        to="/"
+                        to="/upgrade"
                         className="inline-flex animate-bounce items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-primary transition-colors hover:bg-primary/20"
                       >
                         <Sparkles className="size-3" />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -334,11 +334,17 @@ function RouteComponent() {
         <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
           <div className="flex items-center gap-2">
             <Mail className="size-5 text-primary" />
-            <span className="font-semibold">메일상자</span>
+            <Link to="/" className="font-semibold">
+              메일상자
+            </Link>
           </div>
           <nav className="flex items-center gap-6">
-            {/* TODO: 노션 링크 추가 후 href 교체 */}
-            <a href="#" className="text-sm text-muted-foreground transition-colors hover:text-foreground">
+            <a
+              href="https://lumbar-node-b36.notion.site/369a76ffc9a180968462c679978467b1"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
               팀소개
             </a>
             <Link to="/signup" className="text-sm text-muted-foreground transition-colors hover:text-foreground">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -239,10 +239,11 @@ const pricingPlans = [
   },
   {
     name: "PRO Plan",
-    originalPrice: "₩12,900",
-    price: "₩5,900",
+    originalPrice: "₩19,900",
+    price: "₩9,900",
     period: "/월",
     cta: "PRO로 시작하기",
+    // 요금제 결제 페이지가 구현되면 해당 페이지로 링크 변경 필요
     ctaTo: "/signup" as const,
     featured: true,
     comingSoon: true,

--- a/src/routes/upgrade.tsx
+++ b/src/routes/upgrade.tsx
@@ -47,6 +47,7 @@ function RouteComponent() {
       <button
         className={buttonVariants({ variant: "ghost", size: "icon", className: "absolute top-4 left-4" })}
         onClick={() => router.history.back()}
+        aria-label="뒤로 가기"
       >
         <ArrowLeft className="size-4" />
       </button>

--- a/src/routes/upgrade.tsx
+++ b/src/routes/upgrade.tsx
@@ -1,0 +1,112 @@
+import { createFileRoute, Link, useRouter } from "@tanstack/react-router"
+import { ArrowLeft, Check } from "lucide-react"
+
+import { buttonVariants } from "@/components/ui/button"
+
+export const Route = createFileRoute("/upgrade")({
+  component: RouteComponent,
+})
+
+const pricingPlans = [
+  {
+    name: "FREE Plan",
+    price: "₩0",
+    period: "/월",
+    cta: "FREE Plan 사용하기",
+    ctaTo: "/signup" as const,
+    featured: false,
+    comingSoon: false,
+    items: ["이메일 계정 2개 연동", "AI 기반 자동 라벨 분류", "AI 이메일 초안 작성", "AI 답장 작성"],
+  },
+  {
+    name: "PRO Plan",
+    originalPrice: "₩12,900",
+    price: "₩5,900",
+    period: "/월",
+    cta: "PRO Plan 구독하기",
+    ctaTo: "/signup" as const,
+    featured: true,
+    comingSoon: true,
+    items: [
+      "이메일 계정 무제한 연동",
+      "AI 기반 자동 라벨 분류",
+      "AI 이메일 초안 작성",
+      "AI 답장 작성",
+      "AI 사용량 무제한",
+      "우선 고객 지원",
+    ],
+  },
+]
+
+function RouteComponent() {
+  const router = useRouter()
+
+  return (
+    <div className="min-h-svh bg-background">
+      <button
+        className={buttonVariants({ variant: "ghost", size: "icon", className: "absolute top-4 left-4" })}
+        onClick={() => router.history.back()}
+      >
+        <ArrowLeft className="size-4" />
+      </button>
+      <main className="mx-auto h-screen max-w-3xl px-6 py-14">
+        <div className="mb-10 space-y-3 text-center">
+          <h1 className="text-3xl font-bold">요금제</h1>
+          <p className="text-muted-foreground">지금 바로 시작하세요</p>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          {pricingPlans.map((plan) => (
+            <div
+              key={plan.name}
+              className={`relative flex flex-col space-y-6 rounded-2xl border p-8 text-left ${plan.featured ? "pricing-card-featured" : "bg-background shadow-sm"}`}
+            >
+              {plan.comingSoon && (
+                <span className="absolute top-4 right-4 rounded-full bg-muted px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+                  출시 예정
+                </span>
+              )}
+              <div className="space-y-1">
+                <p className={`text-sm font-medium ${plan.featured ? "text-primary" : "text-muted-foreground"}`}>
+                  {plan.name}
+                </p>
+                <div className="space-y-1">
+                  {"originalPrice" in plan && plan.originalPrice && (
+                    <p className="text-sm text-muted-foreground line-through">{plan.originalPrice}</p>
+                  )}
+                  <div className="flex items-end gap-1">
+                    <span className="text-4xl font-bold">{plan.price}</span>
+                    <span className="mb-1 text-sm text-muted-foreground">{plan.period}</span>
+                  </div>
+                </div>
+              </div>
+              <ul className="flex-1 space-y-3">
+                {plan.items.map((item) => (
+                  <li key={item} className="flex items-center gap-3">
+                    <Check className="size-4 shrink-0 text-primary" />
+                    <span className="text-sm">{item}</span>
+                  </li>
+                ))}
+              </ul>
+              <Link
+                to={plan.ctaTo}
+                className={buttonVariants({
+                  size: "lg",
+                  variant: plan.featured ? "default" : "outline",
+                  className: "w-full",
+                })}
+              >
+                {plan.cta}
+              </Link>
+            </div>
+          ))}
+        </div>
+        <div className="mt-12 space-y-3 text-center">
+          <p className="text-sm text-muted-foreground">
+            사용 한도가 적용됩니다. 가격 및 플랜은 메일상자의 재량에 따라 변경될 수 있습니다.
+          </p>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/routes/upgrade.tsx
+++ b/src/routes/upgrade.tsx
@@ -13,18 +13,19 @@ const pricingPlans = [
     price: "₩0",
     period: "/월",
     cta: "FREE Plan 사용하기",
-    ctaTo: "/signup" as const,
+    ctaTo: "/mail/inbox",
     featured: false,
     comingSoon: false,
     items: ["이메일 계정 2개 연동", "AI 기반 자동 라벨 분류", "AI 이메일 초안 작성", "AI 답장 작성"],
   },
   {
     name: "PRO Plan",
-    originalPrice: "₩12,900",
-    price: "₩5,900",
+    originalPrice: "₩19,900",
+    price: "₩9,900",
     period: "/월",
     cta: "PRO Plan 구독하기",
-    ctaTo: "/signup" as const,
+    // 요금제 결제 페이지가 구현되면 해당 페이지로 링크 변경 필요
+    ctaTo: "/mail/inbox",
     featured: true,
     comingSoon: true,
     items: [
@@ -42,7 +43,7 @@ function RouteComponent() {
   const router = useRouter()
 
   return (
-    <div className="min-h-svh bg-background">
+    <div className="min-h-svh animate-in overflow-x-hidden bg-background duration-200 fade-in slide-in-from-right-2">
       <button
         className={buttonVariants({ variant: "ghost", size: "icon", className: "absolute top-4 left-4" })}
         onClick={() => router.history.back()}


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#37

### 📌 Task

- Closes #109 

## 💡 작업 내용

- 요금제 페이지 구현
 
## 📝 추가 설명

- `/upgrade` 에 요금제 페이지 구현
- PRO 요금 5,900원 -> 9,900원으로 업데이트
- 페이지 진입 애니메이션 추가
- 사이드바 유저 메뉴에 "요금제 업그레이드" 항목 추가
- 설정 페이지의 "요금제 업그레이드" 배너 링크 `/upgrade`로 연결
- **추후 요금제 결제 페이지 구현 시 `@src/routes/index.tsx`와 `@src/routes/upgrade.tsx` 파일에 링크 변경 필요**

## 🖼️ 스크린샷

<img width="644" height="312" alt="image" src="https://github.com/user-attachments/assets/9842fe28-240d-4f3e-853a-e813743b3d5b" />


<img width="1919" height="864" alt="image" src="https://github.com/user-attachments/assets/643da6a2-4c0c-4abc-83d9-7eac2c024659" />

