### PR TITLE
[STORY-501] AI 모델 선택 기능 구현

### DIFF
--- a/src/api/ai.ts
+++ b/src/api/ai.ts
@@ -1,8 +1,12 @@
 import { apiClient } from "@/lib/api-client"
-import type { AiUsageListResponse, AiUsageType } from "@/types/ai"
+import type { AiModelListResponse, AiUsageListResponse, AiUsageType } from "@/types/ai"
 
 export async function getAiUsages(types?: AiUsageType[]): Promise<AiUsageListResponse> {
   return apiClient.get<AiUsageListResponse>("/api/v1/ai/usages", {
     params: { type: types },
   })
+}
+
+export async function getAiModels(): Promise<AiModelListResponse> {
+  return apiClient.get<AiModelListResponse>("/api/v1/ai/models")
 }

--- a/src/components/compose/compose-ai-draft-panel.tsx
+++ b/src/components/compose/compose-ai-draft-panel.tsx
@@ -3,10 +3,11 @@ import { ArrowUp, Loader2, Sparkles, Square, WandSparkles, X } from "lucide-reac
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { formatNumber } from "@/lib/date"
 import { cn } from "@/lib/utils"
 import { m } from "@/paraglide/messages"
+import { useAiModels } from "@/queries/ai"
 import type { MailDraftStreamPhase, MailDraftUsage } from "@/types/email"
 
 interface ComposeAiDraftPanelProps {
@@ -16,11 +17,11 @@ interface ComposeAiDraftPanelProps {
   isStreaming: boolean
   phase: MailDraftStreamPhase
   usage: MailDraftUsage | null
-  onGenerate: () => void
+  onGenerate: (model: string | null) => void
   onStop: () => void
 }
 
-const MODEL_OPTIONS = ["Auto"] as const
+const AUTO_MODEL_VALUE = "__auto__"
 
 function getPhaseLabel(phase: MailDraftStreamPhase) {
   if (phase === "subject") return m.compose_ai_phase_subject()
@@ -38,6 +39,16 @@ function formatUsage(usage: MailDraftUsage | null) {
   return `${formatNumber(usage.totalTokens)} tokens`
 }
 
+function formatModelLabel(modelId: string) {
+  return modelId
+    .split("/")
+    .at(-1)!
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ")
+}
+
 export function ComposeAiDraftPanel({
   prompt,
   onPromptChange,
@@ -49,7 +60,8 @@ export function ComposeAiDraftPanel({
   onStop,
 }: ComposeAiDraftPanelProps) {
   const [isOpen, setIsOpen] = useState(false)
-  const [model, setModel] = useState<string>("Auto")
+  const [model, setModel] = useState<string>(AUTO_MODEL_VALUE)
+  const aiModels = useAiModels()
   const inputRef = useRef<HTMLInputElement>(null)
   const wasDraftContentEmptyRef = useRef(isDraftContentEmpty)
   const wasStreamingRef = useRef(false)
@@ -72,6 +84,11 @@ export function ComposeAiDraftPanel({
     wasStreamingRef.current = isStreaming
   }, [isDraftContentEmpty, isStreaming, phase])
 
+  const selectedModel = model === AUTO_MODEL_VALUE ? null : model
+  const modelItems = [
+    { value: AUTO_MODEL_VALUE, label: "Auto" },
+    ...(aiModels.data?.models.map((model) => ({ value: model.id, label: formatModelLabel(model.id) })) ?? []),
+  ]
   const promptText = prompt.trim()
   const usageText = formatUsage(usage)
   const isPanelVisible = isOpen || isStreaming
@@ -101,7 +118,7 @@ export function ComposeAiDraftPanel({
       return
     }
 
-    onGenerate()
+    onGenerate(selectedModel)
   }
 
   return (
@@ -171,21 +188,28 @@ export function ComposeAiDraftPanel({
                 isStreaming ? "pointer-events-none -translate-y-1 opacity-0" : "translate-y-0 opacity-100"
               )}
             >
-              <Select value={model} onValueChange={(value) => setModel(value ?? "Auto")} disabled={isStreaming}>
+              <Select
+                value={model}
+                onValueChange={(value) => setModel(value ?? AUTO_MODEL_VALUE)}
+                items={modelItems}
+                disabled={isStreaming}
+              >
                 <SelectTrigger
                   size="sm"
-                  className="-ml-2 h-8 gap-1.5 border-transparent bg-transparent text-muted-foreground hover:bg-foreground/5 hover:text-foreground focus-visible:ring-0 dark:bg-transparent"
+                  className="-ml-2 h-8 min-w-30 gap-1.5 border-transparent bg-transparent text-muted-foreground hover:bg-foreground/5 hover:text-foreground focus-visible:ring-0 dark:bg-transparent"
                   aria-label={m.compose_ai_model_select()}
                 >
                   <Sparkles className="size-4 text-primary" />
                   <SelectValue />
                 </SelectTrigger>
-                <SelectContent align="start">
-                  {MODEL_OPTIONS.map((option) => (
-                    <SelectItem key={option} value={option}>
-                      {option}
-                    </SelectItem>
-                  ))}
+                <SelectContent align="start" className="min-w-40">
+                  <SelectGroup>
+                    {modelItems.map((option) => (
+                      <SelectItem key={option.value} value={option.value} className="max-w-64">
+                        <span className="block max-w-full truncate">{option.label}</span>
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
                 </SelectContent>
               </Select>
             </div>
@@ -215,7 +239,7 @@ export function ComposeAiDraftPanel({
             onKeyDown={(event) => {
               if (event.key === "Enter" && !event.nativeEvent.isComposing && promptText) {
                 event.preventDefault()
-                onGenerate()
+                onGenerate(selectedModel)
               }
             }}
             placeholder={m.compose_ai_prompt_placeholder()}

--- a/src/components/compose/compose-email.tsx
+++ b/src/components/compose/compose-email.tsx
@@ -575,7 +575,7 @@ export function ComposeEmail({
     setInlineImages(nextInlineImages)
   }
 
-  const handleGenerateDraft = async () => {
+  const handleGenerateDraft = async (model: string | null = null) => {
     if (draftAbortControllerRef.current) {
       return
     }
@@ -621,6 +621,7 @@ export function ComposeEmail({
           replyMessageId: messageId ?? null,
           to: formatMailAddressesForSend(to),
           cc: formatMailAddressesForSend(cc),
+          ...(model ? { model } : {}),
         },
         {
           signal: abortController.signal,
@@ -945,7 +946,7 @@ export function ComposeEmail({
           isStreaming={isDraftStreaming}
           phase={draftStreamPhase}
           usage={draftUsage}
-          onGenerate={() => void handleGenerateDraft()}
+          onGenerate={(model) => void handleGenerateDraft(model)}
           onStop={handleStopDraft}
         />
       </div>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -99,7 +99,7 @@ function SelectItem({ className, children, ...props }: SelectPrimitive.Item.Prop
       )}
       {...props}
     >
-      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+      <SelectPrimitive.ItemText className="flex min-w-0 flex-1 gap-2 whitespace-nowrap">
         {children}
       </SelectPrimitive.ItemText>
       <SelectPrimitive.ItemIndicator

--- a/src/queries/ai.ts
+++ b/src/queries/ai.ts
@@ -1,20 +1,30 @@
 import { queryOptions, useQuery } from "@tanstack/react-query"
 
-import { getAiUsages } from "@/api/ai"
+import { getAiModels, getAiUsages } from "@/api/ai"
 import type { AiUsageType } from "@/types/ai"
 
 export const aiKeys = {
   all: () => ["ai"] as const,
+  models: () => [...aiKeys.all(), "models"] as const,
   usages: (types?: AiUsageType[]) =>
     types ? ([...aiKeys.all(), "usages", types] as const) : ([...aiKeys.all(), "usages"] as const),
 }
 
 export const aiQueries = {
+  models: () =>
+    queryOptions({
+      queryKey: aiKeys.models(),
+      queryFn: getAiModels,
+    }),
   usages: (types?: AiUsageType[]) =>
     queryOptions({
       queryKey: aiKeys.usages(types),
       queryFn: () => getAiUsages(types),
     }),
+}
+
+export function useAiModels() {
+  return useQuery(aiQueries.models())
 }
 
 export function useAiUsages(types?: AiUsageType[]) {

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -22,3 +22,13 @@ export interface AiUsageItem {
 export interface AiUsageListResponse {
   usages: AiUsageItem[]
 }
+
+export interface AiModel {
+  id: string
+  defaultModel: boolean
+}
+
+export interface AiModelListResponse {
+  defaultModel: string
+  models: AiModel[]
+}

--- a/src/types/email.ts
+++ b/src/types/email.ts
@@ -144,6 +144,7 @@ export interface MailDraftStreamRequest {
   replyMessageId: string | null
   to: string[]
   cc: string[]
+  model?: string
 }
 
 export interface MailDraftUsage {


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#24

### 📌 Task

- Closes #115

## 💡 작업 내용

- 모델 목록 조회 API 구현
- 프롬프트 기반 메일 자동 완성 API 모델 선택 파라미터 최신화
- 메일 자동 완성 모델 선택 기능 구현

## 📝 추가 설명

- AI 메일 초안 생성 모델 목록을 서버의 `GET /api/v1/ai/models` 응답 기반으로 조회하도록 추가했습니다.
- `POST /api/v1/mail/drafts/stream` 요청 타입에 선택 모델을 반영하고, 사용자가 실제 모델을 선택한 경우에만 `model` 파라미터를 전송하도록 변경했습니다.
- 모델 선택 Select에 `Auto` 옵션을 추가하고, `Auto` 선택 시 서버 기본 동작을 사용하도록 `model` 파라미터를 생략했습니다.
- 모델 ID는 API 전송 값으로 유지하되, 화면에는 provider prefix를 제거하고 kebab-case를 공백 기반 Pascal Case 라벨로 표시하도록 정리했습니다.
- 긴 모델명이 Select 항목에서 잘리지 않도록 dropdown 폭과 ellipsis 처리를 조정했습니다.

## 🖼️ 스크린샷

<img width="350" height="331" alt="image" src="https://github.com/user-attachments/assets/d70d4529-da93-4fd4-8f35-ab40f6d9d15c" />