### PR TITLE
[STORY-901] 중요 메일 개선

### DIFF
--- a/src/api/emails.ts
+++ b/src/api/emails.ts
@@ -193,7 +193,7 @@ export async function getStarredThreads(
   params: StarredThreadsParams = {}
 ): Promise<MarkerSliceResponse<InboxThreadSummary>> {
   const response = await apiClient.get<MarkerSliceResponse<InboxThreadSummary>>("/api/v1/threads/starred", {
-    params: params as Record<string, string | number | null | undefined>,
+    params: params as Record<string, string | string[] | number | boolean | null | undefined>,
   })
 
   return {
@@ -226,6 +226,10 @@ export async function markMessageAsUnread(messageId: string): Promise<void> {
 
 export async function toggleMessageStar(messageId: string): Promise<void> {
   return apiClient.post<void>(`/api/v1/messages/${messageId}/star`)
+}
+
+export async function toggleThreadStar(threadId: string): Promise<void> {
+  return apiClient.post<void>(`/api/v1/threads/${threadId}/star`)
 }
 
 export async function getUnreadCount(): Promise<UnreadCountResponse> {

--- a/src/components/message/card.tsx
+++ b/src/components/message/card.tsx
@@ -123,11 +123,11 @@ export function MessageCard({
               size="icon-sm"
               onClick={onToggleStar}
               disabled={!onToggleStar || isTogglingStar}
-              title={message.isStar ? m.message_unstar() : m.message_star()}
-              aria-label={message.isStar ? m.message_unstar() : m.message_star()}
-              className={cn(message.isStar && "text-primary")}
+              title={message.star ? m.message_unstar() : m.message_star()}
+              aria-label={message.star ? m.message_unstar() : m.message_star()}
+              className={cn(message.star && "text-primary")}
             >
-              <Star className={cn(message.isStar && "fill-current")} />
+              <Star className={cn(message.star && "fill-primary")} />
             </Button>
             {menuActions ? (
               <DropdownMenu>

--- a/src/components/thread/detail.tsx
+++ b/src/components/thread/detail.tsx
@@ -165,7 +165,7 @@ function ThreadToolbar({
           onClick={onToggleStar}
           disabled={isTogglingStar}
           title={isStar ? m.message_unstar() : m.message_star()}
-          aria-label={m.thread_star()}
+          aria-label={isStar ? m.message_unstar() : m.message_star()}
           className={cn(isStar && "text-primary hover:text-primary")}
         >
           <Star className={cn(isStar && "fill-primary")} />

--- a/src/components/thread/detail.tsx
+++ b/src/components/thread/detail.tsx
@@ -17,12 +17,14 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { useThreadMessageExpansion } from "@/hooks/use-thread-message-expansion"
 import { copyTextToClipboard } from "@/lib/clipboard"
 import { getErrorMessage, getHttpStatus } from "@/lib/http-error"
+import { cn } from "@/lib/utils"
 import {
   useMarkMessageAsRead,
   useMarkMessageAsUnread,
   useMarkThreadAsRead,
   useMarkThreadAsUnread,
   useToggleMessageStar,
+  useToggleThreadStar,
 } from "@/mutations/emails"
 import { useDeleteMessage, useDeleteThread, useRestoreTrashMessage, useRestoreTrashThread } from "@/mutations/trash"
 import { m } from "@/paraglide/messages"
@@ -110,22 +112,28 @@ function getLatestInboundMessage(messages: readonly InboxMessage[]) {
 
 interface ThreadToolbarProps {
   isRead: boolean
+  isStar: boolean
   onClose?: () => void
   onDelete: () => void
   onReply: () => void
   onToggleRead: () => void
+  onToggleStar: () => void
   isDeleting: boolean
   isTogglingRead: boolean
+  isTogglingStar: boolean
 }
 
 function ThreadToolbar({
   isRead,
+  isStar,
   onClose,
   onDelete,
   onReply,
   onToggleRead,
+  onToggleStar,
   isDeleting,
   isTogglingRead,
+  isTogglingStar,
 }: ThreadToolbarProps) {
   return (
     <div className="flex h-11 shrink-0 items-center justify-between gap-2 px-4">
@@ -154,11 +162,13 @@ function ThreadToolbar({
         <Button
           variant="ghost"
           size="icon-sm"
-          onClick={() => toast("준비 중인 기능이에요.")}
-          title={m.message_star()}
+          onClick={onToggleStar}
+          disabled={isTogglingStar}
+          title={isStar ? m.message_unstar() : m.message_star()}
           aria-label={m.thread_star()}
+          className={cn(isStar && "text-primary hover:text-primary")}
         >
-          <Star />
+          <Star className={cn(isStar && "fill-current")} />
         </Button>
         <Button
           variant="ghost"
@@ -231,6 +241,7 @@ export function ThreadDetail({ threadId, messageId = null, onClose }: ThreadDeta
     variables: togglingStarMessageId,
     isPending: isTogglingMessageStar,
   } = useToggleMessageStar()
+  const { mutate: toggleThreadStar, isPending: isTogglingThreadStar } = useToggleThreadStar()
   const { expandedIds, toggleExpanded } = useThreadMessageExpansion({
     threadId,
     messages: thread?.messages ?? [],
@@ -346,12 +357,15 @@ export function ThreadDetail({ threadId, messageId = null, onClose }: ThreadDeta
     <div className="relative flex h-full w-full min-w-0 flex-1 flex-col">
       <ThreadToolbar
         isRead={thread.isRead}
+        isStar={thread.star}
         onClose={onClose}
         onDelete={handleDeleteThread}
         onReply={() => handleReply()}
         onToggleRead={handleToggleThreadRead}
+        onToggleStar={() => toggleThreadStar(thread.threadId)}
         isDeleting={isDeleting}
         isTogglingRead={isMarkingThreadRead || isMarkingThreadUnread}
+        isTogglingStar={isTogglingThreadStar}
       />
       <ThreadHeader thread={thread} account={account} labels={thread.labels} />
       <ThreadMessageList

--- a/src/components/thread/detail.tsx
+++ b/src/components/thread/detail.tsx
@@ -168,7 +168,7 @@ function ThreadToolbar({
           aria-label={m.thread_star()}
           className={cn(isStar && "text-primary hover:text-primary")}
         >
-          <Star className={cn(isStar && "fill-current")} />
+          <Star className={cn(isStar && "fill-primary")} />
         </Button>
         <Button
           variant="ghost"

--- a/src/components/thread/list-item.tsx
+++ b/src/components/thread/list-item.tsx
@@ -146,7 +146,7 @@ function ThreadListItemContent({
           aria-label={thread.star ? m.message_unstar() : m.message_star()}
           title={thread.star ? m.message_unstar() : m.message_star()}
         >
-          <Star className={cn(thread.star && "fill-current")} />
+          <Star className={cn(thread.star && "fill-primary")} />
         </Button>
 
         <Tooltip>
@@ -262,7 +262,7 @@ function ThreadListItemContent({
           aria-label={thread.star ? m.message_unstar() : m.message_star()}
           title={thread.star ? m.message_unstar() : m.message_star()}
         >
-          <Star className={cn(thread.star && "fill-current")} />
+          <Star className={cn(thread.star && "fill-primary")} />
         </Button>
       </div>
     </>
@@ -310,7 +310,7 @@ function ThreadListItemSingleLine({
           aria-label={thread.star ? m.message_unstar() : m.message_star()}
           title={thread.star ? m.message_unstar() : m.message_star()}
         >
-          <Star className={cn(thread.star && "fill-current")} />
+          <Star className={cn(thread.star && "fill-primary")} />
         </Button>
 
         <Tooltip>

--- a/src/components/thread/list-item.tsx
+++ b/src/components/thread/list-item.tsx
@@ -32,6 +32,24 @@ interface ThreadListItemProps {
   onToggleStar?: () => void
 }
 
+function StarButton({ isStar, onToggle, className }: { isStar: boolean; onToggle?: () => void; className?: string }) {
+  return (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      className={cn(className, isStar ? "text-primary hover:text-primary" : "text-muted-foreground/40")}
+      onClick={(event) => {
+        event.stopPropagation()
+        onToggle?.()
+      }}
+      aria-label={isStar ? m.message_unstar() : m.message_star()}
+      title={isStar ? m.message_unstar() : m.message_star()}
+    >
+      <Star className={cn(isStar && "fill-primary")} />
+    </Button>
+  )
+}
+
 function SenderTooltipContent({ participant }: { participant: InboxThreadSummary["participant"] }) {
   const name = participant.name?.trim()
   const email = participant.email.trim()
@@ -132,22 +150,7 @@ function ThreadListItemContent({
           <Checkbox checked={isChecked} onCheckedChange={onToggleCheck} aria-label={m.thread_select_mail()} />
         </div>
 
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          className={cn(
-            "mx-0.5 hidden md:flex",
-            thread.star ? "text-primary hover:text-primary" : "text-muted-foreground/40"
-          )}
-          onClick={(event) => {
-            event.stopPropagation()
-            onToggleStar?.()
-          }}
-          aria-label={thread.star ? m.message_unstar() : m.message_star()}
-          title={thread.star ? m.message_unstar() : m.message_star()}
-        >
-          <Star className={cn(thread.star && "fill-primary")} />
-        </Button>
+        <StarButton isStar={thread.star} onToggle={onToggleStar} className="mx-0.5 hidden md:flex" />
 
         <Tooltip>
           <TooltipTrigger
@@ -248,22 +251,7 @@ function ThreadListItemContent({
           ) : null}
         </div>
 
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          className={cn(
-            "self-end md:hidden",
-            thread.star ? "text-primary hover:text-primary" : "text-muted-foreground/40"
-          )}
-          onClick={(event) => {
-            event.stopPropagation()
-            onToggleStar?.()
-          }}
-          aria-label={thread.star ? m.message_unstar() : m.message_star()}
-          title={thread.star ? m.message_unstar() : m.message_star()}
-        >
-          <Star className={cn(thread.star && "fill-primary")} />
-        </Button>
+        <StarButton isStar={thread.star} onToggle={onToggleStar} className="self-end md:hidden" />
       </div>
     </>
   )
@@ -299,19 +287,7 @@ function ThreadListItemSingleLine({
           <Checkbox checked={isChecked} onCheckedChange={onToggleCheck} aria-label={m.thread_select_mail()} />
         </div>
 
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          className={cn("mx-0.5", thread.star ? "text-primary hover:text-primary" : "text-muted-foreground/40")}
-          onClick={(event) => {
-            event.stopPropagation()
-            onToggleStar?.()
-          }}
-          aria-label={thread.star ? m.message_unstar() : m.message_star()}
-          title={thread.star ? m.message_unstar() : m.message_star()}
-        >
-          <Star className={cn(thread.star && "fill-primary")} />
-        </Button>
+        <StarButton isStar={thread.star} onToggle={onToggleStar} className="mx-0.5" />
 
         <Tooltip>
           <TooltipTrigger

--- a/src/components/thread/list-item.tsx
+++ b/src/components/thread/list-item.tsx
@@ -30,14 +30,29 @@ interface ThreadListItemProps {
   onSelect: () => void
   onToggleCheck: () => void
   onToggleStar?: () => void
+  isTogglingStar?: boolean
 }
 
-function StarButton({ isStar, onToggle, className }: { isStar: boolean; onToggle?: () => void; className?: string }) {
+function StarButton({
+  isStar,
+  onToggle,
+  disabled,
+  className,
+}: {
+  isStar: boolean
+  onToggle?: () => void
+  disabled?: boolean
+  className?: string
+}) {
   return (
     <Button
       variant="ghost"
       size="icon-sm"
       className={cn(className, isStar ? "text-primary hover:text-primary" : "text-muted-foreground/40")}
+      disabled={disabled}
+      onKeyDown={(event) => {
+        event.stopPropagation()
+      }}
       onClick={(event) => {
         event.stopPropagation()
         onToggle?.()
@@ -115,6 +130,7 @@ type ThreadListItemSubProps = {
   attachmentDisplay?: "inline" | "icon"
   onToggleCheck: () => void
   onToggleStar?: () => void
+  isTogglingStar?: boolean
   onHoverStart?: React.MouseEventHandler<HTMLDivElement>
   onHoverEnd?: React.MouseEventHandler<HTMLDivElement>
   onHoverMove?: React.MouseEventHandler<HTMLDivElement>
@@ -131,6 +147,7 @@ function ThreadListItemContent({
   attachmentDisplay,
   onToggleCheck,
   onToggleStar,
+  isTogglingStar,
   onHoverStart,
   onHoverEnd,
   onHoverMove,
@@ -150,7 +167,12 @@ function ThreadListItemContent({
           <Checkbox checked={isChecked} onCheckedChange={onToggleCheck} aria-label={m.thread_select_mail()} />
         </div>
 
-        <StarButton isStar={thread.star} onToggle={onToggleStar} className="mx-0.5 hidden md:flex" />
+        <StarButton
+          isStar={thread.star}
+          onToggle={onToggleStar}
+          disabled={isTogglingStar}
+          className="mx-0.5 hidden md:flex"
+        />
 
         <Tooltip>
           <TooltipTrigger
@@ -251,7 +273,12 @@ function ThreadListItemContent({
           ) : null}
         </div>
 
-        <StarButton isStar={thread.star} onToggle={onToggleStar} className="self-end md:hidden" />
+        <StarButton
+          isStar={thread.star}
+          onToggle={onToggleStar}
+          disabled={isTogglingStar}
+          className="self-end md:hidden"
+        />
       </div>
     </>
   )
@@ -268,6 +295,7 @@ function ThreadListItemSingleLine({
   attachmentDisplay,
   onToggleCheck,
   onToggleStar,
+  isTogglingStar,
   onHoverStart,
   onHoverEnd,
   onHoverMove,
@@ -287,7 +315,7 @@ function ThreadListItemSingleLine({
           <Checkbox checked={isChecked} onCheckedChange={onToggleCheck} aria-label={m.thread_select_mail()} />
         </div>
 
-        <StarButton isStar={thread.star} onToggle={onToggleStar} className="mx-0.5" />
+        <StarButton isStar={thread.star} onToggle={onToggleStar} disabled={isTogglingStar} className="mx-0.5" />
 
         <Tooltip>
           <TooltipTrigger
@@ -388,6 +416,7 @@ export function ThreadListItem({
   onSelect,
   onToggleCheck,
   onToggleStar,
+  isTogglingStar,
 }: ThreadListItemProps) {
   const isMobile = useIsMobile()
   const longPressTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null)
@@ -525,6 +554,7 @@ export function ThreadListItem({
             attachmentDisplay={attachmentDisplay}
             onToggleCheck={onToggleCheck}
             onToggleStar={onToggleStar}
+            isTogglingStar={isTogglingStar}
             onHoverStart={handleMouseEnter}
             onHoverEnd={handleMouseLeave}
             onHoverMove={handleMouseMove}
@@ -541,6 +571,7 @@ export function ThreadListItem({
             attachmentDisplay={attachmentDisplay}
             onToggleCheck={onToggleCheck}
             onToggleStar={onToggleStar}
+            isTogglingStar={isTogglingStar}
             onHoverStart={handleMouseEnter}
             onHoverEnd={handleMouseLeave}
             onHoverMove={handleMouseMove}

--- a/src/components/thread/list-item.tsx
+++ b/src/components/thread/list-item.tsx
@@ -5,6 +5,7 @@ import { AttachmentDownloadChip } from "@/components/attachment/download-chip"
 import { LabelChipList, type LabelChipMap } from "@/components/label/label-chip"
 import { MailAccountIcon } from "@/components/mail-account-icon"
 import { ThreadPreviewPopoverContent } from "@/components/thread/preview-popover"
+import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Popover } from "@/components/ui/popover"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
@@ -28,6 +29,7 @@ interface ThreadListItemProps {
   attachmentDisplay?: "inline" | "icon"
   onSelect: () => void
   onToggleCheck: () => void
+  onToggleStar?: () => void
 }
 
 function SenderTooltipContent({ participant }: { participant: InboxThreadSummary["participant"] }) {
@@ -94,6 +96,7 @@ type ThreadListItemSubProps = {
   labelsColorMap: LabelChipMap
   attachmentDisplay?: "inline" | "icon"
   onToggleCheck: () => void
+  onToggleStar?: () => void
   onHoverStart?: React.MouseEventHandler<HTMLDivElement>
   onHoverEnd?: React.MouseEventHandler<HTMLDivElement>
   onHoverMove?: React.MouseEventHandler<HTMLDivElement>
@@ -109,6 +112,7 @@ function ThreadListItemContent({
   labelsColorMap,
   attachmentDisplay,
   onToggleCheck,
+  onToggleStar,
   onHoverStart,
   onHoverEnd,
   onHoverMove,
@@ -128,13 +132,22 @@ function ThreadListItemContent({
           <Checkbox checked={isChecked} onCheckedChange={onToggleCheck} aria-label={m.thread_select_mail()} />
         </div>
 
-        <Star
+        <Button
+          variant="ghost"
+          size="icon-sm"
           className={cn(
-            "mx-1.5 hidden size-4 shrink-0 md:block",
-            thread.star ? "fill-primary text-primary" : "text-muted-foreground/40"
+            "mx-0.5 hidden md:flex",
+            thread.star ? "text-primary hover:text-primary" : "text-muted-foreground/40"
           )}
-          aria-label={thread.star ? m.message_starred() : undefined}
-        />
+          onClick={(event) => {
+            event.stopPropagation()
+            onToggleStar?.()
+          }}
+          aria-label={thread.star ? m.message_unstar() : m.message_star()}
+          title={thread.star ? m.message_unstar() : m.message_star()}
+        >
+          <Star className={cn(thread.star && "fill-current")} />
+        </Button>
 
         <Tooltip>
           <TooltipTrigger
@@ -235,13 +248,22 @@ function ThreadListItemContent({
           ) : null}
         </div>
 
-        <Star
+        <Button
+          variant="ghost"
+          size="icon-sm"
           className={cn(
-            "size-4 shrink-0 self-end md:hidden",
-            thread.star ? "fill-primary text-primary" : "text-muted-foreground/40"
+            "self-end md:hidden",
+            thread.star ? "text-primary hover:text-primary" : "text-muted-foreground/40"
           )}
-          aria-label={thread.star ? m.message_starred() : undefined}
-        />
+          onClick={(event) => {
+            event.stopPropagation()
+            onToggleStar?.()
+          }}
+          aria-label={thread.star ? m.message_unstar() : m.message_star()}
+          title={thread.star ? m.message_unstar() : m.message_star()}
+        >
+          <Star className={cn(thread.star && "fill-current")} />
+        </Button>
       </div>
     </>
   )
@@ -257,6 +279,7 @@ function ThreadListItemSingleLine({
   labelsColorMap,
   attachmentDisplay,
   onToggleCheck,
+  onToggleStar,
   onHoverStart,
   onHoverEnd,
   onHoverMove,
@@ -276,13 +299,19 @@ function ThreadListItemSingleLine({
           <Checkbox checked={isChecked} onCheckedChange={onToggleCheck} aria-label={m.thread_select_mail()} />
         </div>
 
-        <Star
-          className={cn(
-            "mx-1.5 size-4 shrink-0",
-            thread.star ? "fill-primary text-primary" : "text-muted-foreground/40"
-          )}
-          aria-label={thread.star ? m.message_starred() : undefined}
-        />
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className={cn("mx-0.5", thread.star ? "text-primary hover:text-primary" : "text-muted-foreground/40")}
+          onClick={(event) => {
+            event.stopPropagation()
+            onToggleStar?.()
+          }}
+          aria-label={thread.star ? m.message_unstar() : m.message_star()}
+          title={thread.star ? m.message_unstar() : m.message_star()}
+        >
+          <Star className={cn(thread.star && "fill-current")} />
+        </Button>
 
         <Tooltip>
           <TooltipTrigger
@@ -382,6 +411,7 @@ export function ThreadListItem({
   attachmentDisplay = "inline",
   onSelect,
   onToggleCheck,
+  onToggleStar,
 }: ThreadListItemProps) {
   const isMobile = useIsMobile()
   const longPressTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null)
@@ -518,6 +548,7 @@ export function ThreadListItem({
             labelsColorMap={labelsColorMap}
             attachmentDisplay={attachmentDisplay}
             onToggleCheck={onToggleCheck}
+            onToggleStar={onToggleStar}
             onHoverStart={handleMouseEnter}
             onHoverEnd={handleMouseLeave}
             onHoverMove={handleMouseMove}
@@ -533,6 +564,7 @@ export function ThreadListItem({
             labelsColorMap={labelsColorMap}
             attachmentDisplay={attachmentDisplay}
             onToggleCheck={onToggleCheck}
+            onToggleStar={onToggleStar}
             onHoverStart={handleMouseEnter}
             onHoverEnd={handleMouseLeave}
             onHoverMove={handleMouseMove}

--- a/src/components/thread/list.tsx
+++ b/src/components/thread/list.tsx
@@ -8,7 +8,7 @@ import { useAttachmentDisplay, useInboxView, useMailPreview } from "@/hooks/use-
 import { useIsMobile } from "@/hooks/use-mobile"
 import { ThreadListSkeletonRows } from "@/components/thread/list-skeleton-rows"
 import { ThreadListToolbar } from "@/components/thread/list-toolbar"
-import { useMarkThreadsAsRead, useMarkThreadsAsUnread } from "@/mutations/emails"
+import { useMarkThreadsAsRead, useMarkThreadsAsUnread, useToggleThreadStar } from "@/mutations/emails"
 import { useDeleteThread, useRestoreTrashThread } from "@/mutations/trash"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { useSuspenseLabels } from "@/queries/labels"
@@ -72,6 +72,7 @@ export function ThreadList({
   const { mutate: restoreThread } = useRestoreTrashThread()
   const { mutate: markThreadsAsRead } = useMarkThreadsAsRead()
   const { mutate: markThreadsAsUnread } = useMarkThreadsAsUnread()
+  const { mutate: toggleThreadStar } = useToggleThreadStar()
   const { data: labelsList } = useSuspenseLabels()
   const labelsColorMap = useMemo(
     () => new Map(labelsList.map((l) => [l.id, { colorCode: l.colorCode, name: l.name }])),
@@ -184,6 +185,7 @@ export function ThreadList({
                     attachmentDisplay={attachmentDisplay}
                     onSelect={() => onSelectThread(thread.threadId)}
                     onToggleCheck={() => toggleSelected(thread.threadId)}
+                    onToggleStar={() => toggleThreadStar(thread.threadId)}
                   />
                 )
               })}

--- a/src/components/thread/list.tsx
+++ b/src/components/thread/list.tsx
@@ -72,7 +72,11 @@ export function ThreadList({
   const { mutate: restoreThread } = useRestoreTrashThread()
   const { mutate: markThreadsAsRead } = useMarkThreadsAsRead()
   const { mutate: markThreadsAsUnread } = useMarkThreadsAsUnread()
-  const { mutate: toggleThreadStar } = useToggleThreadStar()
+  const {
+    mutate: toggleThreadStar,
+    isPending: isTogglingThreadStar,
+    variables: togglingStarThreadId,
+  } = useToggleThreadStar()
   const { data: labelsList } = useSuspenseLabels()
   const labelsColorMap = useMemo(
     () => new Map(labelsList.map((l) => [l.id, { colorCode: l.colorCode, name: l.name }])),
@@ -186,6 +190,7 @@ export function ThreadList({
                     onSelect={() => onSelectThread(thread.threadId)}
                     onToggleCheck={() => toggleSelected(thread.threadId)}
                     onToggleStar={() => toggleThreadStar(thread.threadId)}
+                    isTogglingStar={isTogglingThreadStar && togglingStarThreadId === thread.threadId}
                   />
                 )
               })}

--- a/src/mutations/emails.ts
+++ b/src/mutations/emails.ts
@@ -111,7 +111,7 @@ export function useMarkMessageAsUnread() {
 
 export function useToggleMessageStar() {
   return useMutation({
-    mutationFn: (messageId: string) => toggleMessageStar(messageId),
+    mutationFn: toggleMessageStar,
     onSuccess: invalidateEmailAndLabelQueries,
     onError: () => {
       toast.error(m.mail_star_error())
@@ -121,7 +121,7 @@ export function useToggleMessageStar() {
 
 export function useToggleThreadStar() {
   return useMutation({
-    mutationFn: (threadId: string) => toggleThreadStar(threadId),
+    mutationFn: toggleThreadStar,
     onSuccess: invalidateEmailAndLabelQueries,
     onError: () => {
       toast.error(m.mail_star_error())

--- a/src/mutations/emails.ts
+++ b/src/mutations/emails.ts
@@ -12,6 +12,7 @@ import {
   selectReplyDraftSuggestion,
   sendMail,
   toggleMessageStar,
+  toggleThreadStar,
 } from "@/api/emails"
 import { queryClient } from "@/lib/query-client"
 import { m } from "@/paraglide/messages"
@@ -111,6 +112,16 @@ export function useMarkMessageAsUnread() {
 export function useToggleMessageStar() {
   return useMutation({
     mutationFn: (messageId: string) => toggleMessageStar(messageId),
+    onSuccess: invalidateEmailAndLabelQueries,
+    onError: () => {
+      toast.error(m.mail_star_error())
+    },
+  })
+}
+
+export function useToggleThreadStar() {
+  return useMutation({
+    mutationFn: (threadId: string) => toggleThreadStar(threadId),
     onSuccess: invalidateEmailAndLabelQueries,
     onError: () => {
       toast.error(m.mail_star_error())

--- a/src/queries/emails.ts
+++ b/src/queries/emails.ts
@@ -56,7 +56,12 @@ export function useMailboxThreads(mailbox: SupportedMailboxId | null, options: O
 
 export function useStarredThreads(options: Omit<StarredThreadsParams, "marker"> = {}, enabled = true) {
   const size = options.size ?? 50
-  const params = { size }
+  const params = {
+    size,
+    labelId: options.labelId,
+    read: options.read,
+    q: options.q,
+  }
 
   return useInfiniteQuery({
     queryKey: emailKeys.starred(params),

--- a/src/routes/_authenticated/_app/mail/$mailbox.tsx
+++ b/src/routes/_authenticated/_app/mail/$mailbox.tsx
@@ -17,13 +17,7 @@ import { useMailAccounts, mailAccountQueries } from "@/queries/mail-accounts"
 import { emailKeys, useMailboxThreads, useStarredThreads } from "@/queries/emails"
 import { useLabels, labelQueries, useLabelGroups, labelGroupQueries } from "@/queries/labels"
 import { useTrashThreads } from "@/queries/trash"
-import {
-  getMailboxLabel,
-  isSupportedMailboxId,
-  parseMailboxId,
-  type InboxThreadSummary,
-  type PrimaryMailboxId,
-} from "@/types/email"
+import { getMailboxLabel, isSupportedMailboxId, parseMailboxId, type PrimaryMailboxId } from "@/types/email"
 
 export const Route = createFileRoute("/_authenticated/_app/mail/$mailbox")({
   params: {
@@ -94,44 +88,6 @@ function getMailboxThreadsErrorCopy(error: unknown) {
   }
 }
 
-function includesSearchValue(value: string | undefined, normalizedQuery: string) {
-  return value?.toLocaleLowerCase().includes(normalizedQuery) ?? false
-}
-
-function matchesLocalThreadFilters(
-  thread: InboxThreadSummary,
-  options: {
-    query: string
-    unreadOnly: boolean
-    labelIds?: string[]
-  }
-) {
-  if (options.unreadOnly && thread.isRead) {
-    return false
-  }
-
-  if (options.labelIds?.length) {
-    const threadLabelIds = new Set(thread.labels.map((label) => label.labelId))
-
-    if (!options.labelIds.some((labelId) => threadLabelIds.has(labelId))) {
-      return false
-    }
-  }
-
-  const normalizedQuery = options.query.trim().toLocaleLowerCase()
-
-  if (!normalizedQuery) {
-    return true
-  }
-
-  return (
-    includesSearchValue(thread.latestSubject, normalizedQuery) ||
-    includesSearchValue(thread.snippet, normalizedQuery) ||
-    includesSearchValue(thread.participant.name, normalizedQuery) ||
-    includesSearchValue(thread.participant.email, normalizedQuery)
-  )
-}
-
 function MailboxPage() {
   const { mailbox } = Route.useParams()
 
@@ -171,7 +127,15 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
     labelId: effectiveLabelIds,
     q: hasSearchQuery ? query : undefined,
   })
-  const starredThreadsQuery = useStarredThreads({ size: 50 }, isStarredMailbox)
+  const starredThreadsQuery = useStarredThreads(
+    {
+      size: 50,
+      read: filter === "unread" ? false : undefined,
+      labelId: effectiveLabelIds,
+      q: hasSearchQuery ? query : undefined,
+    },
+    isStarredMailbox
+  )
   const {
     data,
     isLoading,
@@ -190,26 +154,9 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
   const selectedAccount = accountId ? (accounts?.find((account) => account.id === accountId) ?? null) : null
 
   const threads = isThreadListMailbox
-    ? loadedThreads.filter((thread) => {
-        if (selectedAccount && thread.accountId !== selectedAccount.id) {
-          return false
-        }
-
-        if (isStarredMailbox) {
-          return matchesLocalThreadFilters(thread, {
-            query,
-            unreadOnly: filter === "unread",
-            labelIds: effectiveLabelIds,
-          })
-        }
-
-        return true
-      })
+    ? loadedThreads.filter((thread) => !selectedAccount || thread.accountId === selectedAccount.id)
     : []
-  const totalThreadCount =
-    isStarredMailbox && (hasSearchQuery || filter === "unread" || selectedAccount || effectiveLabelIds)
-      ? threads.length
-      : baseTotalThreadCount
+  const totalThreadCount = isStarredMailbox && selectedAccount ? threads.length : baseTotalThreadCount
   const mailboxErrorCopy = isError ? getMailboxThreadsErrorCopy(error) : null
   const loadMoreErrorCopy = isFetchNextPageError ? getMailboxThreadsErrorCopy(error) : null
 

--- a/src/types/email.ts
+++ b/src/types/email.ts
@@ -58,7 +58,7 @@ export interface InboxMessage {
   cc: MailAddress[]
   snippet: string
   isRead: boolean
-  isStar: boolean
+  star: boolean
   sentAt: string
   bodyText: string
   bodyHtml: string

--- a/src/types/email.ts
+++ b/src/types/email.ts
@@ -108,7 +108,7 @@ export interface ListThreadsParams {
   q?: string
 }
 
-export type StarredThreadsParams = Pick<ListThreadsParams, "marker" | "size">
+export type StarredThreadsParams = Pick<ListThreadsParams, "marker" | "size" | "labelId" | "read" | "q">
 
 export interface UnreadCountResponse {
   unreadCount: number


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#31

### 📌 Task

- Closes #133 

## 💡 작업 내용

- 스레드 단위 별표 토글 기능 구현
- 별표함 필터를 서버 사이드로 전환
- 메시지 타입 필드명 수정 (`isStar` → `star`)

## 📝 추가 설명

- 별표함 API는 read, labelId, q는 지원하지만 계정 필터(accountId)를 지원하지 않습니다. 해당 필터만 클라이언트에서 처리하며, 이 경우에만 totalCount를 서버 응답 대신 로컬 threads.length로 표시합니다.
- 스레드 레벨 별표 실패 시 메시지 레벨과 동일한 에러 문구를 사용합니다. 사용자에게 메시지/스레드 구분이 의미 없어 별도 i18n 키 없이 재사용했습니다

## 🖼️ 스크린샷

<img width="1917" height="867" alt="image" src="https://github.com/user-attachments/assets/332c3100-c5f7-4961-802a-0ecbcde368c1" />
