### PR TITLE
[STORY-804] PWA 자동 업데이트 설정

### DIFF
--- a/src/components/pwa-update-banner.tsx
+++ b/src/components/pwa-update-banner.tsx
@@ -29,7 +29,7 @@ export function PwaUpdateBanner() {
         className="h-8 w-full justify-start gap-1.5"
         disabled={isApplyingUpdate}
         onClick={() => {
-          void applyPwaUpdate()
+          void applyPwaUpdate().catch(() => {})
         }}
       >
         <RefreshCw className={cn("size-3.5", isApplyingUpdate && "animate-spin")} />

--- a/src/components/pwa-update-banner.tsx
+++ b/src/components/pwa-update-banner.tsx
@@ -1,0 +1,40 @@
+import { useSyncExternalStore } from "react"
+import { RefreshCw } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { applyPwaUpdate, getPwaUpdateServerSnapshot, getPwaUpdateSnapshot, subscribeToPwaUpdate } from "@/lib/pwa"
+
+export function PwaUpdateBanner() {
+  const { isApplyingUpdate, isUpdateAvailable } = useSyncExternalStore(
+    subscribeToPwaUpdate,
+    getPwaUpdateSnapshot,
+    getPwaUpdateServerSnapshot
+  )
+
+  if (!isUpdateAvailable && !isApplyingUpdate) {
+    return null
+  }
+
+  return (
+    <div className="rounded-md border border-sidebar-border bg-sidebar-accent/50 p-2 text-sidebar-accent-foreground">
+      <div className="mb-2 min-w-0">
+        <p className="truncate text-xs font-medium">🎉 메일 상자 업데이트</p>
+        <p className="mt-0.5 line-clamp-2 text-xs text-sidebar-foreground/70">다음 접속시 자동으로 적용됩니다.</p>
+      </div>
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        className="h-8 w-full justify-start gap-1.5"
+        disabled={isApplyingUpdate}
+        onClick={() => {
+          void applyPwaUpdate()
+        }}
+      >
+        <RefreshCw className={cn("size-3.5", isApplyingUpdate && "animate-spin")} />
+        <span className="truncate">{isApplyingUpdate ? "업데이트 중" : "지금 업데이트"}</span>
+      </Button>
+    </div>
+  )
+}

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router"
 import { ChevronDown, Mail, Pencil, Star } from "lucide-react"
 
 import { MailAccountLabel } from "@/components/mail-account-label"
+import { PwaUpdateBanner } from "@/components/pwa-update-banner"
 import { Badge } from "@/components/ui/badge"
 import { buttonVariants } from "@/components/ui/button"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
@@ -125,6 +126,7 @@ export function AppSidebar({
       </SidebarContent>
 
       <SidebarFooter>
+        <PwaUpdateBanner />
         <SidebarUserMenu />
       </SidebarFooter>
     </Sidebar>

--- a/src/lib/pwa.ts
+++ b/src/lib/pwa.ts
@@ -45,7 +45,7 @@ export function registerPwaServiceWorker() {
       immediate: true,
       onNeedRefresh() {
         if (shouldApplyDeferredUpdateOnLoad) {
-          void applyPwaUpdate()
+          void applyPwaUpdate().catch(() => {})
           return
         }
 
@@ -54,7 +54,7 @@ export function registerPwaServiceWorker() {
       },
       onRegisteredSW(_swUrl, registration) {
         if (shouldApplyDeferredUpdateOnLoad && registration?.waiting) {
-          void applyPwaUpdate()
+          void applyPwaUpdate().catch(() => {})
           return
         }
 
@@ -123,11 +123,17 @@ export async function applyPwaUpdate() {
   setDeferredPwaUpdate(false)
 
   try {
-    await updateServiceWorker?.()
+    if (!updateServiceWorker) {
+      throw new Error("PWA update service worker is not initialized.")
+    }
+
+    await updateServiceWorker()
   } catch (error) {
     setDeferredPwaUpdate(true)
-    setPwaUpdateSnapshot({ isApplyingUpdate: false, isUpdateAvailable: true })
+    setPwaUpdateSnapshot({ isUpdateAvailable: true })
     throw error
+  } finally {
+    setPwaUpdateSnapshot({ isApplyingUpdate: false })
   }
 }
 

--- a/src/lib/pwa.ts
+++ b/src/lib/pwa.ts
@@ -1,8 +1,20 @@
 import { registerSW } from "virtual:pwa-register"
 
 const SERVICE_WORKER_READY_TIMEOUT_MS = 10_000
+const PWA_DEFERRED_UPDATE_STORAGE_KEY = "pwa:deferred-update"
+
+interface PwaUpdateSnapshot {
+  isApplyingUpdate: boolean
+  isUpdateAvailable: boolean
+}
 
 let registrationPromise: Promise<ServiceWorkerRegistration | null> | null = null
+let updateServiceWorker: (() => Promise<void>) | null = null
+let pwaUpdateSnapshot: PwaUpdateSnapshot = {
+  isApplyingUpdate: false,
+  isUpdateAvailable: false,
+}
+const pwaUpdateListeners = new Set<() => void>()
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string) {
   let timeoutId: ReturnType<typeof window.setTimeout>
@@ -22,14 +34,39 @@ export function registerPwaServiceWorker() {
   }
 
   registrationPromise ??= (async () => {
+    const shouldApplyDeferredUpdateOnLoad = hasDeferredPwaUpdate()
     let rejectRegistration: (reason?: unknown) => void = () => {}
 
     const registrationFailed = new Promise<never>((_, reject) => {
       rejectRegistration = reject
     })
 
-    registerSW({
+    updateServiceWorker = registerSW({
       immediate: true,
+      onNeedRefresh() {
+        if (shouldApplyDeferredUpdateOnLoad) {
+          void applyPwaUpdate()
+          return
+        }
+
+        setDeferredPwaUpdate(true)
+        setPwaUpdateSnapshot({ isUpdateAvailable: true })
+      },
+      onRegisteredSW(_swUrl, registration) {
+        if (shouldApplyDeferredUpdateOnLoad && registration?.waiting) {
+          void applyPwaUpdate()
+          return
+        }
+
+        void registration
+          ?.update()
+          .then(() => {
+            if (shouldApplyDeferredUpdateOnLoad && !registration.waiting && !registration.installing) {
+              setDeferredPwaUpdate(false)
+            }
+          })
+          .catch(() => {})
+      },
       onRegisterError(error) {
         rejectRegistration(error)
       },
@@ -56,4 +93,73 @@ export async function getPwaServiceWorkerRegistration() {
   }
 
   return registration
+}
+
+export function subscribeToPwaUpdate(listener: () => void) {
+  pwaUpdateListeners.add(listener)
+
+  return () => {
+    pwaUpdateListeners.delete(listener)
+  }
+}
+
+export function getPwaUpdateSnapshot(): PwaUpdateSnapshot {
+  return pwaUpdateSnapshot
+}
+
+export function getPwaUpdateServerSnapshot(): PwaUpdateSnapshot {
+  return {
+    isApplyingUpdate: false,
+    isUpdateAvailable: false,
+  }
+}
+
+export async function applyPwaUpdate() {
+  if (pwaUpdateSnapshot.isApplyingUpdate) {
+    return
+  }
+
+  setPwaUpdateSnapshot({ isApplyingUpdate: true })
+  setDeferredPwaUpdate(false)
+
+  try {
+    await updateServiceWorker?.()
+  } catch (error) {
+    setDeferredPwaUpdate(true)
+    setPwaUpdateSnapshot({ isApplyingUpdate: false, isUpdateAvailable: true })
+    throw error
+  }
+}
+
+function hasDeferredPwaUpdate() {
+  return window.localStorage.getItem(PWA_DEFERRED_UPDATE_STORAGE_KEY) === "1"
+}
+
+function setDeferredPwaUpdate(isDeferred: boolean) {
+  if (isDeferred) {
+    window.localStorage.setItem(PWA_DEFERRED_UPDATE_STORAGE_KEY, "1")
+    return
+  }
+
+  window.localStorage.removeItem(PWA_DEFERRED_UPDATE_STORAGE_KEY)
+}
+
+function setPwaUpdateSnapshot(nextSnapshot: Partial<PwaUpdateSnapshot>) {
+  const nextPwaUpdateSnapshot = {
+    isApplyingUpdate: nextSnapshot.isApplyingUpdate ?? pwaUpdateSnapshot.isApplyingUpdate,
+    isUpdateAvailable: nextSnapshot.isUpdateAvailable ?? pwaUpdateSnapshot.isUpdateAvailable,
+  }
+
+  if (
+    nextPwaUpdateSnapshot.isApplyingUpdate === pwaUpdateSnapshot.isApplyingUpdate &&
+    nextPwaUpdateSnapshot.isUpdateAvailable === pwaUpdateSnapshot.isUpdateAvailable
+  ) {
+    return
+  }
+
+  pwaUpdateSnapshot = nextPwaUpdateSnapshot
+
+  pwaUpdateListeners.forEach((listener) => {
+    listener()
+  })
 }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -13,6 +13,12 @@ declare const self: ServiceWorkerGlobalScope & {
   __WB_MANIFEST: Array<string | { revision: string | null; url: string }>
 }
 
+self.addEventListener("message", (event) => {
+  if (event.data?.type === "SKIP_WAITING") {
+    self.skipWaiting()
+  }
+})
+
 cleanupOutdatedCaches()
 precacheAndRoute(self.__WB_MANIFEST)
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
       strategies: "injectManifest",
       srcDir: "src",
       filename: "sw.ts",
-      registerType: "autoUpdate",
+      registerType: "prompt",
       injectRegister: false,
       manifest: {
         name: "메일상자",


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#38

### 📌 Task

- Closes #119

## 💡 작업 내용

- PWA 자동 업데이트 로직 구현
- 자동 업데이트시 사용자 알림 배너 구현

## 📝 추가 설명

- 프론트엔드가 자동으로 업데이트되지 않던 문제를 해결합니다.
- PWA 서비스 워커 등록 방식을 `autoUpdate`에서 `prompt`로 변경합니다. 첫 업데이트 감지 세션에서는 업데이트 알림 배너를 출력하여 사용자가 작업 중인 화면이 갑자기 새로고침되는 일을 방지합니다.
- 새 버전 감지 시 사이드바 하단에 업데이트 배너를 표시하고, 사용자가 `지금 업데이트`를 누르면 `vite-plugin-pwa`의 `updateServiceWorker()` 흐름으로 업데이트를 적용하도록 구현했습니다.
- 사용자가 업데이트 배너를 무시한 경우 `localStorage`에 deferred update 상태를 저장해, 다음 접속 또는 새로고침 시 자동으로 업데이트 적용을 시도하도록 했습니다.
- 자동 업데이트 적용을 위해 서비스 워커에서 `SKIP_WAITING` 메시지를 처리하도록 추가했습니다.

## 🖼️ 스크린샷

<img width="312" height="249" alt="image" src="https://github.com/user-attachments/assets/ff52ccb8-df65-4323-82d5-eb00351a675b" />