### PR TITLE
[STORY-901] 스레드 조회시 읽음 처리 이슈 해결

### DIFF
--- a/src/components/message/metadata-content.tsx
+++ b/src/components/message/metadata-content.tsx
@@ -18,14 +18,14 @@ function AddressList({ addresses }: { addresses: MailAddress[] }) {
   }
 
   return (
-    <ul className="flex min-w-0 flex-col gap-0.5">
+    <ul className="flex min-w-0 flex-col gap-0">
       {addresses.map((address, index) => (
-        <li key={`${address.email}-${index}`} className="flex min-h-6 min-w-0 items-center gap-1">
-          <span className="min-w-0 flex-1 wrap-break-word">{getMailAddressFullLabel(address)}</span>
+        <li key={`${address.email}-${index}`} className="flex min-h-5 min-w-0 items-start gap-1.5">
+          <span className="min-w-0 flex-1 leading-snug wrap-break-word">{getMailAddressFullLabel(address)}</span>
           <Button
             variant="ghost"
             size="icon-xs"
-            className="shrink-0"
+            className="-mt-0.5 size-5 shrink-0 rounded-md"
             aria-label={m.message_copy_email_aria({ email: address.email })}
             title={m.message_copy_address()}
             onClick={(event) => {
@@ -44,8 +44,10 @@ function AddressList({ addresses }: { addresses: MailAddress[] }) {
 function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <>
-      <dt className="flex min-h-6 items-center text-xs font-medium whitespace-nowrap text-muted-foreground">{label}</dt>
-      <dd className="flex min-h-6 min-w-0 items-center text-xs wrap-break-word">{children}</dd>
+      <dt className="flex min-h-5 items-start text-xs leading-snug font-medium whitespace-nowrap text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="flex min-h-5 min-w-0 items-start text-xs leading-snug wrap-break-word">{children}</dd>
     </>
   )
 }
@@ -62,7 +64,7 @@ export function MessageMetadataContent({ message }: MessageMetadataContentProps)
       <PopoverHeader>
         <PopoverTitle>{m.message_details()}</PopoverTitle>
       </PopoverHeader>
-      <dl className="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-4">
+      <dl className="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-4 gap-y-2">
         <DetailRow label={m.message_detail_from()}>
           <AddressList addresses={[message.from]} />
         </DetailRow>

--- a/src/components/thread/detail.tsx
+++ b/src/components/thread/detail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { ArrowLeft, ChevronsRight, Copy, Forward, MailOpen, Mail, Reply, Star, Trash2 } from "lucide-react"
 import { useNavigate } from "@tanstack/react-router"
 import { toast } from "sonner"
@@ -217,15 +217,9 @@ interface ThreadDetailProps {
 
 export function ThreadDetail({ threadId, messageId = null, onClose }: ThreadDetailProps) {
   const navigate = useNavigate()
+  const processedThreadIdsRef = useRef<Set<string>>(new Set())
   const [showSuggestions, setShowSuggestions] = useState(false)
-  const [prevThreadId, setPrevThreadId] = useState(threadId)
-  const [prevMessageId, setPrevMessageId] = useState(messageId)
 
-  if (prevThreadId !== threadId || prevMessageId !== messageId) {
-    setPrevThreadId(threadId)
-    setPrevMessageId(messageId)
-    setShowSuggestions(false)
-  }
   const { data: thread, isLoading, isError, error, refetch } = useThread(threadId)
   const { data: accounts } = useMailAccounts()
   const { mutate: deleteThread, isPending: isDeleting } = useDeleteThread()
@@ -247,6 +241,17 @@ export function ThreadDetail({ threadId, messageId = null, onClose }: ThreadDeta
     messages: thread?.messages ?? [],
     messageId,
   })
+
+  useEffect(() => {
+    if (!thread || processedThreadIdsRef.current.has(thread.threadId)) {
+      return
+    }
+
+    processedThreadIdsRef.current.add(thread.threadId)
+    if (!thread.isRead) {
+      markThreadRead(thread.threadId)
+    }
+  }, [markThreadRead, thread])
 
   const handleDeleteMessage = (message: InboxMessage, isLast: boolean) => {
     deleteMessage(message.id, {

--- a/src/components/thread/list-item.tsx
+++ b/src/components/thread/list-item.tsx
@@ -434,7 +434,7 @@ export function ThreadListItem({
     "flex cursor-pointer border-b border-l-2 border-l-transparent px-3 py-2.5 transition-colors select-none hover:bg-accent",
     view === "double" ? "flex-col gap-1.5 md:flex-row md:items-start md:gap-3" : "flex-col gap-1",
     isSelected && "border-l-primary",
-    isUnread ? "font-semibold" : "bg-accent/70",
+    isUnread ? "font-semibold" : "bg-accent/50",
     isSelected && isUnread && "bg-accent",
     isChecked && !isSelected && "bg-accent/70"
   )

--- a/src/index.css
+++ b/src/index.css
@@ -122,7 +122,7 @@ This Font Software is licensed under the SIL Open Font License, Version 1.1.
 
   --background: var(--tds-white);
   --foreground: var(--tds-grey-opacity-800);
-  --card: var(--tds-grey-background);
+  --card: var(--tds-grey-50);
   --card-foreground: var(--tds-grey-opacity-800);
   --popover: var(--tds-white);
   --popover-foreground: var(--tds-grey-opacity-800);

--- a/src/routes/_authenticated/_app/mail/$mailbox.tsx
+++ b/src/routes/_authenticated/_app/mail/$mailbox.tsx
@@ -12,7 +12,6 @@ import { useIsMobile } from "@/hooks/use-mobile"
 import { getErrorMessage, getHttpStatus } from "@/lib/http-error"
 import { parseMailRouteSearch } from "@/lib/mail-routing"
 import { cn } from "@/lib/utils"
-import { useMarkThreadAsRead } from "@/mutations/emails"
 import { m } from "@/paraglide/messages"
 import { useMailAccounts, mailAccountQueries } from "@/queries/mail-accounts"
 import { emailKeys, useMailboxThreads, useStarredThreads } from "@/queries/emails"
@@ -120,7 +119,6 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
   const { data: accounts } = useMailAccounts()
   const { data: labels } = useLabels()
   const { data: groups } = useLabelGroups()
-  const { mutate: markAsRead } = useMarkThreadAsRead()
   const supportedMailbox = isSupportedMailboxId(mailbox) ? mailbox : null
   const isStarredMailbox = mailbox === "starred"
   const isThreadListMailbox = supportedMailbox != null || isStarredMailbox
@@ -178,10 +176,8 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
     })
   }
 
-  const visibleSelectedThreadId = threads.some((thread) => thread.threadId === selectedThreadId)
-    ? selectedThreadId
-    : null
-  const hasSelection = visibleSelectedThreadId != null
+  const listSelectedThreadId = threads.some((thread) => thread.threadId === selectedThreadId) ? selectedThreadId : null
+  const hasSelection = selectedThreadId != null
 
   let emptyTitle = m.mail_empty_title()
   let emptyDescription: string | undefined
@@ -217,7 +213,7 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
       isFetchingNextPage={isFetchingNextPage}
       hasNextPage={!!hasNextPage}
       isRefreshing={isRefetching}
-      selectedThreadId={visibleSelectedThreadId}
+      selectedThreadId={listSelectedThreadId}
       filter={filter}
       onFilterChange={(nextFilter) => {
         void navigate({
@@ -229,11 +225,6 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
         })
       }}
       onSelectThread={(threadId) => {
-        const thread = threads.find((t) => t.threadId === threadId)
-        if (thread && !thread.isRead) {
-          markAsRead(threadId)
-        }
-
         void navigate({
           search: (previous) => ({
             ...previous,
@@ -262,23 +253,27 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
     />
   )
 
+  const closeThread = () => {
+    void navigate({
+      search: (previous) => ({
+        ...previous,
+        thread: undefined,
+        message: undefined,
+      }),
+      replace: true,
+    })
+  }
+  const threadDetailKey = selectedThreadId ?? ""
+
   if (isMobile) {
     return (
       <div className="flex min-h-0 w-full min-w-0 flex-1 overflow-hidden">
         {hasSelection ? (
           <ThreadDetail
-            threadId={visibleSelectedThreadId}
+            key={threadDetailKey}
+            threadId={selectedThreadId}
             messageId={selectedMessageId}
-            onClose={() => {
-              void navigate({
-                search: (previous) => ({
-                  ...previous,
-                  thread: undefined,
-                  message: undefined,
-                }),
-                replace: true,
-              })
-            }}
+            onClose={closeThread}
           />
         ) : (
           emailList
@@ -302,18 +297,10 @@ function MailboxView({ mailbox }: { mailbox: PrimaryMailboxId }) {
           <Separator orientation="vertical" />
           <div className="min-h-0 min-w-0 basis-2/3">
             <ThreadDetail
-              threadId={visibleSelectedThreadId}
+              key={threadDetailKey}
+              threadId={selectedThreadId}
               messageId={selectedMessageId}
-              onClose={() => {
-                void navigate({
-                  search: (previous) => ({
-                    ...previous,
-                    thread: undefined,
-                    message: undefined,
-                  }),
-                  replace: true,
-                })
-              }}
+              onClose={closeThread}
             />
           </div>
         </>


### PR DESCRIPTION
## 🔗 관련 작업

### 👤 User Story

- mailsangja/docs4capstone#31

### 📌 Task

- Closes #132 
- Related #93
- Related #77

## 💡 작업 내용

- 스레드 읽음 처리 로직 책임 인박스 페이지에서 상세 조회 페이지로 이동
- 인박스 목록 및 스레드 상세 조회 카드 색상 조정
- 메시지 상세 정보 카드 레이아웃 이슈 수정

## 📝 추가 설명

- 스레드 상세 조회 화면에서 직접 URL/푸시 알림으로 진입해도 읽음 처리가 수행되도록 읽음 처리 책임을 상세 컴포넌트 기준으로 이동했습니다.
- 인박스 리스트의 선택 상태와 상세 패널 표시 기준을 분리해, 현재 로드된 목록에 없는 스레드도 URL의 `thread` 값으로 상세 조회할 수 있도록 정리했습니다.
- 상세 조회 중 사용자가 직접 `읽지 않음` 처리한 스레드가 refetch 후 다시 자동 읽음 처리되지 않도록 최초 open 처리 기준으로 guard를 조정했습니다.
- 인박스 목록의 읽음 스레드 배경과 스레드 상세 메시지 카드 배경을 조정했습니다.
- 메시지 상세 정보 팝오버에서 라벨과 메일 주소를 상단 정렬하고, 여러 수신자/참조자 목록의 세로 간격과 복사 버튼 정렬을 개선했습니다.

## 🖼️ 스크린샷

<img width="360" height="235" alt="image" src="https://github.com/user-attachments/assets/57a6c35f-9c7d-4061-9e87-ea0dd400abd3" />
