### PR TITLE
[STORY-901] AI 추천 답장 UI 개선

### DIFF
--- a/src/components/thread/detail.tsx
+++ b/src/components/thread/detail.tsx
@@ -203,6 +203,14 @@ interface ThreadDetailProps {
 export function ThreadDetail({ threadId, messageId = null, onClose }: ThreadDetailProps) {
   const navigate = useNavigate()
   const [showSuggestions, setShowSuggestions] = useState(false)
+  const [prevThreadId, setPrevThreadId] = useState(threadId)
+  const [prevMessageId, setPrevMessageId] = useState(messageId)
+
+  if (prevThreadId !== threadId || prevMessageId !== messageId) {
+    setPrevThreadId(threadId)
+    setPrevMessageId(messageId)
+    setShowSuggestions(false)
+  }
   const { data: thread, isLoading, isError, error, refetch } = useThread(threadId)
   const { data: accounts } = useMailAccounts()
   const { mutate: deleteThread, isPending: isDeleting } = useDeleteThread()

--- a/src/components/thread/detail.tsx
+++ b/src/components/thread/detail.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { Archive, ArrowLeft, Copy, Forward, MailOpen, Mail, Reply, Trash2 } from "lucide-react"
 import { useNavigate } from "@tanstack/react-router"
 import { toast } from "sonner"
@@ -5,7 +6,10 @@ import { toast } from "sonner"
 import { MailErrorState } from "@/components/mail-error-state"
 import { ThreadHeader } from "@/components/thread/header"
 import { ThreadMessageList } from "@/components/thread/message-list"
-import { ReplyDraftSuggestionAction } from "@/components/thread/reply-draft-suggestion-action"
+import {
+  ReplyDraftSuggestionButton,
+  ReplyDraftSuggestionCards,
+} from "@/components/thread/reply-draft-suggestion-action"
 import { Button } from "@/components/ui/button"
 import { DropdownMenuItem, DropdownMenuSeparator } from "@/components/ui/dropdown-menu"
 import { Separator } from "@/components/ui/separator"
@@ -169,11 +173,11 @@ function ThreadToolbar({
 function ThreadFooter({
   onReply,
   replyDraftMessage,
-  threadId,
+  onShowSuggestions,
 }: {
   onReply: () => void
   replyDraftMessage: InboxMessage | null
-  threadId: string
+  onShowSuggestions: () => void
 }) {
   return (
     <div className="shrink-0 border-t px-6 py-2">
@@ -182,7 +186,9 @@ function ThreadFooter({
           <Reply />
           {m.thread_reply()}
         </Button>
-        {replyDraftMessage ? <ReplyDraftSuggestionAction threadId={threadId} message={replyDraftMessage} /> : null}
+        {replyDraftMessage ? (
+          <ReplyDraftSuggestionButton messageId={replyDraftMessage.id} onClick={onShowSuggestions} />
+        ) : null}
       </div>
     </div>
   )
@@ -196,6 +202,7 @@ interface ThreadDetailProps {
 
 export function ThreadDetail({ threadId, messageId = null, onClose }: ThreadDetailProps) {
   const navigate = useNavigate()
+  const [showSuggestions, setShowSuggestions] = useState(false)
   const { data: thread, isLoading, isError, error, refetch } = useThread(threadId)
   const { data: accounts } = useMailAccounts()
   const { mutate: deleteThread, isPending: isDeleting } = useDeleteThread()
@@ -314,7 +321,7 @@ export function ThreadDetail({ threadId, messageId = null, onClose }: ThreadDeta
   const replyDraftMessage = getLatestInboundMessage(messages)
 
   return (
-    <div className="flex h-full w-full min-w-0 flex-1 flex-col">
+    <div className="relative flex h-full w-full min-w-0 flex-1 flex-col">
       <ThreadToolbar
         isRead={thread.isRead}
         onClose={onClose}
@@ -357,7 +364,19 @@ export function ThreadDetail({ threadId, messageId = null, onClose }: ThreadDeta
           </>
         )}
       />
-      <ThreadFooter onReply={() => handleReply()} threadId={thread.threadId} replyDraftMessage={replyDraftMessage} />
+      {replyDraftMessage && (
+        <ReplyDraftSuggestionCards
+          threadId={thread.threadId}
+          message={replyDraftMessage}
+          show={showSuggestions}
+          onClose={() => setShowSuggestions(false)}
+        />
+      )}
+      <ThreadFooter
+        onReply={() => handleReply()}
+        replyDraftMessage={replyDraftMessage}
+        onShowSuggestions={() => setShowSuggestions((prev) => !prev)}
+      />
     </div>
   )
 }

--- a/src/components/thread/reply-draft-suggestion-action.tsx
+++ b/src/components/thread/reply-draft-suggestion-action.tsx
@@ -151,6 +151,7 @@ export function ReplyDraftSuggestionCards({ threadId, message, show, onClose }: 
   return (
     <div
       data-show={show}
+      inert={!show}
       className={cn(
         "ai-cards-wrapper absolute right-0 bottom-12 left-0 z-10 px-2 py-3",
         "transition-all duration-300 ease-out",

--- a/src/components/thread/reply-draft-suggestion-action.tsx
+++ b/src/components/thread/reply-draft-suggestion-action.tsx
@@ -1,72 +1,103 @@
 import { useState } from "react"
-import { Loader2, Mail, Reply, Sparkles } from "lucide-react"
+import { Loader2, Reply, Sparkles } from "lucide-react"
 import { useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
-import { Popover, PopoverContent, PopoverTitle, PopoverTrigger } from "@/components/ui/popover"
-import { ScrollArea } from "@/components/ui/scroll-area"
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { getErrorMessage } from "@/lib/http-error"
+import { cn } from "@/lib/utils"
 import { useSelectReplyDraftSuggestion } from "@/mutations/emails"
 import { m } from "@/paraglide/messages"
 import { emailKeys, useReplyDraftSuggestions } from "@/queries/emails"
 import type { InboxMessage, ReplyDraftSuggestion, ReplyDraftSuggestionListResponse } from "@/types/email"
 
-interface ReplyDraftSuggestionActionProps {
-  threadId: string
-  message: InboxMessage
-}
-
-interface SuggestionPreviewProps {
+interface SuggestionCardProps {
   suggestion: ReplyDraftSuggestion
   onSelect: (suggestion: ReplyDraftSuggestion) => void
-  isSelecting?: boolean
+  isSelecting: boolean
+  selectedId: string | null
 }
 
-function SuggestionPreview({ suggestion, onSelect, isSelecting = false }: SuggestionPreviewProps) {
+function SuggestionCard({ suggestion, onSelect, isSelecting, selectedId }: SuggestionCardProps) {
+  const isThisSelecting = isSelecting && selectedId === suggestion.id
+
   return (
-    <div className="flex flex-col gap-3">
-      <div className="rounded-lg border bg-background p-4">
-        <p className="max-h-72 overflow-hidden text-sm leading-relaxed whitespace-pre-wrap text-foreground">
-          {suggestion.body}
-        </p>
+    <button
+      onClick={() => onSelect(suggestion)}
+      disabled={isSelecting}
+      aria-label={m.reply_draft_suggestion_aria({ type: suggestion.type })}
+      className={cn(
+        "ai-suggestion-card group flex flex-col gap-2 rounded-xl p-4 text-left transition-all duration-200",
+        "focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:outline-none",
+        "disabled:cursor-not-allowed disabled:opacity-60",
+        "hover:-translate-y-0.5 hover:shadow-lg",
+        "shadow-sm"
+      )}
+    >
+      <div className="flex items-center justify-between gap-1.5">
+        <div className="flex items-center gap-1.5">
+          <Sparkles className="size-3.5 shrink-0 text-primary" />
+          <span className="text-xs font-semibold text-primary">{suggestion.type}</span>
+        </div>
+        {isThisSelecting && <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />}
       </div>
-      <Button onClick={() => onSelect(suggestion)} disabled={isSelecting}>
-        {isSelecting ? <Loader2 className="animate-spin" /> : <Reply />}
+      <p className="line-clamp-4 text-sm leading-relaxed text-foreground">{suggestion.body}</p>
+      <div className="mt-auto flex items-center gap-1 text-xs text-muted-foreground">
+        <Reply className="size-3 shrink-0" />
         {m.reply_draft_suggestion_select()}
-      </Button>
-    </div>
+      </div>
+    </button>
   )
 }
 
-function getSuggestionAriaLabel(suggestion: ReplyDraftSuggestion) {
-  return m.reply_draft_suggestion_aria({ type: suggestion.type })
+interface ReplyDraftSuggestionButtonProps {
+  messageId: string
+  onClick: () => void
 }
 
-export function ReplyDraftSuggestionAction({ threadId, message }: ReplyDraftSuggestionActionProps) {
+export function ReplyDraftSuggestionButton({ messageId, onClick }: ReplyDraftSuggestionButtonProps) {
+  const { data, isPending, isError } = useReplyDraftSuggestions(messageId)
+  const suggestions = data?.suggestions ?? []
+
+  if (isPending || isError || suggestions.length === 0) return null
+
+  return (
+    <Button variant="outline" size="sm" className="shrink-0" onClick={onClick}>
+      <Sparkles className="size-3.5" />
+      {m.reply_draft_ai_reply()}
+    </Button>
+  )
+}
+
+interface ReplyDraftSuggestionCardsProps {
+  threadId: string
+  message: InboxMessage
+  show: boolean
+  onClose: () => void
+}
+
+export function ReplyDraftSuggestionCards({ threadId, message, show, onClose }: ReplyDraftSuggestionCardsProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const isMobile = useIsMobile()
-  const [mobileSuggestion, setMobileSuggestion] = useState<ReplyDraftSuggestion | null>(null)
-  const { data, isPending, isError } = useReplyDraftSuggestions(message.id)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const { data } = useReplyDraftSuggestions(message.id)
   const selectSuggestion = useSelectReplyDraftSuggestion()
   const suggestions = data?.suggestions ?? []
 
-  if (isPending || isError || suggestions.length === 0) {
-    return null
-  }
+  if (suggestions.length === 0) return null
 
   const handleSelect = async (suggestion: ReplyDraftSuggestion) => {
+    setSelectedId(suggestion.id)
     try {
       const replyDraftSuggestion = await selectSuggestion.mutateAsync(suggestion.id)
 
       queryClient.setQueryData<ReplyDraftSuggestionListResponse>(emailKeys.replyDraftSuggestions(message.id), {
         suggestions: [],
       })
-      setMobileSuggestion(null)
       void navigate({
         to: "/compose",
         search: {
@@ -82,93 +113,61 @@ export function ReplyDraftSuggestionAction({ threadId, message }: ReplyDraftSugg
       toast.error(m.reply_draft_suggestion_select_error(), {
         description: getErrorMessage(error, m.common_try_again_later()),
       })
+    } finally {
+      setSelectedId(null)
     }
   }
 
   if (isMobile) {
     return (
-      <Sheet open={mobileSuggestion != null} onOpenChange={(open) => !open && setMobileSuggestion(null)}>
-        <div className="flex shrink-0 items-center gap-1.5">
-          <span className="mx-1 h-5 w-px bg-border" aria-hidden />
-          <div className="mr-1 flex shrink-0 items-center gap-1.5 text-xs font-medium text-muted-foreground">
-            <Sparkles className="size-3.5" />
-            {m.reply_draft_ai_reply()}
-          </div>
-          {suggestions.map((suggestion) => (
-            <SheetTrigger
-              key={suggestion.id}
-              render={
-                <Button
-                  variant="outline"
-                  size="sm"
-                  aria-label={getSuggestionAriaLabel(suggestion)}
-                  onClick={() => setMobileSuggestion(suggestion)}
-                >
-                  <Mail />
-                  {suggestion.type}
-                </Button>
-              }
-            />
-          ))}
-        </div>
-        <SheetContent side="bottom" className="max-h-[85vh] rounded-t-lg">
-          <SheetHeader>
-            <SheetTitle className="flex flex-row items-center gap-2">
-              <Sparkles className="size-4" />
-              <span>
-                {mobileSuggestion
-                  ? m.reply_draft_preview_title({ type: mobileSuggestion.type })
-                  : m.reply_draft_suggestions_title()}
-              </span>
-            </SheetTitle>
+      <Sheet
+        open={show}
+        onOpenChange={(open) => {
+          if (!open) onClose()
+        }}
+      >
+        <SheetContent side="bottom" className="max-h-[75vh] rounded-t-2xl" showCloseButton={false}>
+          <SheetHeader className="sr-only">
+            <SheetTitle>{m.reply_draft_ai_reply()}</SheetTitle>
           </SheetHeader>
-          <ScrollArea className="min-h-0 flex-1 px-4 pb-4">
-            {mobileSuggestion ? (
-              <SuggestionPreview
-                suggestion={mobileSuggestion}
-                onSelect={handleSelect}
-                isSelecting={selectSuggestion.isPending}
-              />
-            ) : null}
-          </ScrollArea>
+          <div className="min-h-0 flex-1 px-4 py-6">
+            <div className="flex flex-col gap-3">
+              {suggestions.map((suggestion) => (
+                <SuggestionCard
+                  key={suggestion.id}
+                  suggestion={suggestion}
+                  onSelect={handleSelect}
+                  isSelecting={selectSuggestion.isPending}
+                  selectedId={selectedId}
+                />
+              ))}
+            </div>
+          </div>
         </SheetContent>
       </Sheet>
     )
   }
 
   return (
-    <div className="flex shrink-0 items-center gap-1.5">
-      <span className="mx-1 h-5 w-px bg-border" aria-hidden />
-      <div className="mr-1 flex shrink-0 items-center gap-1.5 text-xs font-medium text-muted-foreground">
-        <Sparkles className="size-3.5" />
-        {m.reply_draft_ai_reply()}
-      </div>
-      {suggestions.map((suggestion) => (
-        <Popover key={suggestion.id}>
-          <PopoverTrigger
-            openOnHover
-            delay={80}
-            closeDelay={120}
-            render={
-              <Button variant="outline" size="sm" aria-label={getSuggestionAriaLabel(suggestion)}>
-                <Mail />
-                {suggestion.type}
-              </Button>
-            }
+    <div
+      data-show={show}
+      className={cn(
+        "ai-cards-wrapper absolute right-0 bottom-12 left-0 z-10 px-2 py-3",
+        "transition-all duration-300 ease-out",
+        show ? "translate-y-0 opacity-100" : "pointer-events-none translate-y-3 opacity-0"
+      )}
+    >
+      <div className="grid grid-cols-3 gap-3">
+        {suggestions.map((suggestion) => (
+          <SuggestionCard
+            key={suggestion.id}
+            suggestion={suggestion}
+            onSelect={handleSelect}
+            isSelecting={selectSuggestion.isPending}
+            selectedId={selectedId}
           />
-          <PopoverContent side="top" sideOffset={8} className="w-88 max-w-[calc(100vw-2rem)] p-3">
-            <PopoverTitle className="flex flex-row items-center gap-2">
-              <Sparkles className="size-4" />
-              {m.reply_draft_preview_title({ type: suggestion.type })}
-            </PopoverTitle>
-            <SuggestionPreview
-              suggestion={suggestion}
-              onSelect={handleSelect}
-              isSelecting={selectSuggestion.isPending}
-            />
-          </PopoverContent>
-        </Popover>
-      ))}
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -691,3 +691,85 @@
     animation: none;
   }
 }
+
+@keyframes ai-shimmer {
+  0% {
+    background-position: 200% center;
+  }
+  100% {
+    background-position: -200% center;
+  }
+}
+
+@keyframes ai-card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(20px) scale(0.94);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes ai-glow-pulse {
+  0%,
+  100% {
+    box-shadow: 0 2px 8px -1px color-mix(in oklch, var(--primary) 15%, transparent);
+  }
+  50% {
+    box-shadow:
+      0 6px 32px -2px color-mix(in oklch, var(--primary) 50%, transparent),
+      0 2px 16px -2px color-mix(in oklch, var(--primary) 30%, transparent);
+  }
+}
+
+/* data-show가 false일 때 animation-name을 none으로 리셋 → true가 되면 애니메이션 재시작 */
+.ai-cards-wrapper:not([data-show="true"]) .ai-suggestion-card {
+  animation-name: none;
+}
+
+.ai-suggestion-card {
+  background:
+    linear-gradient(var(--background), var(--background)) padding-box,
+    linear-gradient(
+        90deg,
+        color-mix(in oklch, var(--primary) 30%, transparent),
+        color-mix(in oklch, var(--primary) 60%, transparent),
+        color-mix(in oklch, var(--primary) 30%, transparent)
+      )
+      border-box;
+  background-size: 200% auto;
+  border: 1px solid transparent;
+  animation:
+    ai-card-enter 0.4s cubic-bezier(0.16, 1, 0.3, 1) both,
+    ai-shimmer 3s 0.4s linear infinite,
+    ai-glow-pulse 2.4s 0.4s ease-in-out infinite;
+}
+
+.ai-suggestion-card:nth-child(2) {
+  animation-delay: 0.1s, 0.5s, 0.5s;
+}
+
+.ai-suggestion-card:nth-child(3) {
+  animation-delay: 0.2s, 0.6s, 0.6s;
+}
+
+.ai-suggestion-card:hover {
+  background:
+    linear-gradient(var(--background), var(--background)) padding-box,
+    linear-gradient(
+        90deg,
+        color-mix(in oklch, var(--primary) 50%, transparent),
+        color-mix(in oklch, var(--primary) 90%, transparent),
+        color-mix(in oklch, var(--primary) 50%, transparent)
+      )
+      border-box;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ai-suggestion-card {
+    animation: none;
+    border-color: color-mix(in oklch, var(--primary) 30%, transparent);
+  }
+}


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#31

### 📌 Task

- Closes #121 

## 💡 작업 내용

- 푸터에 단일 "AI 답장" 버튼 하나만 표시
- 클릭 시 3개의 추천 답장 카드를 동시에 표시
  - 데스크톱: 스레드 본문 위에 3열 카드 그리드로 오버레이
  - 모바일: 바텀 Sheet로 카드 세로 나열

## 📝 추가 설명

- AI 추천 답장 카드를 본문 위에 띄워서 표시
- 조건부 렌더링 대신 data-show 속성 기반으로 CSS transition 적용
- 추천 답장 표시 시 애니메이션 추가

## 🖼️ 스크린샷

| 데스크톱 | 모바일 |
| -- | -- |
| <img width="1919" height="866" alt="image" src="https://github.com/user-attachments/assets/55bd4da8-c066-4030-af52-9bd36febad85" /> | <img width="374" height="696" alt="image" src="https://github.com/user-attachments/assets/e59737c9-a79f-43bc-a0c2-b279ba12be33" /> |

